### PR TITLE
ioctl: Clarify uapi licence

### DIFF
--- a/ioctl.h
+++ b/ioctl.h
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
-// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-License-Identifier: GPL-2.0-only WITH Linux-syscall-note
 
 #ifndef TTDRIVER_IOCTL_H_INCLUDED
 #define TTDRIVER_IOCTL_H_INCLUDED


### PR DESCRIPTION
The ioctl header is expected to be used like any other linux uapi header, where an exception for derived works is made. This is called the 'syscall-note' in the Linux kernel tree:

 https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/LICENSES/exceptions/Linux-syscall-note