### PR TITLE
Fix power magnitude

### DIFF
--- a/grayskull.c
+++ b/grayskull.c
@@ -649,8 +649,8 @@ static const struct tt_hwmon_attr gs_hwmon_attributes[] = {
 	{ hwmon_in,    hwmon_in_max,      0x74, 16, GENMASK(15, 0), 1    },
 	{ hwmon_curr,  hwmon_curr_input,  0x70, 0,  GENMASK(15, 0), 1000 },
 	{ hwmon_curr,  hwmon_curr_max,    0x70, 16, GENMASK(15, 0), 1000 },
-	{ hwmon_power, hwmon_power_input, 0x6c, 0,  GENMASK(15, 0), 1000 },
-	{ hwmon_power, hwmon_power_max,   0x6c, 16, GENMASK(15, 0), 1000 },
+	{ hwmon_power, hwmon_power_input, 0x6c, 0,  GENMASK(15, 0), 1000000 },
+	{ hwmon_power, hwmon_power_max,   0x6c, 16, GENMASK(15, 0), 1000000 },
 	{ .reg_offset = TT_HWMON_ATTR_END },
 };
 

--- a/wormhole.c
+++ b/wormhole.c
@@ -101,8 +101,8 @@ static const struct tt_hwmon_attr wh_hwmon_attributes[] = {
 	{ hwmon_in,    hwmon_in_max,      0x88, 16, GENMASK(15, 0), 1    },
 	{ hwmon_curr,  hwmon_curr_input,  0x84, 0,  GENMASK(15, 0), 1000 },
 	{ hwmon_curr,  hwmon_curr_max,    0x84, 16, GENMASK(15, 0), 1000 },
-	{ hwmon_power, hwmon_power_input, 0x80, 0,  GENMASK(15, 0), 1000 },
-	{ hwmon_power, hwmon_power_max,   0x80, 16, GENMASK(15, 0), 1000 },
+	{ hwmon_power, hwmon_power_input, 0x80, 0,  GENMASK(15, 0), 1000000 },
+	{ hwmon_power, hwmon_power_max,   0x80, 16, GENMASK(15, 0), 1000000 },
 	{ .reg_offset = TT_HWMON_ATTR_END },
 };
 


### PR DESCRIPTION
Fixes https://github.com/tenstorrent/tt-kmd/issues/5

Example `sensors` output:
```
grayskull-pci-a100
Adapter: PCI adapter
vcore:       740.00 mV (max =  +0.93 V)
asic_temp:    +23.6°C  (high = +75.0°C)
power:         3.00 W  (max = 170.00 W)
current:       6.00 A  (max = +300.00 A)

wormhole-pci-6100
Adapter: PCI adapter
vcore1:      850.00 mV (max =  +0.95 V)
asic1_temp:   +57.1°C  (high = +75.0°C)
power1:       21.00 W  (max =  85.00 W)
current1:     25.00 A  (max = +160.00 A)
```