### PR TITLE
WH/BH outbound ATU support, Episode II

### DIFF
--- a/chardev_private.h
+++ b/chardev_private.h
@@ -21,6 +21,7 @@ struct dmabuf {
 	dma_addr_t phys;
 	u64 size;	// always a multiple of PAGE_SIZE
 	u8 index;
+	int outbound_iatu_region;
 };
 
 // This is our device-private data assocated with each open character device fd.

--- a/enumerate.c
+++ b/enumerate.c
@@ -81,7 +81,16 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 	mutex_init(&tt_dev->chardev_mutex);
 	mutex_init(&tt_dev->iatu_mutex);
 
-	tt_dev->dma_capable = (dma_set_mask_and_coherent(&dev->dev, DMA_BIT_MASK(dma_address_bits ?: device_class->dma_address_bits)) == 0);
+	// Use dma_address_bits from module parameter or device class for coherent
+	// DMA mask, but use a 64-bit mask for streaming mappings. The problem this
+	// solves is that legacy Wormhole software assumes it will get 32-bit DMA
+	// addresses from the ALLOCATE_DMA_BUF API, but a 32 bit DMA mask is too
+	// limiting for user pinnings when IOMMU is enabled.
+	// linux/dma-mapping.h says, "the DMA API guarantees that the coherent DMA
+	// mask can be set to the same or smaller than the streaming DMA mask" so
+	// only set_dma_mask() return value is checked.
+	tt_dev->dma_capable = (dma_set_mask(&dev->dev, DMA_BIT_MASK(dma_address_bits ?: 64)) == 0);
+	dma_set_coherent_mask(&dev->dev, DMA_BIT_MASK(dma_address_bits ?: device_class->dma_address_bits));
 
 	// Max these to ensure the IOVA allocator will not split large pinned regions.
 	dma_set_max_seg_size(&dev->dev, UINT_MAX);

--- a/ioctl.h
+++ b/ioctl.h
@@ -81,19 +81,24 @@ struct tenstorrent_query_mappings {
 	struct tenstorrent_query_mappings_out out;
 };
 
+// tenstorrent_allocate_dma_buf_in.flags
+#define TENSTORRENT_ALLOCATE_DMA_BUF_NOC_DMA 2
+
 struct tenstorrent_allocate_dma_buf_in {
 	__u32 requested_size;
 	__u8  buf_index;	// [0,TENSTORRENT_MAX_DMA_BUFS)
-	__u8  reserved0[3];
+	__u8  flags;
+	__u8  reserved0[2];
 	__u64 reserved1[2];
 };
 
 struct tenstorrent_allocate_dma_buf_out {
-	__u64 physical_address;
+	__u64 physical_address;	// or IOVA
 	__u64 mapping_offset;
 	__u32 size;
 	__u32 reserved0;
-	__u64 reserved1[2];
+	__u64 noc_address;	// valid if TENSTORRENT_ALLOCATE_DMA_BUF_NOC_DMA is set
+	__u64 reserved1;
 };
 
 struct tenstorrent_allocate_dma_buf {

--- a/memory.c
+++ b/memory.c
@@ -506,6 +506,16 @@ long ioctl_allocate_dma_buf(struct chardev_private *priv,
 		goto out;
 	}
 
+	if (in.flags & TENSTORRENT_ALLOCATE_DMA_BUF_NOC_DMA) {
+		bool top_down = true;
+		ret = setup_noc_dma(priv, top_down, in.requested_size, dma_handle, &out.noc_address);
+		if (ret < 0) {
+			dma_free_coherent(&priv->device->pdev->dev, in.requested_size, dma_buf_kernel_ptr, dma_handle);
+			kfree(dmabuf);
+			goto out;
+		}
+	}
+
 	dmabuf->index = in.buf_index;
 	dmabuf->ptr = dma_buf_kernel_ptr;
 	dmabuf->phys = dma_handle;


### PR DESCRIPTION
Introduces outbound ATU programming for NOC DMA as an option for the ALLOCATE_DMA_BUF ioctl:
* repurpose a reserved field in `tenstorrent_allocate_dma_buf_in` for flags
* add TENSTORRENT_ALLOCATE_DMA_BUF_NOC_DMA flag
* repurpose a reserved field in `tenstorrent_allocate_dma_buf_out` for noc_address
* find and program an ATU region at dmabuf allocation (if requested)
* clear ATU region configuration at dmabuf deallocation (if region was programmed)

Minor refactoring in memory.c to share common code between ALLOCATE_DMA_BUF and PIN_PAGES paths:
* Relocate `setup_noc_dma` to avoid adding a prototype for it
* Modify `setup_noc_dma` signature to avoid conflating different ioctl flags

Change DMA mask configuration with two goals:
1. Allow pinning of ~4GB user pages under Wormhole when IOMMU is enabled (i.e. do not constrain DMA addresses of user mappings to 32 bits).
2. Continue to constrain DMA addresses produced by ALLOC_DMA_BUF to 32-bit for Wormhole, for legacy support.

The technique is to distinguish between coherent and streaming mapping DMA address masks.  For Wormhole, use a 32-bit coherent mask for Wormhole (achieves point goal 2) and a 64-bit streaming mask (achieves goal 1).