### PR TITLE
BH: hwmon/sysfs telemetry

### DIFF
--- a/blackhole.c
+++ b/blackhole.c
@@ -10,7 +10,91 @@
 
 #define MAX_MRRS 4096
 
+#define TLB_2M_WINDOW_COUNT 202
+#define TLB_2M_SHIFT 21
+#define TLB_2M_REG_SIZE 12
+#define TLB_2M_WINDOW_SIZE (1 << TLB_2M_SHIFT)
+#define TLB_2M_WINDOW_MASK (TLB_2M_WINDOW_SIZE - 1)
+
+#define TLB_REGS_START 0x1FC00000   // BAR0
+#define TLB_REGS_LEN 0x00001000     // Covers all TLB registers
+
+#define KERNEL_TLB_INDEX (TLB_2M_WINDOW_COUNT - 1)	// Last 2M window is ours
+#define KERNEL_TLB_START (KERNEL_TLB_INDEX * TLB_2M_WINDOW_SIZE)
+#define KERNEL_TLB_LEN TLB_2M_WINDOW_SIZE
+
+struct TLB_2M_REG {
+	union {
+		struct {
+			u32 low32;
+			u32 mid32;
+			u32 high32;
+		};
+		// packed to make y_start straddle mid32 and high32
+		struct __attribute__((packed)) {
+			u64 address : 43;
+			u64 x_end : 6;
+			u64 y_end : 6;
+			u64 x_start : 6;
+			u64 y_start : 6;
+			u64 noc : 2;
+			u64 multicast : 1;
+			u64 ordering : 2;
+			u64 linked : 1;
+			u64 use_static_vc : 1;
+			u64 stream_header : 1;
+			u64 static_vc : 3;
+			u64 reserved : 18;
+		};
+	};
+};
+static_assert(sizeof(struct TLB_2M_REG) == TLB_2M_REG_SIZE, "TLB_2M_REG size mismatch");
+
+static u64 program_tlb(struct blackhole_device *bh, u32 x, u32 y, u64 addr) {
+	struct TLB_2M_REG conf = {0};
+	u8 __iomem *regs = bh->tlb_regs + (KERNEL_TLB_INDEX * TLB_2M_REG_SIZE);
+
+	conf.address = addr >> TLB_2M_SHIFT;
+	conf.x_end = x;
+	conf.y_end = y;
+	conf.ordering = 1;	// strict
+
+	iowrite32(conf.low32, regs + 0);
+	iowrite32(conf.mid32, regs + 4);
+	iowrite32(conf.high32, regs + 8);
+
+	return addr & TLB_2M_WINDOW_MASK;
+}
+
+static u32 noc_read32(struct blackhole_device *bh, u32 x, u32 y, u64 addr) {
+	u64 offset;
+	u32 val;
+
+	mutex_lock(&bh->kernel_tlb_mutex);
+
+	offset = program_tlb(bh, x, y, addr);
+	val = ioread32(bh->kernel_tlb + offset);
+
+	mutex_unlock(&bh->kernel_tlb_mutex);
+
+	return val;
+}
+
 static bool blackhole_init(struct tenstorrent_device *tt_dev) {
+	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
+
+	bh->tlb_regs = pci_iomap_range(bh->tt.pdev, 0, TLB_REGS_START, TLB_REGS_LEN);
+	bh->kernel_tlb = pci_iomap_range(bh->tt.pdev, 0, KERNEL_TLB_START, KERNEL_TLB_LEN);
+
+	if (!bh->tlb_regs || !bh->kernel_tlb) {
+		if (bh->tlb_regs)
+			pci_iounmap(bh->tt.pdev, bh->tlb_regs);
+
+		if (bh->kernel_tlb)
+			pci_iounmap(bh->tt.pdev, bh->kernel_tlb);
+		return false;
+	}
+
 	return true;
 }
 
