### PR TITLE
Explicit type cast to work around compiler error during build in Arch Linux's DKMS hook

### DIFF
--- a/test/dma_buf.cpp
+++ b/test/dma_buf.cpp
@@ -72,7 +72,7 @@ AllocateDmaBufUpTo(int dev_fd, std::uint32_t size, std::uint8_t index)
 void VerifyTooLargeIndexFails(int dev_fd)
 {
     if (TENSTORRENT_MAX_DMA_BUFS <= std::numeric_limits<decltype(tenstorrent_allocate_dma_buf_in::buf_index)>::max()) {
-        auto buf_max = AllocateDmaBuf(dev_fd, page_size(), TENSTORRENT_MAX_DMA_BUFS);
+        auto buf_max = AllocateDmaBuf(dev_fd, page_size(), (std::uint8_t)TENSTORRENT_MAX_DMA_BUFS);
         if (!std::holds_alternative<int>(buf_max))
             THROW_TEST_FAILURE("DMA buf allocation with too-large index was permitted unexpectedly.");
 


### PR DESCRIPTION
Hi,

I know this is an unsupported setup. I'm working on a set of AUR packages to install Tenstorrent software onto Arch Linux. This patch fixes test building during Arch processing the DKMS hook during a kernel or driver upgrade. Otherwise the compiler complains about `TENSTORRENT_MAX_DMA_BUFS` being casted to 0 due to the 3rd parameter in `AllocateDmaBuf` is of type `uint8_t` but the value of TENSTORRENT_MAX_DMA_BUFS is 256.