### PR TITLE
Establish pattern for exposing attributes in sysfs

### DIFF
--- a/device.h
+++ b/device.h
@@ -36,6 +36,7 @@ struct tenstorrent_device {
 	DECLARE_BITMAP(resource_lock, TENSTORRENT_RESOURCE_LOCK_COUNT);
 
 	struct tt_hwmon_context hwmon_context;
+	struct tt_attribute_data *attributes;
 };
 
 struct tenstorrent_device_class {

--- a/grayskull.c
+++ b/grayskull.c
@@ -135,6 +135,18 @@ struct TLB_16M_REG {
 
 #define TLB_16M_SIZE_SHIFT 24
 
+
+static struct tt_attribute_data gs_attributes[] = {
+	{ __ATTR(tt_aiclk,  S_IRUGO, tt_show_attribute, NULL), 0x50, 0xFFFF },
+	{ __ATTR(tt_axiclk, S_IRUGO, tt_show_attribute, NULL), 0x54, 0xFFFF },
+	{ __ATTR(tt_arcclk, S_IRUGO, tt_show_attribute, NULL), 0x58, 0xFFFF },
+	{ __ATTR(tt_card_type, S_IRUGO, tt_show_card_type, NULL), 0x10, 0x0 },
+	{ __ATTR(tt_serial, S_IRUGO, tt_show_card_serial, NULL), 0x10, 0x0 },
+	{ __ATTR(tt_arc_fw_ver, S_IRUGO, tt_show_fw_ver, NULL), 0x18, 0xFFFFFF },
+	{ __ATTR(tt_ttflash_ver, S_IRUGO, tt_show_fw_ver, NULL), 0x98, 0x0 },
+	{ __ATTR_NULL, 0, 0 }
+};
+
 static u32 gs_arc_addr_to_sysreg(u32 arc_addr) {
 	return ARC_CSM_MEMORY_OFFSET + (arc_addr - 0x10000000);
 }
@@ -819,6 +831,8 @@ static bool grayskull_init_hardware(struct tenstorrent_device *tt_dev) {
 	grayskull_noc_init(gs_dev);
 
 	grayskull_hwmon_init(gs_dev);
+
+	tt_dev->attributes = gs_attributes;
 
 	return true;
 }

--- a/hwmon.c
+++ b/hwmon.c
@@ -6,6 +6,7 @@
 #include <linux/stat.h>
 #include <asm/io.h>
 
+#include "device.h"
 #include "hwmon.h"
 
 static umode_t tt_hwmon_is_visible(const void *drvdata, enum hwmon_sensor_types type, u32 attr, int channel) {
@@ -69,3 +70,66 @@ const struct hwmon_ops tt_hwmon_ops = {
 	.read_string = tt_hwmon_read_string,
 };
 
+ssize_t tt_show_attribute(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	struct tenstorrent_device *tt_dev = dev_get_drvdata(dev);
+	struct tt_attribute_data *data = container_of(attr, struct tt_attribute_data, attr);
+	struct tt_hwmon_context *ctx = &tt_dev->hwmon_context;
+	u32 value = ioread32(ctx->telemetry_base + data->reg_offset);
+	value &= data->mask;
+	return sprintf(buf, "%u\n", value);
+}
+
+ssize_t tt_show_card_type(struct device *dev, struct device_attribute *attr, char *buf) {
+	struct tenstorrent_device *tt_dev = dev_get_drvdata(dev);
+	struct tt_attribute_data *data = container_of(attr, struct tt_attribute_data, attr);
+	struct tt_hwmon_context *ctx = &tt_dev->hwmon_context;
+
+	u32 board_id_hi = ioread32(ctx->telemetry_base + data->reg_offset);
+	u16 card_type = (board_id_hi >> 4) & 0xFFFF;
+	char *card_name;
+	switch (card_type) {
+	case 0x3: card_name = "e150"; break;
+	case 0x7: card_name = "e75"; break;
+	case 0x14: card_name = "n300"; break;
+	case 0x18: card_name = "n150"; break;
+	default: card_name = "unknown"; break;
+	}
+
+	return scnprintf(buf, PAGE_SIZE, "%s\n", card_name);
+}
+
+ssize_t tt_show_card_serial(struct device *dev, struct device_attribute *attr, char *buf) {
+	struct tenstorrent_device *tt_dev = dev_get_drvdata(dev);
+	struct tt_attribute_data *data = container_of(attr, struct tt_attribute_data, attr);
+	struct tt_hwmon_context *ctx = &tt_dev->hwmon_context;
+
+	u32 board_id_hi = ioread32(ctx->telemetry_base + data->reg_offset);
+	u32 board_id_lo = ioread32(ctx->telemetry_base + data->reg_offset + 4);
+	return scnprintf(buf, PAGE_SIZE, "%08X%08X\n", board_id_hi, board_id_lo);
+}
+
+ssize_t tt_show_fw_ver(struct device *dev, struct device_attribute *attr, char *buf) {
+	struct tenstorrent_device *tt_dev = dev_get_drvdata(dev);
+	struct tt_attribute_data *data = container_of(attr, struct tt_attribute_data, attr);
+	struct tt_hwmon_context *ctx = &tt_dev->hwmon_context;
+
+	u32 fw_ver = ioread32(ctx->telemetry_base + data->reg_offset);
+	u32 major = (fw_ver >> 24) & 0xFF;
+	u32 minor = (fw_ver >> 16) & 0xFF;
+	u32 patch = (fw_ver >>  8) & 0xFF;
+	u32 ver = fw_ver & 0xFF;
+	return scnprintf(buf, PAGE_SIZE, "%u.%u.%u.%u\n", major, minor, patch, ver);
+}
+
+ssize_t tt_show_eth_fw_ver(struct device *dev, struct device_attribute *attr, char *buf) {
+	struct tenstorrent_device *tt_dev = dev_get_drvdata(dev);
+	struct tt_attribute_data *data = container_of(attr, struct tt_attribute_data, attr);
+	struct tt_hwmon_context *ctx = &tt_dev->hwmon_context;
+
+	u32 fw_ver = ioread32(ctx->telemetry_base + data->reg_offset);
+	u32 major = (fw_ver >> 16) & 0xFF;
+	u32 minor = (fw_ver >> 12) & 0xF;
+	u32 patch = (fw_ver >>  0) & 0xFFF;
+	return scnprintf(buf, PAGE_SIZE, "%u.%u.%u\n", major, minor, patch);
+}

--- a/hwmon.h
+++ b/hwmon.h
@@ -5,6 +5,7 @@
 #define TTDRIVER_HWMON_H_INCLUDED
 
 #include <linux/hwmon.h>
+#include <linux/device.h>
 
 // Sentinel for tt_hwmon_attr's reg_offset field.
 #define TT_HWMON_ATTR_END 0xffffffff
@@ -31,5 +32,18 @@ struct tt_hwmon_context {
 };
 
 extern const struct hwmon_ops tt_hwmon_ops;
+
+struct tt_attribute_data {
+	struct device_attribute attr;
+	u32 reg_offset;
+	u32 mask;
+};
+
+ssize_t tt_show_attribute(struct device *dev, struct device_attribute *attr, char *buf);
+ssize_t tt_show_card_type(struct device *dev, struct device_attribute *attr, char *buf);
+ssize_t tt_show_card_serial(struct device *dev, struct device_attribute *attr, char *buf);
+ssize_t tt_show_fw_ver(struct device *dev, struct device_attribute *attr, char *buf);
+ssize_t tt_show_eth_fw_ver(struct device *dev, struct device_attribute *attr, char *buf);
+
 
 #endif

--- a/wormhole.c
+++ b/wormhole.c
@@ -49,6 +49,20 @@ static void write_iatu_reg(struct wormhole_device *wh_dev, unsigned direction,
 	iowrite32(value, wh_dev->bar2_mapping + offset);
 }
 
+static struct tt_attribute_data wh_attributes[] = {
+	{ __ATTR(tt_aiclk,  S_IRUGO, tt_show_attribute, NULL), 0x60, 0xFFFF },
+	{ __ATTR(tt_axiclk, S_IRUGO, tt_show_attribute, NULL), 0x64, 0xFFFF },
+	{ __ATTR(tt_arcclk, S_IRUGO, tt_show_attribute, NULL), 0x68, 0xFFFF },
+	{ __ATTR(tt_card_type, S_IRUGO, tt_show_card_type, NULL), 0x10, 0x0 },
+	{ __ATTR(tt_serial, S_IRUGO, tt_show_card_serial, NULL), 0x10, 0x0 },
+	{ __ATTR(tt_arc_fw_ver, S_IRUGO, tt_show_fw_ver, NULL), 0x18, 0x0 },
+	{ __ATTR(tt_eth_fw_ver, S_IRUGO, tt_show_eth_fw_ver, NULL), 0x2c, 0x0 },
+	{ __ATTR(tt_m3bl_fw_ver, S_IRUGO, tt_show_fw_ver, NULL), 0x30, 0x0 },
+	{ __ATTR(tt_m3app_fw_ver, S_IRUGO, tt_show_fw_ver, NULL), 0x34, 0x0 },
+	{ __ATTR(tt_ttflash_ver, S_IRUGO, tt_show_fw_ver, NULL), 0xb8, 0x0 },
+	{ __ATTR_NULL, 0, 0 }
+};
+
 static u32 wh_arc_addr_to_sysreg(u32 arc_addr) {
 	return ARC_CSM_START + (arc_addr - 0x10000000);
 }
@@ -165,6 +179,8 @@ static bool wormhole_init_hardware(struct tenstorrent_device *tt_dev) {
 	}
 
 	wormhole_hwmon_init(wh_dev);
+
+	tt_dev->attributes = wh_attributes;
 
 	return true;
 }


### PR DESCRIPTION
Expose card identification information and clock speeds.

Such information does not fit into the hwmon framework.