### PR TITLE
Add nix flake

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,17 @@ on:
 
 jobs:
 
+  build-nix:
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: DeterminateSystems/nix-installer-action@v18
+    - run: nix flake check
+    - run: ./contrib/packaging/nix/ci.sh
+
   build-dkms:
     strategy:
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 Module.symvers
 modules.order
 tenstorrent.mod.c
+
+# nix result symlink
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ sudo modprobe tenstorrent
 ```
 (or reboot, driver will auto-load next boot)
 
+#### With NixOS
+
+1. Add this repository as a nix flake input:
+```nix
+inputs.tt-kmd.url = "github:tenstorrent/tt-kmd";
+```
+
+2. Add in the overlay:
+```nix
+nixpkgs.overlays = [ tt-kmd.overlays.default ];
+```
+
+3. Add the package to the kernel modules and udev packages:
+```nix
+boot.extraModulePackages = [ config.boot.kernelPackages.tt-kmd ];
+services.udev.packages = [ config.boot.kernelPackages.tt-kmd ];
+```
+
+4. Rebuild: `nixos-rebuild switch`
+
 ### To uninstall:
 ```
 sudo modprobe -r tenstorrent

--- a/contrib/packaging/MAINTAINERS.md
+++ b/contrib/packaging/MAINTAINERS.md
@@ -1,0 +1,5 @@
+# Maintainers
+
+| Maintainer   | GitHub ID        | Directory |
+---------------|------------------|---------  |
+| Tristan Ross | [@RossComputerGuy](https://github.com/RossComputerGuy) | `nix` |

--- a/contrib/packaging/README.md
+++ b/contrib/packaging/README.md
@@ -1,0 +1,9 @@
+# Packaging
+
+## Nix
+
+Requires either the Nix CLI or NixOS installed, can be downloaded from [nixos.org](https://nixos.org).
+
+### Updating
+
+Just run `nix flake update` on the top-level of this repository. Ping `@RossComputerGuy` for updates to nixpkgs using the [nixpkgs issue tracker](https://github.com/NixOS/nixpkgs/issues).

--- a/contrib/packaging/nix/ci.sh
+++ b/contrib/packaging/nix/ci.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+system=$(nix-instantiate --expr 'builtins.currentSystem' --eval --raw)
+attrs=$(nix flake show --json | jq --arg system "$system" '.packages[$system] | keys | .[]' -r)
+paths=()
+
+for attr in $attrs; do
+  paths+=(".#packages.$system.$attr")
+done
+
+nix build ${paths[@]}

--- a/contrib/packaging/nix/overlay.nix
+++ b/contrib/packaging/nix/overlay.nix
@@ -1,0 +1,32 @@
+{ lib, inputs }:
+pkgs: prev:
+with pkgs;
+let
+  overlayLinuxPackages =
+    prevLinuxPackages:
+    prevLinuxPackages.extend (
+      linuxPackages: super: {
+        tt-kmd = super.tt-kmd.overrideAttrs (
+          finalAttrs: prevAttrs: {
+            name = "tt-kmd-${finalAttrs.version}-${linuxPackages.kernel.version}";
+            version = "2.0.0-git+${inputs.self.shortRev or "dirty"}";
+
+            src = inputs.self.outPath;
+
+            passthru.isOverlaid = true;
+
+            meta = prevAttrs.meta // {
+              broken = linuxPackages.kernel.kernelOlder "6.10";
+            };
+          }
+        );
+      }
+    );
+in
+{
+  linuxKernel = prev.linuxKernel // {
+    packages = lib.mapAttrs (
+      _: linuxPackages: overlayLinuxPackages linuxPackages
+    ) prev.linuxKernel.packages;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,76 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1751413152,
+        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751578647,
+        "narHash": "sha256-GH9a1gUPWquHAmy21cwnASXlB50S8MrP5mla2Ws2vWc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "26aea5c29ff73ad9d3298fe5bd2ea0f2d029c002",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1751159883,
+        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,56 @@
+{
+  description = "Tenstorrent Kernel Module";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    systems.url = "github:nix-systems/default-linux";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      systems,
+      flake-parts,
+      ...
+    }@inputs:
+    flake-parts.lib.mkFlake { inherit inputs; } (
+      { lib, inputs, ... }:
+      {
+        systems = import inputs.systems;
+        flake.overlays.default = import ./contrib/packaging/nix/overlay.nix { inherit lib inputs; };
+        perSystem =
+          { pkgs, system, ... }:
+          {
+            _module.args.pkgs = import inputs.nixpkgs {
+              inherit system;
+              overlays = [
+                inputs.self.overlays.default
+              ];
+            };
+
+            packages =
+              {
+                default = pkgs.linuxPackages.tt-kmd;
+              }
+              // lib.mapAttrs (_: linuxPackages: linuxPackages.tt-kmd) (
+                lib.filterAttrs (
+                  name: linuxPackages:
+                  let
+                    eval = builtins.tryEval (
+                      linuxPackages ? "tt-kmd"
+                      && linuxPackages.kernel.meta.available
+                      && linuxPackages.tt-kmd.meta.available
+                      && linuxPackages.tt-kmd.passthru.isOverlaid or false
+                    );
+                  in
+                  lib.hasPrefix "linuxPackages_" name && eval.success && eval.value
+                ) pkgs
+              );
+
+            legacyPackages = pkgs;
+          };
+      }
+    );
+}


### PR DESCRIPTION
Since [nixpkgs itself has tt-kmd](https://github.com/NixOS/nixpkgs/pull/421385), let's add a Nix Flake here. I've gone ahead and add a job to the CI for it. I could integrate VM testing to at least test if the driver loads. Aside from that, this should work.