### PR TITLE
Allow driver to build when hwmon is disabled

### DIFF
--- a/enumerate.c
+++ b/enumerate.c
@@ -28,6 +28,12 @@
 static DEFINE_IDR(tenstorrent_dev_idr);
 static DEFINE_MUTEX(tenstorrent_dev_idr_mutex);
 
+#if !IS_ENABLED(CONFIG_HWMON)
+struct device *devm_hwmon_device_register_with_info(struct device *,
+        const char *, void *, const struct hwmon_chip_info *, const struct
+        attribute_group **) { return NULL; }
+#endif
+
 static int tenstorrent_reboot_notifier(struct notifier_block *nb,
 				       unsigned long action, void *data) {
 	struct tenstorrent_device *tt_dev = container_of(nb, struct tenstorrent_device, reboot_notifier);


### PR DESCRIPTION
When the kernel has CONFIG_HWMON=n tt-kmd fails to link due to the missing devm_hwmon_device_register_with_info symbol.

In order to allow testing with eg. Ubuntu 'cloud' kernels, provide a stub for this case.

Without hwmon support the user will miss out on all of the hwmon sensors (and the driver might error out before finishing probing?), so this is not a well supported use case, but it does help for build testing.