### PR TITLE
Attempt to fix NULL pointer dereference

### DIFF
--- a/chardev.c
+++ b/chardev.c
@@ -95,6 +95,8 @@ int tenstorrent_register_device(struct tenstorrent_device *tt_dev)
 	tt_dev->dev.id = tt_dev->ordinal;
 	dev_set_name(&tt_dev->dev, TENSTORRENT "/%d", tt_dev->ordinal);
 
+	INIT_LIST_HEAD(&tt_dev->open_fds);
+
 	cdev_init(&tt_dev->chardev, &chardev_fops);
 	return cdev_device_add(&tt_dev->chardev, &tt_dev->dev);
 }
@@ -376,6 +378,10 @@ static int tt_cdev_open(struct inode *inode, struct file *file)
 	private_data->device = tt_dev;
 	file->private_data = private_data;
 
+	mutex_lock(&tt_dev->chardev_mutex);
+	list_add(&private_data->node, &tt_dev->open_fds);
+	mutex_unlock(&tt_dev->chardev_mutex);
+
 	increment_cdev_open_count(tt_dev);
 
 	return 0;
@@ -399,6 +405,10 @@ static int tt_cdev_release(struct inode *inode, struct file *file)
 	}
 
 	tenstorrent_device_put(tt_dev);
+
+	mutex_lock(&tt_dev->chardev_mutex);
+	list_del(&priv->node);
+	mutex_unlock(&tt_dev->chardev_mutex);
 
 	kfree(file->private_data);
 	file->private_data = NULL;

--- a/chardev_private.h
+++ b/chardev_private.h
@@ -33,6 +33,8 @@ struct chardev_private {
 	struct list_head peer_mappings; // struct peer_resource_mapping.list
 
 	DECLARE_BITMAP(resource_lock, TENSTORRENT_RESOURCE_LOCK_COUNT);
+
+	struct list_head node;	// for struct tenstorrent_device::open_fds
 };
 
 struct chardev_private *get_tenstorrent_priv(struct file *f);

--- a/chardev_private.h
+++ b/chardev_private.h
@@ -34,7 +34,7 @@ struct chardev_private {
 
 	DECLARE_BITMAP(resource_lock, TENSTORRENT_RESOURCE_LOCK_COUNT);
 
-	struct list_head node;	// for struct tenstorrent_device::open_fds
+	struct list_head open_fd;	// node in struct tenstorrent_device.open_fds_list
 };
 
 struct chardev_private *get_tenstorrent_priv(struct file *f);

--- a/device.h
+++ b/device.h
@@ -38,7 +38,7 @@ struct tenstorrent_device {
 	struct tt_hwmon_context hwmon_context;
 	struct tt_attribute_data *attributes;
 
-	struct list_head open_fds;
+	struct list_head open_fds_list;	// List of struct chardev_private, linked through open_fds field
 };
 
 struct tenstorrent_device_class {

--- a/device.h
+++ b/device.h
@@ -37,6 +37,8 @@ struct tenstorrent_device {
 
 	struct tt_hwmon_context hwmon_context;
 	struct tt_attribute_data *attributes;
+
+	struct list_head open_fds;
 };
 
 struct tenstorrent_device_class {

--- a/memory.c
+++ b/memory.c
@@ -763,6 +763,8 @@ void tenstorrent_memory_cleanup(struct chardev_private *priv)
 	unsigned int i;
 	struct peer_resource_mapping *peer_mapping, *tmp_peer_mapping;
 
+	mutex_lock(&priv->mutex);
+
 	hash_for_each_safe(priv->dmabufs, i, tmp_dmabuf, dmabuf, hash_chain) {
 		dma_free_coherent(&tt_dev->pdev->dev, dmabuf->size, dmabuf->ptr, dmabuf->phys);
 
@@ -780,4 +782,6 @@ void tenstorrent_memory_cleanup(struct chardev_private *priv)
 		list_del(&peer_mapping->list);
 		kfree(peer_mapping);
 	}
+
+	mutex_unlock(&priv->mutex);
 }


### PR DESCRIPTION
An attempt to fix https://github.com/tenstorrent/tt-kmd/issues/34.

#34 says, "This presumably also affects pinned system memory" -- yes, I've run into this a couple of times.

I am allocating and mapping/pinning a large buffer with KMD and making it accessible to an L2CPU.  If I forget to quit the userspace process that does this before removing the card from the PCI bus, I get a similar NULL pointer dereference when I do kill the process.

I am removing the card from the bus so I can power it off when I'm not using it, while leaving the host system online.  (The particular card I am working with is in an eGPU dock with its own PSU).  `echo 1 | sudo tee /sys/bus/pci/devices/dddd:BB:DD:F/remove` and `echo 1 | sudo tee /sys/bus/pci/rescan` is a convenient mechanism for this.