### PR TITLE
WH/BH outbound ATU support

### DIFF
--- a/blackhole.c
+++ b/blackhole.c
@@ -642,10 +642,18 @@ static int blackhole_describe_tlb(struct tenstorrent_device *tt_dev, int tlb,
 	return 0;
 }
 
+static int blackhole_configure_outbound_atu(struct tenstorrent_device *tt_dev, u32 region, u64 base, u64 limit,
+					    u64 target)
+{
+	return -EINVAL;
+}
+
 struct tenstorrent_device_class blackhole_class = {
 	.name = "Blackhole",
 	.instance_size = sizeof(struct blackhole_device),
 	.dma_address_bits = 58,
+	.noc_dma_limit = (1ULL << 58) - 1,
+	.noc_pcie_offset = (4ULL << 58),
 	.tlb_kinds = 2,
 	.tlb_counts = { TLB_2M_WINDOW_COUNT, TLB_4G_WINDOW_COUNT },
 	.tlb_sizes = { TLB_2M_WINDOW_SIZE, TLB_4G_WINDOW_SIZE },
@@ -658,4 +666,5 @@ struct tenstorrent_device_class blackhole_class = {
 	.describe_tlb = blackhole_describe_tlb,
 	.save_reset_state = blackhole_save_reset_state,
 	.restore_reset_state = blackhole_restore_reset_state,
+	.configure_outbound_atu = blackhole_configure_outbound_atu,
 };

--- a/blackhole.h
+++ b/blackhole.h
@@ -14,6 +14,7 @@ struct blackhole_device {
 	u8 __iomem *tlb_regs;   // All TLB registers
 	u8 __iomem *kernel_tlb; // Topmost 2M window, reserved for kernel
 	u8 __iomem *noc2axi_cfg;
+	u8 __iomem *bar2_mapping;
 
 	u64 *hwmon_attr_addrs;
 	u64 *sysfs_attr_addrs;

--- a/device.h
+++ b/device.h
@@ -52,6 +52,8 @@ struct tenstorrent_device_class {
 	const char *name;
 	u32 instance_size;
 	u32 dma_address_bits;
+	u64 noc_dma_limit;
+	u64 noc_pcie_offset;
 	u32 tlb_kinds;
 	u32 tlb_counts[MAX_TLB_KINDS];
 	u64 tlb_sizes[MAX_TLB_KINDS];
@@ -67,6 +69,7 @@ struct tenstorrent_device_class {
 	int (*describe_tlb)(struct tenstorrent_device *ttdev, int tlb, struct tlb_descriptor *tlb_desc);
 	void (*save_reset_state)(struct tenstorrent_device *ttdev);
 	void (*restore_reset_state)(struct tenstorrent_device *ttdev);
+	int (*configure_outbound_atu)(struct tenstorrent_device *ttdev, u32 region, u64 base, u64 limit, u64 target);
 };
 
 void tenstorrent_device_put(struct tenstorrent_device *);

--- a/device.h
+++ b/device.h
@@ -13,6 +13,7 @@
 
 #include "ioctl.h"
 #include "hwmon.h"
+#include "memory.h"
 
 struct tenstorrent_device_class;
 
@@ -43,6 +44,9 @@ struct tenstorrent_device {
 
 	DECLARE_BITMAP(tlbs, TENSTORRENT_MAX_INBOUND_TLBS);
 	atomic_t tlb_refs[TENSTORRENT_MAX_INBOUND_TLBS];	// TLB mapping refecounts
+
+	struct mutex iatu_mutex;
+	struct tenstorrent_outbound_iatu_region outbound_iatus[TENSTORRENT_MAX_OUTBOUND_IATU_REGIONS];
 };
 
 struct tlb_descriptor;

--- a/enumerate.c
+++ b/enumerate.c
@@ -79,6 +79,7 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 	tt_dev->ordinal = ordinal;
 
 	mutex_init(&tt_dev->chardev_mutex);
+	mutex_init(&tt_dev->iatu_mutex);
 
 	tt_dev->dma_capable = (dma_set_mask_and_coherent(&dev->dev, DMA_BIT_MASK(dma_address_bits ?: device_class->dma_address_bits)) == 0);
 

--- a/grayskull.c
+++ b/grayskull.c
@@ -879,10 +879,18 @@ static void grayskull_restore_reset_state(struct tenstorrent_device *tt_dev) {
 	// no operation
 }
 
+static int grayskull_configure_outbound_atu(struct tenstorrent_device *tt_dev, u32 region, u64 base, u64 limit,
+					    u64 target)
+{
+	return -EINVAL;
+}
+
 struct tenstorrent_device_class grayskull_class = {
 	.name = "Grayskull",
 	.instance_size = sizeof(struct grayskull_device),
 	.dma_address_bits = 32,
+	.noc_dma_limit = (0xFFFE0000 - 1),
+	.noc_pcie_offset = 0x00000000,
 	.init_device = grayskull_init,
 	.init_hardware = grayskull_init_hardware,
 	.post_hardware_init = grayskull_post_hardware_init,
@@ -891,4 +899,5 @@ struct tenstorrent_device_class grayskull_class = {
 	.last_release_cb = grayskull_last_release_handler,
 	.save_reset_state = grayskull_save_reset_state,
 	.restore_reset_state = grayskull_restore_reset_state,
+	.configure_outbound_atu = grayskull_configure_outbound_atu,
 };

--- a/ioctl.h
+++ b/ioctl.h
@@ -148,6 +148,8 @@ struct tenstorrent_reset_device {
 
 // tenstorrent_pin_pages_in.flags
 #define TENSTORRENT_PIN_PAGES_CONTIGUOUS 1	// app attests that the pages are physically contiguous
+#define TENSTORRENT_PIN_PAGES_NOC_DMA 2		// app wants to use the pages for NOC DMA
+#define TENSTORRENT_PIN_PAGES_NOC_TOP_DOWN 4	// NOC DMA will be allocated top-down (default is bottom-up)
 
 struct tenstorrent_pin_pages_in {
 	__u32 output_size_bytes;
@@ -157,7 +159,12 @@ struct tenstorrent_pin_pages_in {
 };
 
 struct tenstorrent_pin_pages_out {
-	__u64 physical_address;
+	__u64 physical_address;	// or IOVA
+};
+
+struct tenstorrent_pin_pages_out_extended {
+	__u64 physical_address;	// or IOVA
+	__u64 noc_address;
 };
 
 // unpinning subset of a pinned buffer is not supported

--- a/memory.c
+++ b/memory.c
@@ -555,7 +555,7 @@ static int setup_noc_dma(struct chardev_private *priv, int flags, size_t size, u
 
 	limit = base + size - 1;
 	iatu_region = configure_outbound_iatu(priv, base, limit, target);
-	*noc_address = base;
+	*noc_address = tt_dev->dev_class->noc_pcie_offset + base;
 
 	mutex_unlock(&tt_dev->iatu_mutex);
 	return iatu_region;

--- a/memory.c
+++ b/memory.c
@@ -22,6 +22,139 @@
 
 #define BAR0_SIZE (1UL << 29)
 
+static int get_sorted_iatu_region_indices(const struct tenstorrent_outbound_iatu_region *regions, int *sorted_indices)
+{
+	int i;
+	int in_use_count = 0;
+
+	// First, collect indices of in-use regions.
+	for (i = 0; i < TENSTORRENT_MAX_OUTBOUND_IATU_REGIONS; i++) {
+		if (regions[i].priv) {
+			sorted_indices[in_use_count++] = i;
+		}
+	}
+
+	// Insertion sort the collected indices by the corresponding region's base.
+	for (i = 1; i < in_use_count; i++) {
+		int index = sorted_indices[i];
+		u64 base = regions[index].base;
+		int j = i - 1;
+
+		while (j >= 0 && regions[sorted_indices[j]].base > base) {
+			sorted_indices[j + 1] = sorted_indices[j];
+			j--;
+		}
+		sorted_indices[j + 1] = index;
+	}
+
+	return in_use_count;
+}
+
+static u64 find_iatu_region_top_down(const struct tenstorrent_outbound_iatu_region *regions, u64 max_addr, u64 size)
+{
+	int sorted_indices[TENSTORRENT_MAX_OUTBOUND_IATU_REGIONS];
+	u64 current_pos = max_addr;
+	int in_use_count;
+	int i;
+
+	in_use_count = get_sorted_iatu_region_indices(regions, sorted_indices);
+
+	if (in_use_count == 0) {
+		// Allocate at top if there's enough space.
+		if (size <= (max_addr + 1)) {
+			return max_addr - size + 1;
+		}
+		return U64_MAX; // Size too large for address space.
+	}
+
+	// Check each region from top to bottom.
+	for (i = in_use_count - 1; i >= 0; i--) {
+		const struct tenstorrent_outbound_iatu_region *region = &regions[sorted_indices[i]];
+
+		if ((current_pos - region->limit) >= size)
+			return current_pos - size + 1;
+
+		current_pos = region->base - 1;
+	}
+
+	// Check gap at the bottom (from 0 to the lowest region).
+	if ((current_pos + 1) >= size)
+		return current_pos - size + 1;
+
+	return U64_MAX; // No suitable gap found.
+}
+
+static u64 find_iatu_region_bottom_up(const struct tenstorrent_outbound_iatu_region *regions, u64 max_addr, u64 size)
+{
+	int sorted_indices[TENSTORRENT_MAX_OUTBOUND_IATU_REGIONS];
+	u64 current_pos = 0;
+	int in_use_count;
+	int i;
+
+	in_use_count = get_sorted_iatu_region_indices(regions, sorted_indices);
+
+	if (in_use_count == 0) {
+		// Allocate at bottom if there's enough space.
+		if (size <= max_addr + 1) {
+			return 0;
+		}
+		return U64_MAX;
+	}
+
+	// Check each region from bottom to top.
+	for (i = 0; i < in_use_count; i++) {
+		const struct tenstorrent_outbound_iatu_region *region = &regions[sorted_indices[i]];
+
+		if ((region->base - current_pos) >= size)
+			return current_pos;
+
+		current_pos = region->limit + 1;
+	}
+
+	// Check gap at the top (from highest region to max_addr).
+	if ((max_addr - current_pos + 1) >= size)
+		return current_pos;
+
+	return U64_MAX; // No suitable gap found.
+}
+
+// returns the region number or a negative error code.
+static int configure_outbound_iatu(struct chardev_private *priv, u64 base, u64 limit, u64 target)
+{
+	struct tenstorrent_device *tt_dev = priv->device;
+	int region = -1;
+	int i;
+	int ret;
+
+	if (base > limit)
+		return -EINVAL;
+
+	// Find a free region.
+	for (i = 0; i < TENSTORRENT_MAX_OUTBOUND_IATU_REGIONS; ++i) {
+		if (tt_dev->outbound_iatus[i].priv == NULL) {
+			region = i;
+			break;
+		}
+	}
+
+	if (region < 0)
+		return -ENOSPC;
+
+	// Program the hardware.
+	ret = tt_dev->dev_class->configure_outbound_atu(tt_dev, region, base, limit, target);
+	if (ret)
+		return ret;
+
+	// Mark region as in use.
+	tt_dev->outbound_iatus[region].priv = priv;
+	tt_dev->outbound_iatus[region].base = base;
+	tt_dev->outbound_iatus[region].limit = limit;
+	tt_dev->outbound_iatus[region].target = target;
+
+	return region;
+}
+
+
 // In Linux 5.0, dma_alloc_coherent always zeroes memory and dma_zalloc_coherent
 // was removed.
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
@@ -151,11 +284,29 @@ struct pinned_page_range {
 
 	struct sg_table dma_mapping;	// alloc_chained_sgt_for_pages / free_chained_sgt
 	u64 virtual_address;
+
+	int outbound_iatu_region;
 };
 
 static void unpin_pinned_page_range(struct chardev_private *priv,
 	struct pinned_page_range *pinning)
 {
+	if (pinning->outbound_iatu_region >= 0) {
+		struct tenstorrent_device *tt_dev = priv->device;
+		struct tenstorrent_outbound_iatu_region *region;
+		mutex_lock(&tt_dev->iatu_mutex);
+
+		region = &priv->device->outbound_iatus[pinning->outbound_iatu_region];
+		tt_dev->dev_class->configure_outbound_atu(tt_dev, pinning->outbound_iatu_region, 0, 0, 0);
+
+		region->priv = NULL;
+		region->base = 0;
+		region->limit = 0;
+		region->target = 0;
+
+		mutex_unlock(&tt_dev->iatu_mutex);
+	}
+
 	dma_unmap_sgtable(&priv->device->pdev->dev, &pinning->dma_mapping, DMA_BIDIRECTIONAL, 0);
 	free_chained_sgt(&pinning->dma_mapping);
 
@@ -379,9 +530,42 @@ static bool is_pin_pages_size_safe(u64 size)
 #endif
 }
 
+// Return the iATU region number or a negative error code.
+static int setup_noc_dma(struct chardev_private *priv, int flags, size_t size, u64 target, u64 *noc_address)
+{
+	struct tenstorrent_device *tt_dev = priv->device;
+	u64 max_addr = tt_dev->dev_class->noc_dma_limit;
+	u64 base;
+	u64 limit;
+	int iatu_region;
+
+	if (size == 0)
+		return -EINVAL;
+
+	mutex_lock(&tt_dev->iatu_mutex);
+	if (flags & TENSTORRENT_PIN_PAGES_NOC_TOP_DOWN)
+		base = find_iatu_region_top_down(tt_dev->outbound_iatus, max_addr, size);
+	else
+		base = find_iatu_region_bottom_up(tt_dev->outbound_iatus, max_addr, size);
+
+	if (base == U64_MAX) {
+		mutex_unlock(&tt_dev->iatu_mutex);
+		return -ENOMEM;
+	}
+
+	limit = base + size - 1;
+	iatu_region = configure_outbound_iatu(priv, base, limit, target);
+	*noc_address = base;
+
+	mutex_unlock(&tt_dev->iatu_mutex);
+	return iatu_region;
+}
+
 long ioctl_pin_pages(struct chardev_private *priv,
 		     struct tenstorrent_pin_pages __user *arg)
 {
+	const u32 valid_flags = TENSTORRENT_PIN_PAGES_CONTIGUOUS | TENSTORRENT_PIN_PAGES_NOC_DMA |
+				TENSTORRENT_PIN_PAGES_NOC_TOP_DOWN;
 	unsigned long nr_pages;
 	struct page **pages;
 	int pages_pinned;
@@ -389,14 +573,19 @@ long ioctl_pin_pages(struct chardev_private *priv,
 	struct sg_table dma_mapping = {0};
 	long ret;
 	u32 bytes_to_copy;
+	u64 noc_address = 0;
+	int iatu_region = -1;
 
 	struct tenstorrent_pin_pages_in in;
-	struct tenstorrent_pin_pages_out out;
+	struct tenstorrent_pin_pages_out_extended out;
 	memset(&in, 0, sizeof(in));
 	memset(&out, 0, sizeof(out));
 
 	if (copy_from_user(&in, &arg->in, sizeof(in)) != 0)
 		return -EFAULT;
+
+	if (in.flags & ~valid_flags)
+		return -EINVAL;
 
 	if (!PAGE_ALIGNED(in.virtual_address) || !PAGE_ALIGNED(in.size) || in.size == 0)
 		return -EINVAL;
@@ -404,12 +593,24 @@ long ioctl_pin_pages(struct chardev_private *priv,
 	if (!is_pin_pages_size_safe(in.size))
 		return -EINVAL;
 
-	if (in.flags != 0 && in.flags != TENSTORRENT_PIN_PAGES_CONTIGUOUS)
-		return -EINVAL;
+	mutex_lock(&priv->mutex);
+
+	// Block duplicate (VA/size) pinnings. Prevents ambiguity in UNPIN_PAGES
+	// regarding iATU teardown if the same range were pinned multiple times with
+	// different NOC_DMA flags.
+	list_for_each_entry(pinning, &priv->pinnings, list) {
+		if (pinning->virtual_address == in.virtual_address &&
+		    pinning->page_count == PAGE_ALIGN(in.size) >> PAGE_SHIFT) {
+			mutex_unlock(&priv->mutex);
+			return -EEXIST;
+		}
+	}
 
 	pinning = kmalloc(sizeof(*pinning), GFP_KERNEL);
-	if (!pinning)
+	if (!pinning) {
+		mutex_unlock(&priv->mutex);
 		return -ENOMEM;
+	}
 
 	nr_pages = PAGE_ALIGN(in.size) >> PAGE_SHIFT;
 	pages = vzalloc(nr_pages * sizeof(struct page *));
@@ -444,8 +645,6 @@ long ioctl_pin_pages(struct chardev_private *priv,
 			goto err_unpin_pages;
 		}
 
-		mutex_lock(&priv->mutex);
-
 		ret = dma_map_sgtable(&priv->device->pdev->dev, &dma_mapping, DMA_BIDIRECTIONAL, 0);
 
 		if (ret != 0) {
@@ -475,6 +674,14 @@ long ioctl_pin_pages(struct chardev_private *priv,
 		}
 
 		out.physical_address = sg_dma_address(dma_mapping.sgl);
+
+		if (in.flags & TENSTORRENT_PIN_PAGES_NOC_DMA) {
+			ret = setup_noc_dma(priv, in.flags, in.size, out.physical_address, &noc_address);
+
+			if (ret < 0)
+				goto err_dma_unmap;
+			iatu_region = ret;
+		}
 	} else {
 		int i;
 
@@ -488,17 +695,25 @@ long ioctl_pin_pages(struct chardev_private *priv,
 
 		out.physical_address = page_to_phys(pages[0]);
 
-		mutex_lock(&priv->mutex);
+		if (in.flags & TENSTORRENT_PIN_PAGES_NOC_DMA) {
+			ret = setup_noc_dma(priv, in.flags, in.size, out.physical_address, &noc_address);
+
+			if (ret < 0)
+				goto err_unpin_pages;
+			iatu_region = ret;
+		}
 	}
 
 	pinning->page_count = nr_pages;
 	pinning->pages = pages;
 	pinning->dma_mapping = dma_mapping;
 	pinning->virtual_address = in.virtual_address;
+	pinning->outbound_iatu_region = iatu_region;
 
 	list_add(&pinning->list, &priv->pinnings);
 	mutex_unlock(&priv->mutex);
 
+	out.noc_address = noc_address;
 	if (clear_user(&arg->out, in.output_size_bytes) != 0)
 		return -EFAULT;
 
@@ -513,13 +728,13 @@ err_dma_unmap:
 	dma_unmap_sgtable(&priv->device->pdev->dev, &dma_mapping, DMA_BIDIRECTIONAL, 0);
 err_unlock_priv:
 	free_chained_sgt(&dma_mapping);
-	mutex_unlock(&priv->mutex);
 err_unpin_pages:
 	unpin_user_pages_dirty_lock(pages, pages_pinned, false);
 err_vfree_pages:
 	vfree(pages);
 err_free_pinning:
 	kfree(pinning);
+	mutex_unlock(&priv->mutex);
 	return ret;
 }
 

--- a/memory.h
+++ b/memory.h
@@ -38,4 +38,12 @@ long ioctl_configure_tlb(struct chardev_private *priv,
 int tenstorrent_mmap(struct chardev_private *priv, struct vm_area_struct *vma);
 void tenstorrent_memory_cleanup(struct chardev_private *priv);
 
+#define TENSTORRENT_MAX_OUTBOUND_IATU_REGIONS 16
+struct tenstorrent_outbound_iatu_region {
+	struct chardev_private *priv;	// Owner of this region
+	u64 base;
+	u64 limit;
+	u64 target;
+};
+
 #endif

--- a/wormhole.c
+++ b/wormhole.c
@@ -4,6 +4,7 @@
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 #include <linux/bitfield.h>
 #include <linux/types.h>
+#include <linux/kernel.h>
 
 #include "wormhole.h"
 #include "grayskull.h"
@@ -39,17 +40,30 @@
 #define IATU_BASE 0x1200	// Relative to the start of BAR2
 #define IATU_OUTBOUND 0
 #define IATU_INBOUND 1
+#define IATU_OUTBOUND_REGIONS 16
 #define IATU_REGION_STRIDE 0x100
 #define IATU_REGION_CTRL_1_INBOUND	0x00
 #define IATU_REGION_CTRL_2_INBOUND	0x04
 #define IATU_LOWER_TARGET_ADDR_INBOUND	0x14
 #define IATU_UPPER_TARGET_ADDR_INBOUND	0x18
+#define IATU_REGION_CTRL_1_OUTBOUND 0x00
+#define IATU_REGION_CTRL_2_OUTBOUND 0x04
+#define IATU_LOWER_BASE_ADDR_OUTBOUND 0x08
+#define IATU_UPPER_BASE_ADDR_OUTBOUND 0x0C
+#define IATU_LIMIT_ADDR_OUTBOUND 0x10
+#define IATU_LOWER_TARGET_ADDR_OUTBOUND 0x14
+#define IATU_UPPER_TARGET_ADDR_OUTBOUND 0x18
 
 // IATU_REGION_CTRL_2_INBOUND fields
 #define REGION_EN (1 << 31)
 #define BAR_MATCH_MODE (1 << 30)
 #define FUZZY_TYPE_MATCH (1 << 27) // MRd, MWr, MRdLk are considered the same.
 #define BAR_NUM(n) ((n) << 8)
+
+// IATU_REGION_CTRL_2_OUTBOUND fields
+#define DMA_BYPASS (1 << 27)
+#define TLP_BYPASS (1 << 21)
+#define FUNC_BYPASS (1 << 19)
 
 // BAR4 is 32MB and will be mapped to the system registers from 0x1E000000
 // to 0x20000000.
@@ -433,7 +447,29 @@ static void wormhole_restore_reset_state(struct tenstorrent_device *tt_dev) {
 static int wormhole_configure_outbound_atu(struct tenstorrent_device *tt_dev, u32 region, u64 base, u64 limit,
 					   u64 target)
 {
-	return -EINVAL;
+	struct wormhole_device *wh = tt_dev_to_wh_dev(tt_dev);
+	u32 region_ctrl_1 = 0x0; // MEM type
+	u32 region_ctrl_2 = (limit == 0) ? 0 : (REGION_EN | DMA_BYPASS | TLP_BYPASS | FUNC_BYPASS);
+	u32 lower_base = lower_32_bits(base);
+	u32 upper_base = upper_32_bits(base);
+	u32 lower_target = lower_32_bits(target);
+	u32 upper_target = upper_32_bits(target);
+
+	if (region >= IATU_OUTBOUND_REGIONS)
+		return -EINVAL;
+
+	if (limit > U32_MAX)
+		return -EINVAL;
+
+	WRITE_IATU_REG(wh, OUTBOUND, region, LOWER_BASE_ADDR, lower_base);
+	WRITE_IATU_REG(wh, OUTBOUND, region, UPPER_BASE_ADDR, upper_base);
+	WRITE_IATU_REG(wh, OUTBOUND, region, LOWER_TARGET_ADDR, lower_target);
+	WRITE_IATU_REG(wh, OUTBOUND, region, UPPER_TARGET_ADDR, upper_target);
+	WRITE_IATU_REG(wh, OUTBOUND, region, LIMIT_ADDR, limit);
+	WRITE_IATU_REG(wh, OUTBOUND, region, REGION_CTRL_1, region_ctrl_1);
+	WRITE_IATU_REG(wh, OUTBOUND, region, REGION_CTRL_2, region_ctrl_2);
+
+	return 0;
 }
 
 struct tenstorrent_device_class wormhole_class = {

--- a/wormhole.c
+++ b/wormhole.c
@@ -430,10 +430,18 @@ static void wormhole_restore_reset_state(struct tenstorrent_device *tt_dev) {
 	close_dbi(wh);
 }
 
+static int wormhole_configure_outbound_atu(struct tenstorrent_device *tt_dev, u32 region, u64 base, u64 limit,
+					   u64 target)
+{
+	return -EINVAL;
+}
+
 struct tenstorrent_device_class wormhole_class = {
 	.name = "Wormhole",
 	.instance_size = sizeof(struct wormhole_device),
 	.dma_address_bits = 32,
+	.noc_dma_limit = (0xFFFE0000 - 1),
+	.noc_pcie_offset = 0x800000000ULL,
 	.tlb_kinds = NUM_TLB_KINDS,
 	.tlb_counts = { TLB_1M_WINDOW_COUNT, TLB_2M_WINDOW_COUNT, TLB_16M_WINDOW_COUNT },
 	.tlb_sizes = { TLB_1M_WINDOW_SIZE, TLB_2M_WINDOW_SIZE, TLB_16M_WINDOW_SIZE },
@@ -447,4 +455,5 @@ struct tenstorrent_device_class wormhole_class = {
 	.describe_tlb = wormhole_describe_tlb,
 	.save_reset_state = wormhole_save_reset_state,
 	.restore_reset_state = wormhole_restore_reset_state,
+	.configure_outbound_atu = wormhole_configure_outbound_atu,
 };


### PR DESCRIPTION
Introduces support for configuring the outbound PCIE Address Translation Unit (iATU) on Wormhole and Blackhole chips.  

This is step one in an effort to enable IOMMU support for Wormhole in a manner that is mostly transparent to applications and tools.  Background: https://tenstorrent.atlassian.net/wiki/spaces/syseng/pages/903544840/32-bit+DMA+migration+to+IOMMU

Changes:

1.  Outbound ATU Infrastructure & ASIC Implementation:
    * Introduces a `configure_outbound_atu` function pointer to the `tenstorrent_device_class` structure, along with initial stub implementations.
    * Provides concrete iATU programming implementations for Wormhole and Blackhole chips, enabling them to configure outbound mappings.
    * Adds necessary device-specific constants such as `noc_dma_limit` and `noc_pcie_offset` to support varied hardware capabilities.
    * For Blackhole, `bar2_mapping` is added to access iATU registers.

2.  `PIN_PAGES` IOCTL Enhancements:
    * Expands the `TENSTORRENT_IOCTL_PIN_PAGES` API with new flags to control NOC DMA mapping:
        * `TENSTORRENT_PIN_PAGES_NOC_DMA`: Allows applications to request that pinned pages also be mapped into the PCIE tile's NOC address space via an outbound iATU region.
        * `TENSTORRENT_PIN_PAGES_NOC_TOP_DOWN`: Provides an option to use a top-down allocation strategy for the NOC address; the default remains bottom-up.
    * Introduces the `tenstorrent_pin_pages_out_extended` output structure. If `TENSTORRENT_PIN_PAGES_NOC_DMA` is requested and the output buffer is sufficiently large, this structure returns the allocated `noc_address` (which includes the ASIC-specific `noc_pcie_offset`) back to the user-space application.

3.  iATU Region Management and Integration:
    * Adds state tracking for configured outbound iATU regions within the driver (`outbound_iatus` array in `struct tenstorrent_device`), protected by a new `iatu_mutex`.
    * Implements helper functions to find available address ranges, supporting both top-down and bottom-up allocation strategies by sorting and inspecting currently used regions.
    * Integrates iATU configuration into `ioctl_pin_pages`: when `TENSTORRENT_PIN_PAGES_NOC_DMA` is specified, an available iATU region is found, configured with the physical address of the pinned pages as the target, and its NOC base address is returned.
    * Ensures that iATU regions are properly released:
        * The hardware iATU region is disabled and marked as free when pages are unpinned (`unpin_pinned_page_range`).
        * All iATU regions owned by a file descriptor are cleaned up upon device release (`tenstorrent_memory_cleanup`).
    * Includes a check to prohibit double-mapping (pinning) of the same virtual address range for the same process.