### PR TITLE
module: added alpine support

### DIFF
--- a/AKMBUILD
+++ b/AKMBUILD
@@ -1,0 +1,3 @@
+modname=tenstorrent
+modver=1.34
+built_modules="tenstorrent.ko"

--- a/README.md
+++ b/README.md
@@ -24,8 +24,20 @@ sudo modprobe tenstorrent
 ```
 (or reboot, driver will auto-load next boot)
 
+* (Alpine Linux) You must have akms installed.
+    * `apk install akms`
+```
+doas akms install
+doas modprobe tenstorrent
+```
+
 ### To uninstall:
 ```
 sudo modprobe -r tenstorrent
 sudo dkms remove tenstorrent/1.34 --all
+```
+* Alpine Linux (`akms`)
+```
+doas modprobe -r tenstorrent
+doas akms uninstall tenstorrent
 ```


### PR DESCRIPTION
Alpine linux uses akms instead of dkms, this PR make sure that the module compiles and installed on alpine linux as per https://github.com/tenstorrent/tt-metal/issues/18290 requirement.