### PR TITLE
Suspend/resume support

### DIFF
--- a/device.h
+++ b/device.h
@@ -44,6 +44,7 @@ struct tenstorrent_device_class {
 	u32 instance_size;
 	bool (*init_device)(struct tenstorrent_device *ttdev);
 	bool (*init_hardware)(struct tenstorrent_device *ttdev);
+	bool (*post_hardware_init)(struct tenstorrent_device *ttdev);
 	void (*cleanup_hardware)(struct tenstorrent_device *ttdev);
 	void (*cleanup_device)(struct tenstorrent_device *ttdev);
 	void (*first_open_cb)(struct tenstorrent_device *ttdev);

--- a/device.h
+++ b/device.h
@@ -44,6 +44,7 @@ struct tenstorrent_device_class {
 	u32 instance_size;
 	bool (*init_device)(struct tenstorrent_device *ttdev);
 	bool (*init_hardware)(struct tenstorrent_device *ttdev);
+	void (*cleanup_hardware)(struct tenstorrent_device *ttdev);
 	void (*cleanup_device)(struct tenstorrent_device *ttdev);
 	void (*first_open_cb)(struct tenstorrent_device *ttdev);
 	void (*last_release_cb)(struct tenstorrent_device *ttdev);

--- a/enumerate.c
+++ b/enumerate.c
@@ -90,7 +90,8 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 	tt_dev->interrupt_enabled = tenstorrent_enable_interrupts(tt_dev);
 
 	if (device_class->init_device(tt_dev))
-		device_class->init_hardware(tt_dev);
+		if (device_class->init_hardware(tt_dev))
+			device_class->post_hardware_init(tt_dev);
 
 	pci_save_state(dev);
 

--- a/enumerate.c
+++ b/enumerate.c
@@ -142,6 +142,7 @@ static void tt_dev_release(struct kref *tt_dev_kref) {
 	if (tt_dev->dev_class->reboot)
 		unregister_reboot_notifier(&tt_dev->reboot_notifier);
 
+	tt_dev->dev_class->cleanup_hardware(tt_dev);
 	tt_dev->dev_class->cleanup_device(tt_dev);
 
 	pci_disable_pcie_error_reporting(pdev);

--- a/grayskull.c
+++ b/grayskull.c
@@ -717,6 +717,7 @@ static void grayskull_hwmon_init(struct grayskull_device *gs_dev) {
 	if (IS_ERR(hwmon_device))
 		goto grayskull_hwmon_init_err;
 
+	tt_dev->attributes = gs_attributes;
 
 	return;
 
@@ -831,9 +832,13 @@ static bool grayskull_init_hardware(struct tenstorrent_device *tt_dev) {
 
 	grayskull_noc_init(gs_dev);
 
-	grayskull_hwmon_init(gs_dev);
+	return true;
+}
 
-	tt_dev->attributes = gs_attributes;
+static bool grayskull_post_hardware_init(struct tenstorrent_device *tt_dev) {
+	struct grayskull_device *gs_dev = tt_dev_to_gs_dev(tt_dev);
+
+	grayskull_hwmon_init(gs_dev);
 
 	return true;
 }
@@ -872,6 +877,7 @@ struct tenstorrent_device_class grayskull_class = {
 	.instance_size = sizeof(struct grayskull_device),
 	.init_device = grayskull_init,
 	.init_hardware = grayskull_init_hardware,
+	.post_hardware_init = grayskull_post_hardware_init,
 	.cleanup_hardware = grayskull_cleanup_hardware,
 	.cleanup_device = grayskull_cleanup,
 	.last_release_cb = grayskull_last_release_handler,

--- a/grayskull.c
+++ b/grayskull.c
@@ -838,11 +838,15 @@ static bool grayskull_init_hardware(struct tenstorrent_device *tt_dev) {
 	return true;
 }
 
-static void grayskull_cleanup(struct tenstorrent_device *tt_dev) {
+static void grayskull_cleanup_hardware(struct tenstorrent_device *tt_dev) {
 	struct grayskull_device *gs_dev = tt_dev_to_gs_dev(tt_dev);
 
 	if (gs_dev->reset_unit_regs != NULL)
 		grayskull_shutdown_firmware(tt_dev->pdev, gs_dev->reset_unit_regs);
+}
+
+static void grayskull_cleanup(struct tenstorrent_device *tt_dev) {
+	struct grayskull_device *gs_dev = tt_dev_to_gs_dev(tt_dev);
 
 	if (gs_dev->reg_iomap != NULL)
 		pci_iounmap(gs_dev->tt.pdev, gs_dev->reg_iomap);
@@ -868,6 +872,7 @@ struct tenstorrent_device_class grayskull_class = {
 	.instance_size = sizeof(struct grayskull_device),
 	.init_device = grayskull_init,
 	.init_hardware = grayskull_init_hardware,
+	.cleanup_hardware = grayskull_cleanup_hardware,
 	.cleanup_device = grayskull_cleanup,
 	.last_release_cb = grayskull_last_release_handler,
 };

--- a/wormhole.c
+++ b/wormhole.c
@@ -160,6 +160,8 @@ static void wormhole_hwmon_init(struct wormhole_device *wh_dev) {
 	if (IS_ERR(hwmon_device))
 		goto wormhole_hwmon_init_err;
 
+	tt_dev->attributes = wh_attributes;
+
 	return;
 
 wormhole_hwmon_init_err:
@@ -179,9 +181,13 @@ static bool wormhole_init_hardware(struct tenstorrent_device *tt_dev) {
 		grayskull_send_arc_fw_message_with_args(reset_unit_regs(wh_dev), WH_FW_MSG_UPDATE_M3_AUTO_RESET_TIMEOUT, auto_reset_timeout, 0, 10000, NULL);
 	}
 
-	wormhole_hwmon_init(wh_dev);
+	return true;
+}
 
-	tt_dev->attributes = wh_attributes;
+static bool wormhole_post_hardware_init(struct tenstorrent_device *tt_dev) {
+	struct wormhole_device *wh_dev = tt_dev_to_wh_dev(tt_dev);
+
+	wormhole_hwmon_init(wh_dev);
 
 	return true;
 }
@@ -213,6 +219,7 @@ struct tenstorrent_device_class wormhole_class = {
 	.instance_size = sizeof(struct wormhole_device),
 	.init_device = wormhole_init,
 	.init_hardware = wormhole_init_hardware,
+	.post_hardware_init = wormhole_post_hardware_init,
 	.cleanup_hardware = wormhole_cleanup_hardware,
 	.cleanup_device = wormhole_cleanup,
 	.reboot = wormhole_reboot,

--- a/wormhole.c
+++ b/wormhole.c
@@ -186,10 +186,14 @@ static bool wormhole_init_hardware(struct tenstorrent_device *tt_dev) {
 	return true;
 }
 
-static void wormhole_cleanup(struct tenstorrent_device *tt_dev) {
+static void wormhole_cleanup_hardware(struct tenstorrent_device *tt_dev) {
 	struct wormhole_device *wh_dev = tt_dev_to_wh_dev(tt_dev);
 
 	grayskull_shutdown_firmware(tt_dev->pdev, reset_unit_regs(wh_dev));
+}
+
+static void wormhole_cleanup(struct tenstorrent_device *tt_dev) {
+	struct wormhole_device *wh_dev = tt_dev_to_wh_dev(tt_dev);
 
 	if (wh_dev->bar2_mapping != NULL)
 		pci_iounmap(wh_dev->tt.pdev, wh_dev->bar2_mapping);
@@ -209,6 +213,7 @@ struct tenstorrent_device_class wormhole_class = {
 	.instance_size = sizeof(struct wormhole_device),
 	.init_device = wormhole_init,
 	.init_hardware = wormhole_init_hardware,
+	.cleanup_hardware = wormhole_cleanup_hardware,
 	.cleanup_device = wormhole_cleanup,
 	.reboot = wormhole_reboot,
 };

--- a/wormhole.c
+++ b/wormhole.c
@@ -208,12 +208,6 @@ static void wormhole_cleanup(struct tenstorrent_device *tt_dev) {
 		pci_iounmap(wh_dev->tt.pdev, wh_dev->bar4_mapping);
 }
 
-static void wormhole_reboot(struct tenstorrent_device *tt_dev) {
-	struct wormhole_device *wh_dev = tt_dev_to_wh_dev(tt_dev);
-
-	grayskull_shutdown_firmware(tt_dev->pdev, reset_unit_regs(wh_dev));
-}
-
 struct tenstorrent_device_class wormhole_class = {
 	.name = "Wormhole",
 	.instance_size = sizeof(struct wormhole_device),
@@ -222,5 +216,5 @@ struct tenstorrent_device_class wormhole_class = {
 	.post_hardware_init = wormhole_post_hardware_init,
 	.cleanup_hardware = wormhole_cleanup_hardware,
 	.cleanup_device = wormhole_cleanup,
-	.reboot = wormhole_reboot,
+	.reboot = wormhole_cleanup_hardware,
 };


### PR DESCRIPTION
Separate hardware init/cleanup from software init/cleanup and attach it to power management callbacks.