### PR TITLE
Include the header for fixed width integer types

### DIFF
--- a/test/dma_buf.cpp
+++ b/test/dma_buf.cpp
@@ -4,6 +4,7 @@
 #include <limits>
 #include <variant>
 #include <cerrno>
+#include <cstdint>
 
 #include <sys/ioctl.h>
 #include <sys/mman.h>

--- a/test/lock.cpp
+++ b/test/lock.cpp
@@ -3,6 +3,7 @@
 
 #include <optional>
 #include <string>
+#include <cstdint>
 
 #include <errno.h>
 #include <sys/ioctl.h>


### PR DESCRIPTION
My distro is probably setting some pedantic compiler flags that fail the build without this header.