### PR TITLE
Fix `error: 'numeric_limits' is not a member of 'std'`

### DIFF
--- a/test/query_mappings.cpp
+++ b/test/query_mappings.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 
 #include <sys/ioctl.h>
 #include <sys/mman.h>


### PR DESCRIPTION
The build failed with that error in nix with gcc13

`make -C test`

Ref https://stackoverflow.com/questions/71296302/numeric-limits-is-not-a-member-of-std