### PR TITLE
Save and restore MPS for VM tt-smi reset

### DIFF
--- a/blackhole.h
+++ b/blackhole.h
@@ -13,9 +13,12 @@ struct blackhole_device {
 	struct mutex kernel_tlb_mutex;	// Guards access to kernel_tlb
 	u8 __iomem *tlb_regs;   // All TLB registers
 	u8 __iomem *kernel_tlb; // Topmost 2M window, reserved for kernel
+	u8 __iomem *noc2axi_cfg;
 
 	u64 *hwmon_attr_addrs;
 	u64 *sysfs_attr_addrs;
+
+	u8 saved_mps;
 };
 
 #define tt_dev_to_bh_dev(ttdev) \

--- a/chardev.c
+++ b/chardev.c
@@ -184,10 +184,12 @@ static long ioctl_reset_device(struct chardev_private *priv,
 		return -EFAULT;
 
 	if (in.flags == TENSTORRENT_RESET_DEVICE_RESTORE_STATE) {
-		if (safe_pci_restore_state(pdev))
+		if (safe_pci_restore_state(pdev)) {
+			priv->device->dev_class->restore_reset_state(priv->device);
 			ok = priv->device->dev_class->init_hardware(priv->device);
-		else
+		} else {
 			ok = false;
+		}
 	} else if (in.flags == TENSTORRENT_RESET_DEVICE_RESET_PCIE_LINK) {
 		ok = pcie_hot_reset_and_restore_state(pdev);
 	} else if (in.flags == TENSTORRENT_RESET_DEVICE_CONFIG_WRITE) {

--- a/device.h
+++ b/device.h
@@ -65,6 +65,8 @@ struct tenstorrent_device_class {
 	void (*reboot)(struct tenstorrent_device *ttdev);
 	int (*configure_tlb)(struct tenstorrent_device *ttdev, int tlb, struct tenstorrent_noc_tlb_config *config);
 	int (*describe_tlb)(struct tenstorrent_device *ttdev, int tlb, struct tlb_descriptor *tlb_desc);
+	void (*save_reset_state)(struct tenstorrent_device *ttdev);
+	void (*restore_reset_state)(struct tenstorrent_device *ttdev);
 };
 
 void tenstorrent_device_put(struct tenstorrent_device *);

--- a/enumerate.c
+++ b/enumerate.c
@@ -99,6 +99,7 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 			device_class->post_hardware_init(tt_dev);
 
 	pci_save_state(dev);
+	device_class->save_reset_state(tt_dev);
 
 	tenstorrent_register_device(tt_dev);
 

--- a/grayskull.c
+++ b/grayskull.c
@@ -41,8 +41,6 @@
 #define TTKMD_ARC_IF_OFFSET 0x77000
 #define ARC_CSM_ROW_HARVESTING_OFFSET 0x7836C
 
-#define SCRATCH_REG(n) (0x60 + (n)*sizeof(u32))	/* byte offset */
-
 #define POST_CODE_REG SCRATCH_REG(0)
 #define POST_CODE_MASK ((u32)0x3FFF)
 #define POST_CODE_ARC_SLEEP 2

--- a/grayskull.c
+++ b/grayskull.c
@@ -870,6 +870,15 @@ static void grayskull_last_release_handler(struct tenstorrent_device *tt_dev) {
 						0, 0, 10000, NULL);
 }
 
+
+static void grayskull_save_reset_state(struct tenstorrent_device *tt_dev) {
+	// no operation
+}
+
+static void grayskull_restore_reset_state(struct tenstorrent_device *tt_dev) {
+	// no operation
+}
+
 struct tenstorrent_device_class grayskull_class = {
 	.name = "Grayskull",
 	.instance_size = sizeof(struct grayskull_device),
@@ -880,4 +889,6 @@ struct tenstorrent_device_class grayskull_class = {
 	.cleanup_hardware = grayskull_cleanup_hardware,
 	.cleanup_device = grayskull_cleanup,
 	.last_release_cb = grayskull_last_release_handler,
+	.save_reset_state = grayskull_save_reset_state,
+	.restore_reset_state = grayskull_restore_reset_state,
 };

--- a/grayskull.h
+++ b/grayskull.h
@@ -18,6 +18,8 @@ struct grayskull_device {
 	struct tt_hwmon_context *hwmon_context;
 };
 
+#define SCRATCH_REG(n) (0x60 + (n)*sizeof(u32))	/* byte offset */
+
 #define tt_dev_to_gs_dev(ttdev) \
 	container_of((tt_dev), struct grayskull_device, tt)
 

--- a/pcie.h
+++ b/pcie.h
@@ -5,6 +5,7 @@
 #define TTDRIVER_PCIE_H_INCLUDED
 
 #include "device.h"
+#define DBI_DEVICE_CONTROL_DEVICE_STATUS 0x78
 
 bool safe_pci_restore_state(struct pci_dev *pdev);
 bool complete_pcie_init(struct tenstorrent_device *tt_dev, u8 __iomem* reset_unit_regs);

--- a/wormhole.h
+++ b/wormhole.h
@@ -9,8 +9,12 @@
 
 struct wormhole_device {
 	struct tenstorrent_device tt;
+	struct mutex kernel_tlb_mutex;	// Guards access to kernel_tlb
+
 	u8 __iomem *bar2_mapping;
 	u8 __iomem *bar4_mapping;
+
+	u8 saved_mps;
 };
 
 #define tt_dev_to_wh_dev(ttdev) \


### PR DESCRIPTION
tt-kmd does not have permission to change the MPS through config space read and write in VM. This creates an issue as device does not know what MPS value it should take after the reset. This MR allows tt-kmd to save MPS value and restore MPS value after reset through NOC loopback to DBI.