### PR TITLE
Draft: hwmon support for N300

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 obj-m += tenstorrent.o
-tenstorrent-y := module.o chardev.o enumerate.o interrupt.o grayskull.o wormhole.o pcie.o hwmon.o
+tenstorrent-y := module.o chardev.o enumerate.o interrupt.o grayskull.o wormhole.o pcie.o hwmon.o eth.o tlb.o
 
 KDIR := /lib/modules/$(shell uname -r)/build
 KMAKE := $(MAKE) -C $(KDIR) M=$(CURDIR)

--- a/device.h
+++ b/device.h
@@ -38,6 +38,14 @@ struct tenstorrent_device {
 	struct tt_hwmon_context hwmon_context;
 };
 
+struct noc_addr_t {
+	u64 addr;
+	u32 x;
+	u32 y;
+};
+
+struct tlb_t;
+
 struct tenstorrent_device_class {
 	const char *name;
 	u32 instance_size;
@@ -47,6 +55,8 @@ struct tenstorrent_device_class {
 	void (*first_open_cb)(struct tenstorrent_device *ttdev);
 	void (*last_release_cb)(struct tenstorrent_device *ttdev);
 	void (*reboot)(struct tenstorrent_device *ttdev);
+	bool (*noc_read32)(struct tenstorrent_device *ttdev, struct tlb_t *tlb, struct noc_addr_t *addr, u32 *val);
+	bool (*noc_write32)(struct tenstorrent_device *ttdev, struct tlb_t *tlb, struct noc_addr_t *addr, u32 val);
 };
 
 void tenstorrent_device_put(struct tenstorrent_device *);

--- a/eth.c
+++ b/eth.c
@@ -121,7 +121,7 @@ void wormhole_eth_probe(struct wormhole_device *wh_dev)
 		wh_dev->num_connected_cores++;
 	}
 
-	tlb_free(&wh_dev->tlb_pool, tlb);
+	tlb_free(tlb);
 }
 
 bool wormhole_eth_read32(struct wormhole_device *wh_dev, u32 eth_core, u64 sys_addr, u32 rack, u32 *value)
