### PR TITLE
WH/GS: add divisor to tt_hwmon_attr and correct hwmon temp multiplier

### DIFF
--- a/grayskull.c
+++ b/grayskull.c
@@ -654,14 +654,14 @@ bool grayskull_read_fw_telemetry_offset(u8 __iomem *reset_unit_regs, u32 *offset
 
 
 static const struct tt_hwmon_attr gs_hwmon_attributes[] = {
-	{ hwmon_temp,  hwmon_temp_input,  0x64, 0,  GENMASK(15, 0), 64   },
-	{ hwmon_temp,  hwmon_temp_max,    0x78, 0,  GENMASK(15, 0), 1000 },
-	{ hwmon_in,    hwmon_in_input,    0x60, 0,  GENMASK(31, 0), 1    },
-	{ hwmon_in,    hwmon_in_max,      0x74, 16, GENMASK(15, 0), 1    },
-	{ hwmon_curr,  hwmon_curr_input,  0x70, 0,  GENMASK(15, 0), 1000 },
-	{ hwmon_curr,  hwmon_curr_max,    0x70, 16, GENMASK(15, 0), 1000 },
-	{ hwmon_power, hwmon_power_input, 0x6c, 0,  GENMASK(15, 0), 1000000 },
-	{ hwmon_power, hwmon_power_max,   0x6c, 16, GENMASK(15, 0), 1000000 },
+	{ hwmon_temp,  hwmon_temp_input,  0x64, 0,  GENMASK(15, 0), 1000,    16 },
+	{ hwmon_temp,  hwmon_temp_max,    0x78, 0,  GENMASK(15, 0), 1000,    1 },
+	{ hwmon_in,    hwmon_in_input,    0x60, 0,  GENMASK(31, 0), 1,       1 },
+	{ hwmon_in,    hwmon_in_max,      0x74, 16, GENMASK(15, 0), 1,       1 },
+	{ hwmon_curr,  hwmon_curr_input,  0x70, 0,  GENMASK(15, 0), 1000,    1 },
+	{ hwmon_curr,  hwmon_curr_max,    0x70, 16, GENMASK(15, 0), 1000,    1 },
+	{ hwmon_power, hwmon_power_input, 0x6c, 0,  GENMASK(15, 0), 1000000, 1 },
+	{ hwmon_power, hwmon_power_max,   0x6c, 16, GENMASK(15, 0), 1000000, 1 },
 	{ .reg_offset = TT_HWMON_ATTR_END },
 };
 

--- a/hwmon.c
+++ b/hwmon.c
@@ -39,6 +39,7 @@ static int tt_hwmon_read(struct device *dev, enum hwmon_sensor_types type, u32 a
 			value >>= attribute->shift;
 			value &= attribute->mask;
 			value *= attribute->multiplier;
+			value /= attribute->divisor;
 			*val = value;
 			return 0;
 		}

--- a/hwmon.h
+++ b/hwmon.h
@@ -17,6 +17,7 @@ struct tt_hwmon_attr {
 	u32 shift;
 	u32 mask;
 	u32 multiplier;
+	u32 divisor;
 };
 
 struct tt_hwmon_label {

--- a/wormhole.c
+++ b/wormhole.c
@@ -146,14 +146,14 @@ fail_bar2:
 }
 
 static const struct tt_hwmon_attr wh_hwmon_attributes[] = {
-	{ hwmon_temp,  hwmon_temp_input,  0x74, 0,  GENMASK(15, 0), 64   },
-	{ hwmon_temp,  hwmon_temp_max,    0x8c, 0,  GENMASK(15, 0), 1000 },
-	{ hwmon_in,    hwmon_in_input,    0x70, 0,  GENMASK(31, 0), 1    },
-	{ hwmon_in,    hwmon_in_max,      0x88, 16, GENMASK(15, 0), 1    },
-	{ hwmon_curr,  hwmon_curr_input,  0x84, 0,  GENMASK(15, 0), 1000 },
-	{ hwmon_curr,  hwmon_curr_max,    0x84, 16, GENMASK(15, 0), 1000 },
-	{ hwmon_power, hwmon_power_input, 0x80, 0,  GENMASK(15, 0), 1000000 },
-	{ hwmon_power, hwmon_power_max,   0x80, 16, GENMASK(15, 0), 1000000 },
+	{ hwmon_temp,  hwmon_temp_input,  0x74, 0,  GENMASK(15, 0), 1000,    16 },
+	{ hwmon_temp,  hwmon_temp_max,    0x8c, 0,  GENMASK(15, 0), 1000,    1 },
+	{ hwmon_in,    hwmon_in_input,    0x70, 0,  GENMASK(31, 0), 1,       1 },
+	{ hwmon_in,    hwmon_in_max,      0x88, 16, GENMASK(15, 0), 1,       1 },
+	{ hwmon_curr,  hwmon_curr_input,  0x84, 0,  GENMASK(15, 0), 1000,    1 },
+	{ hwmon_curr,  hwmon_curr_max,    0x84, 16, GENMASK(15, 0), 1000,    1 },
+	{ hwmon_power, hwmon_power_input, 0x80, 0,  GENMASK(15, 0), 1000000, 1 },
+	{ hwmon_power, hwmon_power_max,   0x80, 16, GENMASK(15, 0), 1000000, 1 },
 	{ .reg_offset = TT_HWMON_ATTR_END },
 };
 


### PR DESCRIPTION
To report temperature in millidegrees C, the raw telemetry value needs to be divided by 16 and multiplied by 1000 rather than multiplied by 64. Add divisor field to tt_hwmon_attr to support this change.