### PR TITLE
ci: Run sparse on files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,12 @@ jobs:
     - uses: actions/checkout@v4
     - run: |
         sudo apt update
-        sudo apt install -y make
+        sudo apt install -y make sparse
+    - run: |
         make -j $(nproc)
     - uses: actions/upload-artifact@v4
       with:
         name: driver-${{ matrix.os }}
         path: tenstorrent.ko
+    - run: |
+        make C=2 -j $(nproc)


### PR DESCRIPTION
This separates installation of dependencies from building the code, to make it easier to spot warnings in the UI.

It also adds a step to re-build the files with the sparse checker. This runs after uploading the .ko, so the uploaded file is not built with checking.

The output currently looks like this:

https://github.com/tenstorrent/tt-kmd/actions/runs/15300276060/job/43038874608#step:6:14

If we merge this first, then we can see the warnings go away once #68 goes in.