### PR TITLE
dma: split streaming/coherent DMA masks

### DIFF
--- a/enumerate.c
+++ b/enumerate.c
@@ -80,7 +80,8 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 
 	mutex_init(&tt_dev->chardev_mutex);
 
-	tt_dev->dma_capable = (dma_set_mask_and_coherent(&dev->dev, DMA_BIT_MASK(dma_address_bits ?: device_class->dma_address_bits)) == 0);
+	tt_dev->dma_capable = (dma_set_mask(&dev->dev, DMA_BIT_MASK(64)) == 0);
+	dma_set_coherent_mask(&dev->dev, DMA_BIT_MASK(dma_address_bits ?: device_class->dma_address_bits));
 
 	// Max these to ensure the IOVA allocator will not split large pinned regions.
 	dma_set_max_seg_size(&dev->dev, UINT_MAX);


### PR DESCRIPTION
See https://github.com/tenstorrent/tt-kmd/issues/40 and the commit message for more detail.

With this change user pinnings get 64-bit IOVAs and driver dmabufs get 32-bit IOVAs.  An augmented version of the test code to follow...