@@ -28,6 +112,12 @@ static void blackhole_cleanup_hardware(struct tenstorrent_device *tt_dev) {
 }
 
 static void blackhole_cleanup(struct tenstorrent_device *tt_dev) {
+	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
+
+	if (bh->tlb_regs)
+		pci_iounmap(tt_dev->pdev, bh->tlb_regs);
+	if (bh->kernel_tlb)
+		pci_iounmap(tt_dev->pdev, bh->kernel_tlb);
 }
 
 struct tenstorrent_device_class blackhole_class = {

--- a/blackhole.h
+++ b/blackhole.h
@@ -11,7 +11,7 @@ struct blackhole_device {
 	struct tenstorrent_device tt;
 };
 
-#define tt_dev_to_wh_dev(ttdev) \
+#define tt_dev_to_bh_dev(ttdev) \
 	container_of((tt_dev), struct blackhole_device, tt)
 
 #endif

--- a/blackhole.h
+++ b/blackhole.h
@@ -13,6 +13,9 @@ struct blackhole_device {
 	struct mutex kernel_tlb_mutex;	// Guards access to kernel_tlb
 	u8 __iomem *tlb_regs;   // All TLB registers
 	u8 __iomem *kernel_tlb; // Topmost 2M window, reserved for kernel
+
+	u64 *hwmon_attr_addrs;
+	u64 *sysfs_attr_addrs;
 };
 
 #define tt_dev_to_bh_dev(ttdev) \

--- a/blackhole.h
+++ b/blackhole.h
@@ -9,6 +9,10 @@
 
 struct blackhole_device {
 	struct tenstorrent_device tt;
+
+	struct mutex kernel_tlb_mutex;	// Guards access to kernel_tlb
+	u8 __iomem *tlb_regs;   // All TLB registers
+	u8 __iomem *kernel_tlb; // Topmost 2M window, reserved for kernel
 };
 
 #define tt_dev_to_bh_dev(ttdev) \

--- a/device.h
+++ b/device.h
@@ -36,7 +36,8 @@ struct tenstorrent_device {
 	DECLARE_BITMAP(resource_lock, TENSTORRENT_RESOURCE_LOCK_COUNT);
 
 	struct tt_hwmon_context hwmon_context;
-	struct tt_attribute_data *attributes;
+
+	const struct tt_attribute_data *attributes;
 
 	struct list_head open_fds_list;	// List of struct chardev_private, linked through open_fds field
 };

--- a/enumerate.c
+++ b/enumerate.c
@@ -108,7 +108,7 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 	}
 
 	if (tt_dev->attributes) {
-		struct tt_attribute_data *data = tt_dev->attributes;
+		const struct tt_attribute_data *data = tt_dev->attributes;
 		for (; data->attr.attr.name; data++)
 			device_create_file(&tt_dev->dev, &data->attr);
 	}
@@ -126,7 +126,7 @@ static void tenstorrent_pci_remove(struct pci_dev *dev)
 	}
 
 	if (tt_dev->attributes) {
-		struct tt_attribute_data *data = tt_dev->attributes;
+		const struct tt_attribute_data *data = tt_dev->attributes;
 		for (; data->attr.attr.name; data++)
 			device_remove_file(&tt_dev->dev, &data->attr);
 	}


### PR DESCRIPTION
See individual commit messages for detail.  

Example `sensors` output:
```
blackhole-pci-0100
Adapter: PCI adapter
vcore:       742.00 mV
asic_temp:    +40.8°C
power:        30.00 W
current:      41.00 A
```

Example of what is exposed in sysfs:
```
joel@blackhole /sys/class/tenstorrent/tenstorrent!0 $ cat tt_serial
0000036100000000
joel@blackhole /sys/class/tenstorrent/tenstorrent!0 $ cat tt_fw_bundle_ver
80.13.2.0
joel@blackhole /sys/class/tenstorrent/tenstorrent!0 $ cat tt_m3app_fw_ver
0.3.1.0
```

This change makes little attempt to integrate with the existing mechanisms in hwmon.h/hwmon.c:
* BH: Locations of telemetry data must be discovered by probing for their "tags" at runtime; GS/WH: offsets are hard-coded.
* BH: Telemetry access uses a TLB window to ARC; GS/WH: ARC CSM is available without a TLB.
* GS/WH hwmon attribute decoding mechanism (shift, mask, multiplier) is insufficient to decode BH ASIC temperature.