@@ -214,7 +214,7 @@ bool wormhole_eth_read32(struct wormhole_device *wh_dev, u32 eth_core, u64 sys_a
 	eth_write_reg(wh_dev, tlb, eth_core, ETH_RESP_RD_PTR_ADDR, resp_rd);
 
 wormhole_eth_read32_done:
-	tlb_free(&wh_dev->tlb_pool, tlb);
+	tlb_free(tlb);
 
 	// Response is only valid if we return true.
 	return resp_flags == ETH_CMD_RD_DATA;

--- a/eth.c
+++ b/eth.c
@@ -48,18 +48,35 @@ struct eth_cmd_t {
 
 static u32 eth_read_reg(struct wormhole_device *wh_dev, struct tlb_t *tlb, u32 eth_idx, u32 addr)
 {
-	return wh_read32(wh_dev, tlb, WH_ETH_NOC0_X[eth_idx], WH_ETH_NOC0_Y[eth_idx], addr);
+	struct noc_addr_t noc_addr = {
+		.addr = addr,
+		.x = WH_ETH_NOC0_X[eth_idx],
+		.y = WH_ETH_NOC0_Y[eth_idx],
+	};
+	u32 val;
+	wormhole_noc_read32(&wh_dev->tt, tlb, &noc_addr, &val);
+	return val;
 }
 
 static void eth_write_reg(struct wormhole_device *wh_dev, struct tlb_t *tlb, u32 eth_idx, u32 addr, u32 value)
 {
-	wh_write32(wh_dev, tlb, WH_ETH_NOC0_X[eth_idx], WH_ETH_NOC0_Y[eth_idx], addr, value);
+	struct noc_addr_t noc_addr = {
+		.addr = addr,
+		.x = WH_ETH_NOC0_X[eth_idx],
+		.y = WH_ETH_NOC0_Y[eth_idx],
+	};
+	wormhole_noc_write32(&wh_dev->tt, tlb, &noc_addr, value);
 }
 
 static void eth_write_block(struct wormhole_device *wh_dev, struct tlb_t *tlb, u32 eth_idx, u32 addr, const void *src,
 			    size_t size)
 {
-	wh_memcpy_toio(wh_dev, tlb, WH_ETH_NOC0_X[eth_idx], WH_ETH_NOC0_Y[eth_idx], addr, src, size);
+	struct noc_addr_t noc_addr = {
+		.addr = addr,
+		.x = WH_ETH_NOC0_X[eth_idx],
+		.y = WH_ETH_NOC0_Y[eth_idx],
+	};
+	wormhole_noc_write(&wh_dev->tt, tlb, &noc_addr, src, size);
 }
 
 static bool eth_queue_full(u32 wr, u32 rd)

--- a/eth.c
+++ b/eth.c
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+
+#include "eth.h"
+#include "wormhole.h"
+#include "tlb.h"
+
+#define ETH_TIMEOUT_MS 250
+#define ETH_MIN_FW_VERSION 0x6069000
+
+#define ETH_FW_VERSION_ADDR 0x210
+#define ETH_PORT_STATUS_ADDR 0x1200
+#define ETH_REMOTE_RACK_ADDR 0x11128
+#define ETH_REMOTE_SHELF_ADDR 0x1124
+#define ETH_REQ_WR_PTR_ADDR 0x110a0
+#define ETH_REQ_RD_PTR_ADDR 0x110b0
+#define ETH_REQ_QUEUE_ADDR 0x110c0
+#define ETH_RESP_RD_PTR_ADDR 0x11230
+#define ETH_RESP_WR_PTR_ADDR 0x11220
+#define ETH_RESP_WR_PTR_ADDR 0x11220
+#define ETH_RESP_QUEUE_ADDR 0x11240
+
+#define ETH_CMD_WR_REQ (0x1 << 0)
+#define ETH_CMD_WR_ACK (0x1 << 1)
+#define ETH_CMD_RD_REQ (0x1 << 2)
+#define ETH_CMD_RD_DATA (0x1 << 3)
+
+#define ETH_STATUS_UNKNOWN 0
+#define ETH_STATUS_NOT_CONNECTED 1
+
+static const u32 WH_ETH_NOC0_X[WH_ETH_CORE_COUNT] = { 9, 1, 8, 2, 7, 3, 6, 4, 9, 1, 8, 2, 7, 3, 6, 4 };
+static const u32 WH_ETH_NOC0_Y[WH_ETH_CORE_COUNT] = { 0, 0, 0, 0, 0, 0, 0, 0, 6, 6, 6, 6, 6, 6, 6, 6 };
+
+struct eth_cmd_t {
+	uint64_t sys_addr;
+	uint32_t data;
+	uint32_t flags;
+	uint16_t rack;
+	uint16_t src_resp_buf_index;
+	uint32_t local_buf_index;
+	uint8_t src_resp_q_id;
+	uint8_t host_mem_txn_id;
+	uint16_t padding;
+	uint32_t src_addr_tag;
+};
+
+static u32 eth_read_reg(struct wormhole_device *wh_dev, struct tlb_t *tlb, u32 eth_idx, u32 addr)
+{
+	return wh_read32(wh_dev, tlb, WH_ETH_NOC0_X[eth_idx], WH_ETH_NOC0_Y[eth_idx], addr);
+}
+
+static void eth_write_reg(struct wormhole_device *wh_dev, struct tlb_t *tlb, u32 eth_idx, u32 addr, u32 value)
+{
+	wh_write32(wh_dev, tlb, WH_ETH_NOC0_X[eth_idx], WH_ETH_NOC0_Y[eth_idx], addr, value);
+}
+
+static void eth_write_block(struct wormhole_device *wh_dev, struct tlb_t *tlb, u32 eth_idx, u32 addr, const void *src,
+			    size_t size)
+{
+	wh_memcpy_toio(wh_dev, tlb, WH_ETH_NOC0_X[eth_idx], WH_ETH_NOC0_Y[eth_idx], addr, src, size);
+}
+
+static bool eth_queue_full(u32 wr, u32 rd)
+{
+	// The queues are 4 entries deep; valid pointer values are 0..7 inclusive.
+	// The queue is full if the write pointer is 4 ahead of the read pointer.
+	return (wr != rd) && ((wr & 3) == (rd & 3));
+}
+
+void wormhole_eth_probe(struct wormhole_device *wh_dev)
+{
+	struct tlb_t *tlb;
+	u32 i;
+
+	wh_dev->num_connected_cores = 0;
+	tlb = tlb_alloc(&wh_dev->tlb_pool);
+
+	if (!tlb)
+		return;
+
+	for (i = 0; i < WH_ETH_CORE_COUNT; i++) {
+		struct connected_eth_core *core_info = &wh_dev->connected_eth_cores[wh_dev->num_connected_cores];
+		u32 fw_version = eth_read_reg(wh_dev, tlb, i, ETH_FW_VERSION_ADDR);
+		u32 port_status = eth_read_reg(wh_dev, tlb, i, ETH_PORT_STATUS_ADDR + (i * 4));
+		u32 remote_rack = eth_read_reg(wh_dev, tlb, i, ETH_REMOTE_RACK_ADDR);
+		u32 remote_shelf = eth_read_reg(wh_dev, tlb, i, ETH_REMOTE_SHELF_ADDR);
+
+		if (fw_version < ETH_MIN_FW_VERSION)
+			continue;
+
+		if (port_status == ETH_STATUS_UNKNOWN || port_status == ETH_STATUS_NOT_CONNECTED)
+			continue;
+
+		core_info->core_num = i;
+		core_info->remote_rack_x = (remote_rack >> 0) & 0xFF;
+		core_info->remote_rack_y = (remote_rack >> 8) & 0xFF;
+		core_info->remote_shelf_x = (remote_shelf >> 16) & 0x3F;
+		core_info->remote_shelf_y = (remote_shelf >> 22) & 0x3F;
+		core_info->remote_noc_x = (remote_shelf >> 4) & 0x3F;
+		core_info->remote_noc_y = (remote_shelf >> 10) & 0x3F;
+
+		wh_dev->num_connected_cores++;
+	}
+
+	tlb_free(&wh_dev->tlb_pool, tlb);
+}
+
+bool wormhole_eth_read32(struct wormhole_device *wh_dev, u32 eth_core, u64 sys_addr, u32 rack, u32 *value)
+{
+	struct eth_cmd_t cmd;
+	struct tlb_t *tlb;
+	unsigned long timeout;
+	u32 req_rd, req_wr, resp_rd, resp_wr; // queue pointers; 0 <= ptr < 8
+	u32 req_slot, resp_slot; // queue indices; 0 <= slot < 4
+	u32 req_offset;
+	u32 resp_offset;
+	u32 resp_flags_offset;
+	u32 resp_data_offset;
+	u32 fw_version;
+	u32 resp_flags = 0;
+
+	tlb = tlb_alloc(&wh_dev->tlb_pool);
+	if (!tlb)
+		return false;
+
+	fw_version = eth_read_reg(wh_dev, tlb, eth_core, ETH_FW_VERSION_ADDR);
+	if (fw_version < ETH_MIN_FW_VERSION) {
+		pr_err("ETH FW version: %u is too old.\n", fw_version);
+		goto wormhole_eth_read32_done;
+	}
+
+	// Read the current position of the read and write pointers for both the
+	// request and response queues.
+	req_wr = eth_read_reg(wh_dev, tlb, eth_core, ETH_REQ_WR_PTR_ADDR);
+	req_rd = eth_read_reg(wh_dev, tlb, eth_core, ETH_REQ_RD_PTR_ADDR);
+	resp_wr = eth_read_reg(wh_dev, tlb, eth_core, ETH_RESP_WR_PTR_ADDR);
+	resp_rd = eth_read_reg(wh_dev, tlb, eth_core, ETH_RESP_RD_PTR_ADDR);
+
+	// Encode the command.
+	memset(&cmd, 0, sizeof(struct eth_cmd_t));
+	cmd.sys_addr = sys_addr;
+	cmd.data = sizeof(u32);
+	cmd.rack = rack;
+	cmd.flags = ETH_CMD_RD_REQ;
+
+	if (eth_queue_full(req_wr, req_rd)) {
+		pr_err("ETH queue %u full\n", eth_core);
+		goto wormhole_eth_read32_done;
+	}
+
+	// Write the request to the slot in the request queue.
+	req_slot = req_wr & 3;
+	req_offset = req_slot * sizeof(struct eth_cmd_t);
+	eth_write_block(wh_dev, tlb, eth_core, ETH_REQ_QUEUE_ADDR + req_offset, &cmd, sizeof(struct eth_cmd_t));
+
+	// Write the request write pointer.
+	req_wr = (req_wr + 1) & 0x7;
+	eth_write_reg(wh_dev, tlb, eth_core, ETH_REQ_WR_PTR_ADDR, req_wr);
+
+	// UMD says,
+	// 	erisc firmware will:
+	// 1. clear response flags
+	// 2. start operation
+	// 3. advance response wrptr
+	// 4. complete operation and write data into response or buffer
+	// 5. set response flags
+
+	// Busy wait until the response write pointer changes.
+	timeout = jiffies + msecs_to_jiffies(ETH_TIMEOUT_MS);
+	while (resp_wr == eth_read_reg(wh_dev, tlb, eth_core, ETH_RESP_WR_PTR_ADDR)) {
+		if (time_after(jiffies, timeout)) {
+			pr_err("ETH response timeout\n");
+			break;
+		}
+	}
+
+	// Busy wait until flags are set.
+	resp_slot = resp_rd & 3; // 0 <= resp_slot < 4
+	resp_offset = resp_slot * sizeof(struct eth_cmd_t);
+	resp_flags_offset = resp_offset + offsetof(struct eth_cmd_t, flags);
+	timeout = jiffies + msecs_to_jiffies(ETH_TIMEOUT_MS);
+	while ((resp_flags = eth_read_reg(wh_dev, tlb, eth_core, ETH_RESP_QUEUE_ADDR + resp_flags_offset)) == 0) {
+		if (time_after(jiffies, timeout)) {
+			pr_err("ETH response timeout\n");
+			break;
+		}
+	}
+
+	// Read the response.
+	resp_data_offset = resp_offset + offsetof(struct eth_cmd_t, data);
+	*value = eth_read_reg(wh_dev, tlb, eth_core, ETH_RESP_QUEUE_ADDR + resp_data_offset);
+
+	// Increment/wrap/update the response read pointer.
+	resp_rd = (resp_rd + 1) & 0x7;
+	eth_write_reg(wh_dev, tlb, eth_core, ETH_RESP_RD_PTR_ADDR, resp_rd);
+
+wormhole_eth_read32_done:
+	tlb_free(&wh_dev->tlb_pool, tlb);
+
+	// Response is only valid if we return true.
+	return resp_flags == ETH_CMD_RD_DATA;
+}

--- a/eth.h
+++ b/eth.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef TTDRIVER_ETH_H_INCLUDED
+#define TTDRIVER_ETH_H_INCLUDED
+
+#include <linux/types.h>
+
+#define WH_ETH_CORE_COUNT 16
+
+struct wormhole_device;
+
+struct connected_eth_core {
+    u32 core_num;
+    u32 fw_version;
+    u32 remote_rack_x;
+    u32 remote_rack_y;
+    u32 remote_shelf_x;
+    u32 remote_shelf_y;
+    u32 remote_noc_x;
+    u32 remote_noc_y;
+};
+
+void wormhole_eth_probe(struct wormhole_device *wh_dev);
+bool wormhole_eth_read32(struct wormhole_device *wh_dev, u32 eth_core, u64 sys_addr, u32 rack, u32 *value);
+
+#endif

--- a/grayskull.c
+++ b/grayskull.c
@@ -901,7 +901,7 @@ static bool grayskull_noc_read32(struct tenstorrent_device *tt_dev, struct tlb_t
 	*val = ioread32(gs_dev->bar0_mapping + TLB_OFFSET(tlb->index) + (noc_addr->addr % tlb->size));
 
 	if (manage_tlb)
-		tlb_free(pool, tlb);
+		tlb_free(tlb);
 
 	return true;
 }
@@ -921,7 +921,7 @@ static bool grayskull_noc_write32(struct tenstorrent_device *tt_dev, struct tlb_
 	iowrite32(val, gs_dev->bar0_mapping + TLB_OFFSET(tlb->index) + (noc_addr->addr % tlb->size));
 
 	if (manage_tlb)
-		tlb_free(pool, tlb);
+		tlb_free(tlb);
 
 	return true;
 }

--- a/grayskull.h
+++ b/grayskull.h
@@ -6,9 +6,11 @@
 
 #include <linux/types.h>
 #include "device.h"
+#include "tlb.h"
 
 struct grayskull_device {
 	struct tenstorrent_device tt;
+	u8 __iomem *bar0_mapping;
 	u8 __iomem *reg_iomap;	// everything after the TLB windows
 	u8 __iomem *kernel_tlb;	// covers one TLB window
 	u8 __iomem *reset_unit_regs;
@@ -16,6 +18,7 @@ struct grayskull_device {
 	u32 watchdog_fw_reset_vec;
 	u32 smbus_fw_reset_vec;
 	struct tt_hwmon_context *hwmon_context;
+	struct tlb_pool tlb_pool;
 };
 
 #define tt_dev_to_gs_dev(ttdev) \

--- a/hwmon.h
+++ b/hwmon.h
@@ -16,18 +16,26 @@ struct tt_hwmon_attr {
 	u32 shift;
 	u32 mask;
 	u32 multiplier;
+	int channel;
 };
 
 struct tt_hwmon_label {
 	enum hwmon_sensor_types type;
 	u32 attr;
 	const char *name;
+	int channel;
 };
 
 struct tt_hwmon_context {
+	struct tenstorrent_device *tt_dev;
 	const struct tt_hwmon_label *labels;
 	const struct tt_hwmon_attr *attributes;
-	u8 __iomem *telemetry_base;
+	
+	// telemetry_offset is relative to the start of ARC CSM for local reads;
+	// for remote reads, add it to the NOC endpoint address for the remote ARC.
+	u32 telemetry_offset;	// Relative to ARC_CSM_START
+
+	u32 (*read32)(u64 offset, struct tt_hwmon_context *context, int channel);
 };
 
 extern const struct hwmon_ops tt_hwmon_ops;

--- a/tlb.c
+++ b/tlb.c
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <linux/sched.h>
+#include <linux/slab.h>
+
+#include "tlb.h"
+#include "wormhole.h"
+
+#define TLB_SIZE_FROM_INDEX(i) \
+	((i) < TLB_COUNT_1M ? TLB_SIZE_1M : (i) < TLB_COUNT_1M + TLB_COUNT_2M ? TLB_SIZE_2M : TLB_SIZE_16M)
+
+#define TLB_1M_BASE 0
+#define TLB_2M_BASE (TLB_1M_BASE + TLB_SIZE_1M * TLB_COUNT_1M)
+#define TLB_16M_BASE (TLB_2M_BASE + TLB_SIZE_2M * TLB_COUNT_2M)
+#define TLB_OFFSET(index)                                                                             \
+	((index) < TLB_COUNT_1M		       ? TLB_1M_BASE + (index) * TLB_SIZE_1M :                \
+	 (index) < TLB_COUNT_1M + TLB_COUNT_2M ? TLB_2M_BASE + ((index)-TLB_COUNT_1M) * TLB_SIZE_2M : \
+						 TLB_16M_BASE + ((index)-TLB_COUNT_1M - TLB_COUNT_2M) * TLB_SIZE_16M)
+
+static u32 tlb_read32(u8 __iomem *bar0, struct tlb_t *tlb, u32 offset)
+{
+	return ioread32(bar0 + TLB_OFFSET(tlb->index) + (offset % tlb->size));
+}
+
+static void tlb_write32(u8 __iomem *bar0, struct tlb_t *tlb, u32 offset, u32 value)
+{
+	iowrite32(value, bar0 + TLB_OFFSET(tlb->index) + (offset % tlb->size));
+}
+
+static void tlb_memcpy_toio(u8 __iomem *bar0, struct tlb_t *tlb, u32 offset, const void *src, size_t n)
+{
+	memcpy_toio(bar0 + TLB_OFFSET(tlb->index) + (offset % tlb->size), src, n);
+}
+
+void tlb_pool_init(struct tlb_pool *pool)
+{
+	int i;
+
+	spin_lock_init(&pool->lock);
+	init_waitqueue_head(&pool->wait_queue);
+
+	for (i = 0; i < TLB_COUNT; i++) {
+		pool->avail[i] = false;
+		pool->tlbs[i].index = i;
+		pool->tlbs[i].size = TLB_SIZE_FROM_INDEX(i);
+	}
+
+	// This is the current (Feb 2024) convention held by UMD/KMD: UMD gets all
+	// except the last TLB, which is 16MB and reserved for KMD.
+	pool->avail[TLB_COUNT - 1] = true;
+}
+
+struct tlb_t *tlb_alloc(struct tlb_pool *pool)
+{
+	struct tlb_t *tlb = NULL;
+	DECLARE_WAITQUEUE(wait, current);
+
+	spin_lock(&pool->lock);
+
+	for (;;) {
+		int index;
+		for (index = 0; index < TLB_COUNT; index++) {
+			if (pool->avail[index]) {
+				pool->avail[index] = false;
+				tlb = &pool->tlbs[index];
+				goto done;
+			}
+		}
+
+		// No TLBs free - wait for one to become available.
+		set_current_state(TASK_UNINTERRUPTIBLE);
+		add_wait_queue(&pool->wait_queue, &wait);
+		spin_unlock(&pool->lock);
+		schedule();
+		remove_wait_queue(&pool->wait_queue, &wait);
+		spin_lock(&pool->lock);
+		// FIXME: Add a timeout.
+	}
+
+done:
+	spin_unlock(&pool->lock);
+	return tlb;
+}
+
+void tlb_free(struct tlb_pool *pool, struct tlb_t *tlb)
+{
+	spin_lock(&pool->lock);
+	pool->avail[tlb->index] = true;
+	wake_up(&pool->wait_queue);
+	spin_unlock(&pool->lock);
+}
+
+void tlb_set_config(struct tlb_t *tlb, u64 address, u64 x, u64 y)
+{
+	struct tlb_config *config = &tlb->config;
+	memset(config, 0, sizeof(*config));
+
+	config->address = address / tlb->size;
+	config->x_end = x;
+	config->y_end = y;
+}
+
+u32 wh_read32(struct wormhole_device *wh, struct tlb_t *tlb, u32 x, u32 y, u64 addr)
+{
+	tlb_set_config(tlb, addr, x, y);
+	wh_program_tlb(wh, tlb);
+	return tlb_read32(wh->bar0_mapping, tlb, addr);
+}
+
+void wh_write32(struct wormhole_device *wh, struct tlb_t *tlb, u32 x, u32 y, u64 addr, u32 value)
+{
+	tlb_set_config(tlb, addr, x, y);
+	wh_program_tlb(wh, tlb);
+	tlb_write32(wh->bar0_mapping, tlb, addr, value);
+}
+
+void wh_memcpy_toio(struct wormhole_device *wh, struct tlb_t *tlb, u32 x, u32 y, u64 addr, const void *src, size_t size)
+{
+	tlb_set_config(tlb, addr, x, y);
+	wh_program_tlb(wh, tlb);
+	tlb_memcpy_toio(wh->bar0_mapping, tlb, addr, src, size);
+}

--- a/tlb.c
+++ b/tlb.c
@@ -21,6 +21,7 @@ void tlb_pool_init(struct tlb_pool *pool)
 		pool->avail[i] = false;
 		pool->tlbs[i].index = i;
 		pool->tlbs[i].size = TLB_SIZE_FROM_INDEX(i);
+		pool->tlbs[i].pool = pool;
 	}
 
 	// This is the current (Feb 2024) convention held by UMD/KMD: UMD gets all
@@ -60,8 +61,9 @@ done:
 	return tlb;
 }
 
-void tlb_free(struct tlb_pool *pool, struct tlb_t *tlb)
+void tlb_free(struct tlb_t *tlb)
 {
+	struct tlb_pool *pool = tlb->pool;
 	spin_lock(&pool->lock);
 	pool->avail[tlb->index] = true;
 	wake_up(&pool->wait_queue);

--- a/tlb.h
+++ b/tlb.h
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <linux/types.h>
+#include <linux/spinlock.h>
+#include <linux/wait.h>
+
+#ifndef TTDRIVER_TLB_H_INCLUDED
+#define TTDRIVER_TLB_H_INCLUDED
+
+#define TLB_SIZE_1M (1 * (1024 * 1024))
+#define TLB_SIZE_2M (2 * (1024 * 1024))
+#define TLB_SIZE_16M (16 * (1024 * 1024))
+#define TLB_COUNT_1M 156
+#define TLB_COUNT_2M 10
+#define TLB_COUNT_16M 20
+#define TLB_COUNT (156 + 10 + 20)
+
+struct wormhole_device;
+
+struct tlb_config {
+	u64 address;
+	u64 x_end;
+	u64 y_end;
+	u64 x_start;
+	u64 y_start;
+	u64 noc_sel;
+	u64 mcast;
+	u64 ordering;
+	u64 linked;
+};
+
+// TLB represents a mapping from a region of BAR0 to a chip endpoint.
+struct tlb_t {
+	u32 index;	// 0 <= index < TLB_COUNT
+	u32 size;	// 1MB, 2MB, or 16MB
+
+	struct tlb_config config;
+	u64 encoded_config;		// for hardware
+};
+
+struct tlb_pool {
+	spinlock_t lock;
+	bool avail[TLB_COUNT];
+	struct tlb_t tlbs[TLB_COUNT];
+	wait_queue_head_t wait_queue;
+};
+
+void tlb_pool_init(struct tlb_pool *);
+struct tlb_t *tlb_alloc(struct tlb_pool *);
+void tlb_free(struct tlb_pool *, struct tlb_t *);
+void tlb_set_config(struct tlb_t *, u64 address, u64 x, u64 y);
+
+// Read/write to a chip endpoint using a TLB.
+// If necessary, the TLB will mapped.
+u32 wh_read32(struct wormhole_device *, struct tlb_t *, u32 x, u32 y, u64 addr);
+void wh_write32(struct wormhole_device *, struct tlb_t *, u32 x, u32 y, u64 addr, u32 value);
+void wh_memcpy_toio(struct wormhole_device *, struct tlb_t *, u32 x, u32 y, u64 addr, const void *src, size_t size);
+
+#endif

--- a/tlb.h
+++ b/tlb.h
@@ -43,6 +43,7 @@ struct tlb_config {
 
 // TLB represents a mapping from a region of BAR0 to a chip endpoint.
 struct tlb_t {
+	struct tlb_pool *pool;
 	u32 index;	// 0 <= index < TLB_COUNT
 	u32 size;	// 1MB, 2MB, or 16MB
 
@@ -59,7 +60,7 @@ struct tlb_pool {
 
 void tlb_pool_init(struct tlb_pool *);
 struct tlb_t *tlb_alloc(struct tlb_pool *);
-void tlb_free(struct tlb_pool *, struct tlb_t *);
+void tlb_free(struct tlb_t *);
 void tlb_set_config(struct tlb_t *tlb, struct noc_addr_t *noc_addr);
 u64 tlb_encode_config(struct tlb_t *tlb, int local_offset_width);
 

--- a/wormhole.c
+++ b/wormhole.c
@@ -311,7 +311,7 @@ bool wormhole_noc_read(struct tenstorrent_device *tt_dev, struct tlb_t *tlb, str
 	memcpy_fromio(dst, iomem, size);
 
 	if (manage_tlb)
-		tlb_free(pool, tlb);
+		tlb_free(tlb);
 
 	return true;
 }
@@ -333,7 +333,7 @@ bool wormhole_noc_write(struct tenstorrent_device *tt_dev, struct tlb_t *tlb, st
 	memcpy_toio(iomem, src, size);
 
 	if (manage_tlb)
-		tlb_free(pool, tlb);
+		tlb_free(tlb);
 
 	return true;
 }

--- a/wormhole.h
+++ b/wormhole.h
@@ -6,14 +6,25 @@
 
 #include <linux/types.h>
 #include "device.h"
+#include "eth.h"
+#include "tlb.h"
 
 struct wormhole_device {
 	struct tenstorrent_device tt;
+	u8 __iomem *bar0_mapping;
 	u8 __iomem *bar2_mapping;
 	u8 __iomem *bar4_mapping;
+
+	struct connected_eth_core connected_eth_cores[WH_ETH_CORE_COUNT];
+	u32 num_connected_cores;
+
+	struct tlb_pool tlb_pool;
 };
 
 #define tt_dev_to_wh_dev(ttdev) \
 	container_of((tt_dev), struct wormhole_device, tt)
+
+
+void wh_program_tlb(struct wormhole_device *, struct tlb_t *);
 
 #endif

--- a/wormhole.h
+++ b/wormhole.h
@@ -25,6 +25,9 @@ struct wormhole_device {
 	container_of((tt_dev), struct wormhole_device, tt)
 
 
-void wh_program_tlb(struct wormhole_device *, struct tlb_t *);
+bool wormhole_noc_write32(struct tenstorrent_device *tt_dev, struct tlb_t *tlb, struct noc_addr_t *noc_addr, u32 val);
+bool wormhole_noc_read32(struct tenstorrent_device *tt_dev, struct tlb_t *tlb, struct noc_addr_t *noc_addr, u32 *val);
+bool wormhole_noc_write(struct tenstorrent_device *tt_dev, struct tlb_t *tlb, struct noc_addr_t *noc_addr,
+				const void *src, size_t size);
 
 #endif


### PR DESCRIPTION
Adds hwmon support for N300 cards, where the second chip is not visible to Linux via PCIe but is connected to the first chip via ethernet. 

* Add simple TLB management mechanism
  * Introduces `tlb_t`: pattern is to allocate, use, and free a `tlb_t`
  * Solves the problem of multiple processes attempting to use the same TLB for different purposes
  * Functions for performing reads and writes to the region of BAR0 that corresponds to a `tlb_t`
  * Currently only manages the single TLB allocated to the kernel

* Small refactor of hwmon code
  * Introduce a layer of indirection to support both GS and WH with the same implementation in hwmon.c
  * Introduce notion of hwmon channels

* Introduce N300 hwmon support
  * Add code for probing the state of a local WH chip's ethernet cores
  * Add code for remote chip IO

Example `sensors` output:

```
grayskull-pci-a100
Adapter: PCI adapter
vcore:       740.00 mV (max =  +0.93 V)
asic_temp:    +25.3°C  (high = +75.0°C)
power:         3.00 W  (max = 170.00 W)
current:       6.00 A  (max = +300.00 A)

wormhole-pci-6100
Adapter: PCI adapter
vcore1:      720.00 mV (max =  +0.95 V)
vcore2:      720.00 mV (max =  +0.95 V)
asic_temp1:   +46.5°C  (high = +75.0°C)
asic_temp2:   +33.4°C  (high = +75.0°C)
power1:       12.00 W  (max =  85.00 W)
power2:       11.00 W  (max =  85.00 W)
current1:     15.00 A  (max = +160.00 A)
current2:     14.00 A  (max = +160.00 A)
```