### PR TITLE
Updated driver API to version 2

### DIFF
--- a/ioctl.h
+++ b/ioctl.h
@@ -7,7 +7,7 @@
 #include <linux/types.h>
 #include <linux/ioctl.h>
 
-#define TENSTORRENT_DRIVER_VERSION 1
+#define TENSTORRENT_DRIVER_VERSION 2
 
 #define TENSTORRENT_IOCTL_MAGIC 0xFA
 

--- a/test/ioctl.h
+++ b/test/ioctl.h
@@ -7,7 +7,7 @@
 #include <linux/types.h>
 #include <linux/ioctl.h>
 
-#define TENSTORRENT_DRIVER_VERSION 1
+#define TENSTORRENT_DRIVER_VERSION 2
 
 #define TENSTORRENT_IOCTL_MAGIC 0xFA
 


### PR DESCRIPTION
Driver version 1.33 had a bug in the implementation of the tlb allocation API, which required an API breaking change to fix in 1.34. To reflect this breaking change I have updated the driver API version to 2