### PR TITLE
Add userspace library libttkmd

### DIFF
--- a/chardev.c
+++ b/chardev.c
@@ -21,7 +21,7 @@
 #include "ioctl.h"
 #include "pcie.h"
 #include "memory.h"
-#include "module.h"
+#include "version.h"
 #include "tlb.h"
 
 static dev_t tt_device_id;

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# Makefile for the Tenstorrent KMD User-space Library
+
+# Compiler and Flags
+CC ?= gcc
+# Add parent directory to include path for ioctl.h
+INCLUDES := -I..
+# CFLAGS for the library (requires Position-Independent Code)
+CFLAGS_LIB := -O2 -Wall -Wextra -fPIC $(INCLUDES)
+# CFLAGS for the example
+CFLAGS_EX := -O2 -Wall -Wextra
+
+# Linker Flags
+# -L. tells the linker to look for libraries in the current directory.
+LDFLAGS := -L.
+# -lttkmd links against our libttkmd.so
+LDLIBS := -lttkmd
+
+# Installation Prefix
+PREFIX ?= /usr/local
+# Project-specific include directory for namespacing.
+INCLUDE_DIR := $(PREFIX)/include/tenstorrent
+
+# Project Files
+TARGET_LIB := libttkmd.so
+TARGET_EX := example
+
+SOURCES_LIB := ttkmd.c
+OBJECTS_LIB := $(SOURCES_LIB:.c=.o)
+SOURCES_EX := example.c
+
+# The main public header for our library.
+HEADER_LIB := ttkmd.h
+# The KMD uAPI header from the parent directory (private, not installed).
+HEADER_KMD := ../ioctl.h
+# The shared version header between the library and the kernel module.
+HEADER_VERSION := ../version.h
+
+
+# Phony targets are not files.
+.PHONY: all clean install uninstall run
+
+# Default target: build everything.
+all: $(TARGET_LIB) $(TARGET_EX)
+
+# Rule to build the shared library from its object files.
+$(TARGET_LIB): $(OBJECTS_LIB)
+	@echo "  LD (Shared) $@"
+	$(CC) -shared -o $@ $(OBJECTS_LIB)
+
+# Rule to build the example program. It depends on the library being built first.
+# The rpath argument ensures the example can find the .so file in the same directory.
+$(TARGET_EX): $(SOURCES_EX) $(TARGET_LIB)
+	@echo "  CC (Example) $@"
+	$(CC) $(CFLAGS_EX) $(SOURCES_EX) -o $@ $(LDFLAGS) $(LDLIBS) -Wl,-rpath,'$$ORIGIN'
+
+# Generic rule for creating object files from C source files for the library.
+# The objects depend on both our library's public header and the private KMD uAPI header.
+$(OBJECTS_LIB): %.o: %.c $(HEADER_LIB) $(HEADER_KMD) $(HEADER_VERSION)
+	@echo "  CC (Library) $<"
+	$(CC) $(CFLAGS_LIB) -c $< -o $@
+
+# Target to clean up the build directory.
+clean:
+	@echo "  CLEAN"
+	rm -f $(TARGET_LIB) $(TARGET_EX) $(OBJECTS_LIB)
+
+# Target to install the library and the public header.
+# The header is installed into a project-specific subdirectory to avoid name conflicts.
+install: $(TARGET_LIB) $(HEADER_LIB)
+	@echo "  INSTALL"
+	install -d $(DESTDIR)$(INCLUDE_DIR)
+	install -d $(DESTDIR)$(PREFIX)/lib
+	install -m 644 $(HEADER_LIB) $(DESTDIR)$(INCLUDE_DIR)
+	install -m 755 $(TARGET_LIB) $(DESTDIR)$(PREFIX)/lib
+
+# Target to uninstall the library and header.
+uninstall:
+	@echo "  UNINSTALL"
+	rm -f $(DESTDIR)$(INCLUDE_DIR)/$(HEADER_LIB)
+	rm -f $(DESTDIR)$(PREFIX)/lib/$(TARGET_LIB)
+	-rmdir --ignore-fail-on-non-empty $(DESTDIR)$(INCLUDE_DIR)
+
+# Convenience target to build and run the example.
+run: $(TARGET_EX)
+	@echo "  RUN"
+	./$(TARGET_EX)
+

--- a/lib/example.c
+++ b/lib/example.c
@@ -1,0 +1,380 @@
+/**
+ * SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include "ttkmd.h"
+
+#include <errno.h>
+#include <linux/mman.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <time.h>
+
+#ifdef PROFILE_API_CALLS
+#define OK(expr) do { \
+    struct timespec start, end; \
+    clock_gettime(CLOCK_MONOTONIC, &start); \
+    int rc = (expr); \
+    clock_gettime(CLOCK_MONOTONIC, &end); \
+    long long duration_ns = (end.tv_sec - start.tv_sec) * 1000000000LL + (end.tv_nsec - start.tv_nsec); \
+    printf("[PROFILE] %-70s took %12lld ns\n", #expr, duration_ns); \
+    if (rc != 0) { FATAL("API call failed: " #expr); } \
+} while (0)
+#else
+#define OK(expr) do { if ((expr) != 0) { FATAL("API call failed: " #expr); } } while (0)
+#endif
+#define FATAL(fmt, ...) do { fprintf(stderr, "%s:%d " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); exit(1); } while (0)
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define MAX_DEVICES 32
+#define UNUSED(x) (void)(x)
+
+#define WH_SIZE_X 10
+#define WH_SIZE_Y 12
+#define WH_PCIE_X 0
+#define WH_PCIE_Y 3
+#define WH_DDR_X 0
+#define WH_DDR_Y 0
+#define WH_ARC_X 0
+#define WH_ARC_Y 10
+#define WH_ARC_NOC_NODE_ID 0xFFFB2002CULL
+#define WH_TENSIX_NOC_NODE_ID 0xFFB2002CULL
+
+#define BH_SIZE_X 17
+#define BH_SIZE_Y 12
+#define BH_PCIE_X 19
+#define BH_PCIE_Y 24
+#define BH_DDR_X 17
+#define BH_DDR_Y 12
+#define BH_NOC_NODE_ID_LOGICAL 0xFFB20148ULL
+
+static bool is_wormhole(tt_device_t* dev)
+{
+    uint64_t arch;
+    OK(tt_device_get_attr(dev, TT_DEVICE_ATTR_CHIP_ARCH, &arch));
+    return arch == TT_DEVICE_ARCH_WORMHOLE;
+}
+
+static bool is_blackhole(tt_device_t* dev)
+{
+    uint64_t arch;
+    OK(tt_device_get_attr(dev, TT_DEVICE_ATTR_CHIP_ARCH, &arch));
+    return arch == TT_DEVICE_ARCH_BLACKHOLE;
+}
+
+static void* allocate_dma_buffer(size_t len)
+{
+    void* addr = MAP_FAILED;
+
+    if ((len % (1UL << 30)) == 0) {
+        addr = mmap(0, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_1GB, -1, 0);
+    }
+
+    if (addr == MAP_FAILED && (len % (1UL << 21)) == 0) {
+        addr = mmap(0, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_2MB, -1, 0);
+    }
+
+    if (addr == MAP_FAILED) {
+        addr = mmap(0, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    }
+
+    /* TODO: use madvise instead? */
+
+    return addr;
+}
+
+static void query_attributes(tt_device_t* dev)
+{
+    const char* arch;
+    uint64_t vendor_id, device_id;
+    uint64_t pci_domain, pci_bus, pci_device, pci_function;
+    uint64_t num_1m_tlbs, num_2m_tlbs, num_16m_tlbs, num_4g_tlbs;
+    uint64_t semver_major, semver_minor, semver_patch;
+    uint64_t api_version;
+
+    OK(tt_device_get_attr(dev, TT_DEVICE_ATTR_PCI_VENDOR_ID, &vendor_id));
+    OK(tt_device_get_attr(dev, TT_DEVICE_ATTR_PCI_DEVICE_ID, &device_id));
+    OK(tt_device_get_attr(dev, TT_DEVICE_ATTR_PCI_DOMAIN, &pci_domain));
+    OK(tt_device_get_attr(dev, TT_DEVICE_ATTR_PCI_BUS, &pci_bus));
+    OK(tt_device_get_attr(dev, TT_DEVICE_ATTR_PCI_DEVICE, &pci_device));
+    OK(tt_device_get_attr(dev, TT_DEVICE_ATTR_PCI_FUNCTION, &pci_function));
+    OK(tt_device_get_attr(dev, TT_DEVICE_ATTR_NUM_1M_TLBS, &num_1m_tlbs));
+    OK(tt_device_get_attr(dev, TT_DEVICE_ATTR_NUM_2M_TLBS, &num_2m_tlbs));
+    OK(tt_device_get_attr(dev, TT_DEVICE_ATTR_NUM_16M_TLBS, &num_16m_tlbs));
+    OK(tt_device_get_attr(dev, TT_DEVICE_ATTR_NUM_4G_TLBS, &num_4g_tlbs));
+
+    OK(tt_driver_get_attr(dev, TT_DRIVER_SEMVER_MAJOR, &semver_major));
+    OK(tt_driver_get_attr(dev, TT_DRIVER_SEMVER_MINOR, &semver_minor));
+    OK(tt_driver_get_attr(dev, TT_DRIVER_SEMVER_PATCH, &semver_patch));
+    OK(tt_driver_get_attr(NULL, TT_DRIVER_API_VERSION, &api_version));  /* OK to call with NULL device. */
+
+    arch = is_wormhole(dev) ? "Wormhole" :
+           is_blackhole(dev) ? "Blackhole" : "Unknown";
+
+    printf("\t Driver: %lu.%lu.%lu (API %lu)\n", semver_major, semver_minor, semver_patch, api_version);
+    printf("\t %04lx:%02lx:%02lx.%lx %04lx:%04lx", pci_domain, pci_bus, pci_device, pci_function, vendor_id, device_id);
+    printf(" (%s)\n", arch);
+
+    if (num_1m_tlbs > 0) {
+        printf("\t %lu 1M TLBs\n", num_1m_tlbs);
+    }
+    if (num_2m_tlbs > 0) {
+        printf("\t %lu 2M TLBs\n", num_2m_tlbs);
+    }
+    if (num_16m_tlbs > 0) {
+        printf("\t %lu 16M TLBs\n", num_16m_tlbs);
+    }
+    if (num_4g_tlbs > 0) {
+        printf("\t %lu 4G TLBs\n", num_4g_tlbs);
+    }
+}
+
+static uint32_t seed;
+static void my_srand(uint32_t new_seed)
+{
+    seed = new_seed;
+}
+
+static inline uint32_t my_rand(void)
+{
+    seed = seed * 1103515245 + 12345;
+    return (uint32_t)(seed / 65536) % 32768;
+}
+
+static void noc_dma_test(tt_device_t* dev, size_t len)
+{
+    /* Allocate a DMA buffer. */
+    void* buffer = allocate_dma_buffer(len);
+    if (buffer == MAP_FAILED) {
+        FATAL("Failed to allocate DMA buffer: %s", strerror(errno));
+    }
+    memset(buffer, 0, len);
+
+    /* Map the DMA buffer. */
+    tt_dma_t* dma_handle;
+    OK(tt_dma_map(dev, buffer, len, TT_DMA_FLAG_NOC, &dma_handle));
+
+    /* Allocate a TLB window */
+    tt_tlb_t *tlb;
+    size_t tlb_size = TT_TLB_SIZE_2M;
+    void* mmio;
+    OK(tt_tlb_alloc(dev, tlb_size, TT_MMIO_CACHE_MODE_WC, &tlb));
+    OK(tt_tlb_get_mmio(tlb, &mmio));
+
+    /* Prepare the NOC address (x, y, address) that targets the buffer. */
+    uint16_t pcie_x = is_wormhole(dev) ? WH_PCIE_X : is_blackhole(dev) ? BH_PCIE_X : -1;
+    uint16_t pcie_y = is_wormhole(dev) ? WH_PCIE_Y : is_blackhole(dev) ? BH_PCIE_Y : -1;
+    uint64_t noc_addr;
+    OK(tt_dma_get_noc_addr(dma_handle, &noc_addr));
+
+    /* Write a pattern through the window. */
+    uint64_t bytes_remaining = len;
+    uint64_t seed = 17;
+    my_srand(seed);
+    while (bytes_remaining > 0) {
+        uint64_t aligned_addr = noc_addr & ~(tlb_size - 1);
+        uint64_t offset = noc_addr & (tlb_size - 1);
+        size_t chunk_size = MIN(bytes_remaining, tlb_size - offset);
+        uint32_t* dst_ptr = (uint32_t*)((uint8_t*)mmio + offset);
+
+        /* Map the TLB window for this chunk. */
+        if (tt_tlb_map_unicast(dev, tlb, pcie_x, pcie_y, aligned_addr) != 0) {
+            FATAL("Failed to configure TLB for write");
+        }
+
+        for (size_t i = 0; i < chunk_size; i += 4) {
+            uint32_t value = my_rand();
+            dst_ptr[i / 4] = value;
+        }
+
+        bytes_remaining -= chunk_size;
+        noc_addr += chunk_size;
+    }
+
+    /* Release the TLB window. */
+    OK(tt_tlb_free(dev, tlb));
+
+    /* Unmap the DMA buffer. */
+    OK(tt_dma_unmap(dev, dma_handle));
+
+    /* Verify the written data by re-generating the pattern and comparing. */
+    my_srand(seed);
+    for (size_t i = 0; i < len / sizeof(uint32_t); i++) {
+        uint32_t expected_value = my_rand();
+        uint32_t actual_value = ((uint32_t*)buffer)[i];
+
+        if (expected_value != actual_value) {
+            FATAL("Data mismatch at index %zu: expected %u, got %u", i, expected_value, actual_value);
+        }
+    }
+
+    /* Deallocate the buffer. */
+    munmap(buffer, len);
+
+    printf("NOC DMA (size=0x%lx) test PASSED\n", len);
+}
+
+static bool is_tensix_wh(uint32_t x, uint32_t y)
+{
+    return (((y != 6) && (y >= 1) && (y <= 11)) && // valid Y
+            ((x != 5) && (x >= 1) && (x <= 9)));   // valid X
+}
+
+static void node_id_test_wh(tt_device_t* dev)
+{
+    uint32_t node_id;
+    uint32_t node_id_x;
+    uint32_t node_id_y;
+
+    if (!is_wormhole(dev)) {
+        return;
+    }
+
+    OK(tt_noc_read32(dev, WH_ARC_X, WH_ARC_Y, WH_ARC_NOC_NODE_ID, &node_id));
+
+    node_id_x = (node_id >> 0x0) & 0x3f;
+    node_id_y = (node_id >> 0x6) & 0x3f;
+
+    if (node_id_x != WH_ARC_X || node_id_y != WH_ARC_Y) {
+        FATAL("ARC ID mismatch, expected (%u, %u), got (%u, %u)", WH_ARC_X, WH_ARC_Y, node_id_x, node_id_y);
+    }
+
+    for (uint32_t x = 0; x < WH_SIZE_X; ++x) {
+        for (uint32_t y = 0; y < WH_SIZE_Y; ++y) {
+            if (!is_tensix_wh(x, y)) {
+                continue;
+            }
+
+            OK(tt_noc_read32(dev, x, y, WH_TENSIX_NOC_NODE_ID, &node_id));
+
+            node_id_x = (node_id >> 0x0) & 0x3f;
+            node_id_y = (node_id >> 0x6) & 0x3f;
+
+            if (node_id_x != x || node_id_y != y) {
+                FATAL("Tensix ID mismatch, expected (%u, %u), got (%u, %u)", x, y, node_id_x, node_id_y);
+            }
+        }
+    }
+
+    printf("NOC node id test PASSED\n");
+}
+
+static bool is_tensix_bh(uint32_t x, uint32_t y)
+{
+    return (y >= 2 && y <= 11) &&   // Valid y range
+        ((x >= 1 && x <= 7) ||      // Left block
+        (x >= 10 && x <= 16));      // Right block
+}
+
+static void node_id_test_bh(tt_device_t* dev)
+{
+    uint32_t node_id;
+    uint32_t node_id_x;
+    uint32_t node_id_y;
+
+    if (!is_blackhole(dev)) {
+        return;
+    }
+
+    for (uint32_t x = 0; x < BH_SIZE_X; ++x) {
+        for (uint32_t y = 0; y < BH_SIZE_Y; ++y) {
+            if (!is_tensix_bh(x, y)) {
+                continue;
+            }
+
+            OK(tt_noc_read32(dev, x, y, BH_NOC_NODE_ID_LOGICAL, &node_id));
+
+            node_id_x = (node_id >> 0x0) & 0x3f;
+            node_id_y = (node_id >> 0x6) & 0x3f;
+
+            if (node_id_x != x || node_id_y != y) {
+                FATAL("Tensix ID mismatch, expected (%u, %u), got (%u, %u)", x, y, node_id_x, node_id_y);
+            }
+        }
+    }
+
+    printf("NOC node id test PASSED\n");
+}
+
+void block_io_test(tt_device_t* dev)
+{
+    uint16_t ddr_x = is_wormhole(dev) ? WH_DDR_X : is_blackhole(dev) ? BH_DDR_X : -1;
+    uint16_t ddr_y = is_wormhole(dev) ? WH_DDR_Y : is_blackhole(dev) ? BH_DDR_Y : -1;
+
+    /* Allocate buffer. */
+    void* data;
+    size_t len = 0x380000; /* 3.5 MiB */
+    data = malloc(len);
+    if (!data) {
+        FATAL("Failed to allocate memory for data: %s", strerror(errno));
+    }
+
+    /* Fill buffer with pseudorandom numbers. */
+    my_srand(42);
+    for (size_t i = 0; i < len / sizeof(uint32_t); i++) {
+        ((uint32_t*)data)[i] = my_rand();
+    }
+
+    /* Write the buffer and read it back in a few different places */
+    uint64_t addresses[] = { 0x000000, 0xF00008, 0x50000C };
+    for (size_t i = 0; i < sizeof(addresses) / sizeof(addresses[0]); i++) {
+        uint64_t addr = addresses[i];
+
+        /* Write data to the NOC. */
+        OK(tt_noc_write(dev, ddr_x, ddr_y, addr, data, len));
+
+        /* Read it back into a new buffer. */
+        void* read_data = malloc(len);
+        if (!read_data) {
+            FATAL("Failed to allocate memory for read data: %s", strerror(errno));
+        }
+        OK(tt_noc_read(dev, ddr_x, ddr_y, addr, read_data, len));
+
+        /* Verify that the data matches. */
+        if (memcmp(data, read_data, len) != 0) {
+            FATAL("Data mismatch at address 0x%lx", addr);
+        }
+
+        free(read_data);
+    }
+
+    printf("Block I/O test PASSED\n");
+}
+
+int main(int argc, char** argv)
+{
+    uint64_t api_version;
+    OK(tt_driver_get_attr(NULL, TT_DRIVER_API_VERSION, &api_version));
+    printf("Tenstorrent Driver API Version: %lu\n", api_version);
+
+    for (int i = 0; i < MAX_DEVICES; ++i) {
+        char chardev_path[32];
+        snprintf(chardev_path, sizeof(chardev_path), "/dev/tenstorrent/%d", i);
+
+        tt_device_t* dev;
+        if (tt_device_open(chardev_path, &dev) != 0)
+            continue;
+
+        printf("Running tests on %s\n", chardev_path);
+
+        query_attributes(dev);
+        node_id_test_wh(dev);
+        node_id_test_bh(dev);
+        block_io_test(dev);
+        noc_dma_test(dev, 0x1000);
+        noc_dma_test(dev, 0x4000);
+        noc_dma_test(dev, 0x204000);
+        noc_dma_test(dev, 1ULL << 21);
+        noc_dma_test(dev, 1ULL << 30);
+
+        OK(tt_device_close(dev));
+        printf("\n");
+    }
+    return 0;
+
+    UNUSED(argc);
+    UNUSED(argv);
+}

--- a/lib/ttkmd.c
+++ b/lib/ttkmd.c
@@ -1,0 +1,546 @@
+/**
+ * SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include "ttkmd.h"
+
+#include "ioctl.h"    /* From tt-kmd */
+#include "version.h"  /* From tt-kmd */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/mman.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#define BLACKHOLE_PCI_DEVICE_ID 0xb140
+#define WORMHOLE_PCI_DEVICE_ID 0x401e
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define DEBUG(fmt, ...) do { fprintf(stderr, "%s:%d " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); } while (0)
+
+static uint64_t TLB_COUNT_1M[] = {
+    [TT_DEVICE_ARCH_UNKNOWN] = 0,
+    [TT_DEVICE_ARCH_WORMHOLE] = 156,
+    [TT_DEVICE_ARCH_BLACKHOLE] = 0,
+};
+
+static uint64_t TLB_COUNT_2M[] = {
+    [TT_DEVICE_ARCH_UNKNOWN] = 0,
+    [TT_DEVICE_ARCH_WORMHOLE] = 10,
+    [TT_DEVICE_ARCH_BLACKHOLE] = 202,
+};
+
+static uint64_t TLB_COUNT_16M[] = {
+    [TT_DEVICE_ARCH_UNKNOWN] = 0,
+    [TT_DEVICE_ARCH_WORMHOLE] = 20,
+    [TT_DEVICE_ARCH_BLACKHOLE] = 0,
+};
+
+static uint64_t TLB_COUNT_4G[] = {
+    [TT_DEVICE_ARCH_UNKNOWN] = 0,
+    [TT_DEVICE_ARCH_WORMHOLE] = 0,
+    [TT_DEVICE_ARCH_BLACKHOLE] = 8
+};
+
+struct tt_device_t {
+    int fd;
+};
+
+struct tt_tlb_t {
+    uint32_t id;
+    size_t size;
+    void* mmio;
+};
+
+struct tt_dma_t {
+    void* addr;             /* Virtual address */
+    size_t len;             /* Bytes */
+    uint64_t iova;          /* I/O Virtual Address */
+    uint64_t noc;           /* NOC address (inside EP PCIe tile) */
+};
+
+int tt_device_open(const char* chardev_path, tt_device_t** out_dev)
+{
+    struct tt_device_t* dev = malloc(sizeof(struct tt_device_t));
+
+    if (!dev) {
+        return -ENOMEM;
+    }
+
+    memset(dev, 0, sizeof(struct tt_device_t));
+
+    dev->fd = open(chardev_path, O_RDWR | O_CLOEXEC);
+    if (dev->fd == -1) {
+        int e = errno;
+        free(dev);
+        return -e;
+    }
+
+    uint64_t major = 0;
+    uint64_t minor = 0;
+    uint64_t patch = 0;
+
+    int ret;
+    if ((ret = tt_driver_get_attr(dev, TT_DRIVER_SEMVER_MAJOR, &major)) != 0 ||
+        (ret = tt_driver_get_attr(dev, TT_DRIVER_SEMVER_MINOR, &minor)) != 0 ||
+        (ret = tt_driver_get_attr(dev, TT_DRIVER_SEMVER_PATCH, &patch)) != 0) {
+        close(dev->fd);
+        free(dev);
+        return ret;
+    }
+
+    if (major != TENSTORRENT_DRIVER_VERSION_MAJOR || minor < TENSTORRENT_DRIVER_VERSION_MINOR) {
+	    DEBUG("Driver version mismatch: compiled for v%d.%d.%d; detected v%lu.%lu.%lu\n",
+              TENSTORRENT_DRIVER_VERSION_MAJOR, TENSTORRENT_DRIVER_VERSION_MINOR, TENSTORRENT_DRIVER_VERSION_PATCH,
+              major, minor, patch);
+	    close(dev->fd);
+	    free(dev);
+	    return -ENODEV;
+    }
+
+    *out_dev = dev;
+
+    return 0;
+}
+
+int tt_device_close(tt_device_t* dev)
+{
+    if (close(dev->fd) != 0) {
+        return -errno;
+    }
+
+    free(dev);
+    return 0;
+}
+
+int tt_device_get_attr(tt_device_t* dev, enum tt_device_attr attr, uint64_t* out_value)
+{
+    struct tenstorrent_get_device_info get_device_info = {0};
+
+    get_device_info.in.output_size_bytes = sizeof(get_device_info.out);
+
+    if (ioctl(dev->fd, TENSTORRENT_IOCTL_GET_DEVICE_INFO, &get_device_info) != 0) {
+        return -errno;
+    }
+
+    uint64_t arch = TT_DEVICE_ARCH_UNKNOWN;
+    if (get_device_info.out.device_id == BLACKHOLE_PCI_DEVICE_ID) {
+        arch = TT_DEVICE_ARCH_BLACKHOLE;
+    } else if (get_device_info.out.device_id == WORMHOLE_PCI_DEVICE_ID) {
+        arch = TT_DEVICE_ARCH_WORMHOLE;
+    }
+
+    switch (attr) {
+        case TT_DEVICE_ATTR_PCI_DOMAIN:
+            *out_value = get_device_info.out.pci_domain;
+            break;
+        case TT_DEVICE_ATTR_PCI_BUS:
+            *out_value = get_device_info.out.bus_dev_fn >> 8;
+            break;
+        case TT_DEVICE_ATTR_PCI_DEVICE:
+            *out_value = (get_device_info.out.bus_dev_fn >> 3) & 0x1F;
+            break;
+        case TT_DEVICE_ATTR_PCI_FUNCTION:
+            *out_value = get_device_info.out.bus_dev_fn & 0x07;
+            break;
+        case TT_DEVICE_ATTR_PCI_VENDOR_ID:
+            *out_value = get_device_info.out.vendor_id;
+            break;
+        case TT_DEVICE_ATTR_PCI_DEVICE_ID:
+            *out_value = get_device_info.out.device_id;
+            break;
+        case TT_DEVICE_ATTR_PCI_SUBSYSTEM_ID:
+            *out_value = get_device_info.out.subsystem_id;
+            break;
+        case TT_DEVICE_ATTR_CHIP_ARCH:
+            *out_value = arch;
+            break;
+        case TT_DEVICE_ATTR_NUM_1M_TLBS:
+            *out_value = TLB_COUNT_1M[arch];
+            break;
+        case TT_DEVICE_ATTR_NUM_2M_TLBS:
+            *out_value = TLB_COUNT_2M[arch];
+            break;
+        case TT_DEVICE_ATTR_NUM_16M_TLBS:
+            *out_value = TLB_COUNT_16M[arch];
+            break;
+        case TT_DEVICE_ATTR_NUM_4G_TLBS:
+            *out_value = TLB_COUNT_4G[arch];
+            break;
+        default:
+            return -EINVAL;
+    }
+
+    return 0;
+}
+
+int tt_driver_get_attr(tt_device_t* dev, enum tt_driver_attr attr, uint64_t* out_value)
+{
+    struct tenstorrent_get_driver_info get_driver_info = {0};
+    get_driver_info.in.output_size_bytes = sizeof(get_driver_info.out);
+
+    /* OK to call with NULL dev, but can't return semver without a device. */
+    if (dev) {
+        if (ioctl(dev->fd, TENSTORRENT_IOCTL_GET_DRIVER_INFO, &get_driver_info) != 0) {
+            return -errno;
+        }
+    }
+
+    switch (attr) {
+        case TT_DRIVER_API_VERSION:
+            *out_value = TENSTORRENT_DRIVER_VERSION;
+            return 0;
+        case TT_DRIVER_SEMVER_MAJOR:
+            *out_value = get_driver_info.out.driver_version_major;
+            return dev ? 0 : -ENODEV;
+        case TT_DRIVER_SEMVER_MINOR:
+            *out_value = get_driver_info.out.driver_version_minor;
+            return dev ? 0 : -ENODEV;
+        case TT_DRIVER_SEMVER_PATCH:
+            *out_value = get_driver_info.out.driver_version_patch;
+            return dev ? 0 : -ENODEV;
+        default:
+            return -EINVAL;
+    }
+
+    return 0;
+}
+
+int tt_noc_read32(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, uint32_t* value)
+{
+    if (addr % 4 != 0) {
+        return -EINVAL;
+    }
+
+    tt_tlb_t* tlb;
+    int ret = tt_tlb_alloc(dev, TT_TLB_SIZE_2M, TT_MMIO_CACHE_MODE_UC, &tlb);
+    if (ret != 0) {
+        return ret;
+    }
+
+    uint64_t aligned_addr = addr & ~(tlb->size - 1);
+    ret = tt_tlb_map_unicast(dev, tlb, x, y, aligned_addr);
+
+    if (ret != 0) {
+        tt_tlb_free(dev, tlb);
+        return ret;
+    }
+
+    uint64_t offset = addr & (tlb->size - 1);
+    *value = *(volatile uint32_t*)((uint8_t*)tlb->mmio + offset);
+
+    tt_tlb_free(dev, tlb);
+    return 0;
+}
+
+int tt_noc_write32(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, uint32_t value)
+{
+    if (addr % 4 != 0) {
+        return -EINVAL;
+    }
+
+    tt_tlb_t* tlb;
+    int ret = tt_tlb_alloc(dev, TT_TLB_SIZE_2M, TT_MMIO_CACHE_MODE_UC, &tlb);
+    if (ret != 0) {
+        return ret;
+    }
+
+    uint64_t aligned_addr = addr & ~(tlb->size - 1);
+    ret = tt_tlb_map_unicast(dev, tlb, x, y, aligned_addr);
+
+    if (ret != 0) {
+        tt_tlb_free(dev, tlb);
+        return ret;
+    }
+
+    uint64_t offset = addr & (tlb->size - 1);
+    *(volatile uint32_t*)((uint8_t*)tlb->mmio + offset) = value;
+
+    tt_tlb_free(dev, tlb);
+    return 0;
+}
+
+int tt_noc_read(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, void* dst, size_t len)
+{
+    uint8_t* dst_ptr = (uint8_t*)dst;
+    tt_tlb_t* tlb;
+    int32_t ret;
+
+    if (addr % 4 != 0 || len % 4 != 0) {
+        return -EINVAL;
+    }
+
+    ret = tt_tlb_alloc(dev, TT_TLB_SIZE_2M, TT_MMIO_CACHE_MODE_WC, &tlb);
+    if (ret != 0) {
+        return ret;
+    }
+
+    while (len > 0) {
+        uint64_t aligned_addr = addr & ~(tlb->size - 1);
+        uint64_t offset = addr & (tlb->size - 1);
+        size_t chunk_size = MIN(len, tlb->size - offset);
+        uint8_t* src_ptr = (uint8_t*)tlb->mmio + offset;
+
+        ret = tt_tlb_map_unicast(dev, tlb, x, y, aligned_addr);
+
+        if (ret != 0) {
+            tt_tlb_free(dev, tlb);
+            return ret;
+        }
+
+        memcpy(dst_ptr, src_ptr, chunk_size);
+
+        dst_ptr += chunk_size;
+        len -= chunk_size;
+        addr += chunk_size;
+    }
+
+    tt_tlb_free(dev, tlb);
+
+    return 0;
+}
+
+int tt_noc_write(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, const void* src, size_t len)
+{
+    const uint8_t* src_ptr = (const uint8_t*)src;
+    tt_tlb_t* tlb;
+    int32_t ret;
+
+    if (addr % 4 != 0 || len % 4 != 0) {
+        return -EINVAL;
+    }
+
+    ret = tt_tlb_alloc(dev, TT_TLB_SIZE_2M, TT_MMIO_CACHE_MODE_WC, &tlb);
+    if (ret != 0) {
+        return ret;
+    }
+
+    while (len > 0) {
+        uint64_t aligned_addr = addr & ~(tlb->size - 1);
+        uint64_t offset = addr & (tlb->size - 1);
+        size_t chunk_size = MIN(len, tlb->size - offset);
+        uint8_t* dst_ptr = (uint8_t*)tlb->mmio + offset;
+
+        ret = tt_tlb_map_unicast(dev, tlb, x, y, aligned_addr);
+
+        if (ret != 0) {
+            tt_tlb_free(dev, tlb);
+            return ret;
+        }
+
+        memcpy(dst_ptr, src_ptr, chunk_size);
+
+        src_ptr += chunk_size;
+        len -= chunk_size;
+        addr += chunk_size;
+    }
+
+    tt_tlb_free(dev, tlb);
+
+    return 0;
+}
+
+int tt_dma_map(tt_device_t* dev, void* addr, size_t len, int flags, tt_dma_t** out_dma)
+{
+    int page_size = getpagesize();
+    if (len == 0 || len % page_size != 0 || addr == NULL || (uint64_t)addr % page_size != 0) {
+        return -EINVAL;
+    }
+
+    struct tt_dma_t* dma = malloc(sizeof(struct tt_dma_t));
+
+    if (!dma) {
+        return -ENOMEM;
+    }
+
+    memset(dma, 0, sizeof(struct tt_dma_t));
+
+    struct {
+        struct tenstorrent_pin_pages_in in;
+        struct tenstorrent_pin_pages_out_extended out;
+    } pin_pages;
+
+    memset(&pin_pages, 0, sizeof(pin_pages));
+
+    pin_pages.in.output_size_bytes = sizeof(pin_pages.out);
+    pin_pages.in.virtual_address = (uint64_t)addr;
+    pin_pages.in.size = len;
+
+    if (flags & TT_DMA_FLAG_NOC) {
+        pin_pages.in.flags = TENSTORRENT_PIN_PAGES_NOC_DMA;
+    } else if (flags & TT_DMA_FLAG_NOC_TOP_DOWN) {
+        pin_pages.in.flags = TENSTORRENT_PIN_PAGES_NOC_TOP_DOWN;
+    } else {
+        pin_pages.in.flags = 0;
+    }
+
+    if (ioctl(dev->fd, TENSTORRENT_IOCTL_PIN_PAGES, &pin_pages) != 0) {
+        int e = errno;
+        free(dma);
+        return -e;
+    }
+
+    dma->addr = addr;
+    dma->len = len;
+    dma->iova = pin_pages.out.physical_address;
+
+    if (flags & (TT_DMA_FLAG_NOC | TT_DMA_FLAG_NOC_TOP_DOWN)) {
+        dma->noc = pin_pages.out.noc_address;
+    } else {
+        dma->noc = ~0ULL;
+    }
+
+    *out_dma = dma;
+
+    return 0;
+}
+
+int tt_dma_unmap(tt_device_t* dev, tt_dma_t* dma)
+{
+    struct tenstorrent_unpin_pages unpin = {0};
+    unpin.in.virtual_address = (uint64_t)dma->addr;
+    unpin.in.size = dma->len;
+
+    if (ioctl(dev->fd, TENSTORRENT_IOCTL_UNPIN_PAGES, &unpin) != 0) {
+        return -errno;
+    }
+
+    free(dma);
+
+    return 0;
+}
+
+int tt_dma_get_dma_addr(tt_dma_t* dma, uint64_t* out_dma_addr)
+{
+    *out_dma_addr = dma->iova;
+    return 0;
+}
+
+int tt_dma_get_noc_addr(tt_dma_t* dma, uint64_t* out_noc_addr)
+{
+    if (dma->noc == ~0ULL) {
+        return -EINVAL;
+    }
+
+    *out_noc_addr = dma->noc;
+    return 0;
+}
+
+int tt_tlb_alloc(tt_device_t* dev, size_t size, enum tt_tlb_cache_mode cache, tt_tlb_t** out_tlb)
+{
+    struct tt_tlb_t* tlb = malloc(sizeof(struct tt_tlb_t));
+
+    if (!tlb) {
+        return -ENOMEM;
+    }
+
+    memset(tlb, 0, sizeof(struct tt_tlb_t));
+
+    struct tenstorrent_allocate_tlb alloc_tlb = {0};
+    alloc_tlb.in.size = size;
+
+    if (ioctl(dev->fd, TENSTORRENT_IOCTL_ALLOCATE_TLB, &alloc_tlb) != 0) {
+        int e = errno;
+        free(tlb);
+        return -e;
+    }
+
+    off_t offset = cache == TT_MMIO_CACHE_MODE_UC ? alloc_tlb.out.mmap_offset_uc : alloc_tlb.out.mmap_offset_wc;
+    tlb->id = alloc_tlb.out.id;
+    tlb->size = size;
+    tlb->mmio = mmap(NULL, tlb->size, PROT_READ | PROT_WRITE, MAP_SHARED, dev->fd, offset);
+
+    if (tlb->mmio == MAP_FAILED) {
+        struct tenstorrent_free_tlb free_tlb = {0};
+        int e = errno;
+        free_tlb.in.id = tlb->id;
+        if (ioctl(dev->fd, TENSTORRENT_IOCTL_FREE_TLB, &free_tlb) != 0) {
+            fprintf(stderr, "Leaked TLB %u: after mmap failure: %s\n", tlb->id, strerror(errno));
+        }
+
+        free(tlb);
+        errno = e;
+        return -e;
+    }
+
+    *out_tlb = tlb;
+
+    return 0;
+}
+
+int tt_tlb_free(tt_device_t* dev, tt_tlb_t* tlb)
+{
+    int ret = 0;
+
+    /* Unmap the userspace view of the TLB. This is required by the driver. */
+    munmap(tlb->mmio, tlb->size);
+
+    /* Tell the driver to release the backing hardware resource. */
+    struct tenstorrent_free_tlb free_tlb = {0};
+    free_tlb.in.id = tlb->id;
+    if (ioctl(dev->fd, TENSTORRENT_IOCTL_FREE_TLB, &free_tlb) != 0) {
+        ret = -errno;
+    }
+
+    free(tlb);
+
+    return ret;
+}
+
+int tt_tlb_get_mmio(tt_tlb_t* tlb, void** out_mmio)
+{
+    *out_mmio = tlb->mmio;
+    return 0;
+}
+
+int tt_tlb_map(tt_device_t* dev, tt_tlb_t* tlb, tt_noc_addr_config_t* config)
+{
+    struct tenstorrent_configure_tlb configure_tlb = {0};
+
+    if (config->addr & (tlb->size - 1)) {
+        return -EINVAL;
+    }
+
+    configure_tlb.in.id = tlb->id;
+    configure_tlb.in.config.addr = config->addr;
+    configure_tlb.in.config.x_end = config->x_end;
+    configure_tlb.in.config.y_end = config->y_end;
+    configure_tlb.in.config.x_start = config->x_start;
+    configure_tlb.in.config.y_start = config->y_start;
+    configure_tlb.in.config.noc = config->noc;
+    configure_tlb.in.config.mcast = config->mcast;
+    configure_tlb.in.config.ordering = config->ordering;
+    configure_tlb.in.config.static_vc = config->static_vc;
+
+    if (ioctl(dev->fd, TENSTORRENT_IOCTL_CONFIGURE_TLB, &configure_tlb) != 0) {
+        return -errno;
+    }
+
+    return 0;
+}
+
+int tt_tlb_map_unicast(tt_device_t* dev, tt_tlb_t* tlb, uint8_t x, uint8_t y, uint64_t addr)
+{
+    struct tenstorrent_configure_tlb configure_tlb = {0};
+
+    if (addr & (tlb->size - 1)) {
+        return -EINVAL;
+    }
+
+    configure_tlb.in.id = tlb->id;
+    configure_tlb.in.config.addr = addr;
+    configure_tlb.in.config.x_end = x;
+    configure_tlb.in.config.y_end = y;
+
+    if (ioctl(dev->fd, TENSTORRENT_IOCTL_CONFIGURE_TLB, &configure_tlb) != 0) {
+        return -errno;
+    }
+
+    return 0;
+}

--- a/lib/ttkmd.h
+++ b/lib/ttkmd.h
@@ -1,0 +1,402 @@
+/**
+ * SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+ * SPDX-License-Identifier: GPL-2.0-only
+ *
+ * @file ttkmd.h
+ * @brief Userspace library for the Tenstorrent Kernel Mode Driver (tt-kmd).
+ *
+ * This library provides a stable interface for interacting with Tenstorrent
+ * Wormhole (WH) and Blackhole (BH) devices. It serves as a low-level API for
+ * userspace clients.
+ */
+
+#ifndef TTKMD_H_
+#define TTKMD_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Opaque handle to a Tenstorrent PCIe device.
+ */
+typedef struct tt_device_t tt_device_t;
+
+/**
+ * @brief Opaque handle to a TLB window.
+ *
+ * A TLB window is a fixed size aperture in the host address space that is
+ * mappable to a device NOC (Network on Chip) location.
+ */
+typedef struct tt_tlb_t tt_tlb_t;
+
+/**
+ * @brief Opaque handle to a DMA mapping.
+ *
+ * A DMA mapping is host memory made device-accessible by the driver.
+ */
+typedef struct tt_dma_t tt_dma_t;
+
+/**
+ * @brief Configuration for a TLB window's mapping to the device NOC.
+ *
+ * These parameters control how memory operations on a TLB window are translated
+ * into transactions on the device's NOC. See `tt_tlb_map()` for details.
+ */
+typedef struct tt_noc_addr_config_t {
+    uint64_t addr;      /**< Local address aligned to the TLB window size */
+    uint16_t x_end;     /**< X coord for unicast; rectangle end for multicast */
+    uint16_t y_end;     /**< Y coord for unicast; rectangle end for multicast */
+    uint16_t x_start;   /**< 0 for unicast; rectangle start for multicast */
+    uint16_t y_start;   /**< 0 for unicast; rectangle start for multicast */
+    uint8_t noc;        /**< 0 or 1 */
+    uint8_t mcast;      /**< 1 to enable multicast */
+    uint8_t ordering;   /**< Ordering semantics; see `enum tt_noc_ordering` */
+    uint8_t static_vc;  /**< 1 to enable static virtual channel */
+} tt_noc_addr_config_t;
+
+/**
+ * @brief Supported Tenstorrent device architectures.
+ */
+enum tt_device_arch {
+    TT_DEVICE_ARCH_UNKNOWN = 0,
+    TT_DEVICE_ARCH_WORMHOLE,
+    TT_DEVICE_ARCH_BLACKHOLE
+};
+
+/**
+ * @brief Queryable attributes of a Tenstorrent device.
+ */
+enum tt_device_attr {
+    TT_DEVICE_ATTR_PCI_DOMAIN = 0,
+    TT_DEVICE_ATTR_PCI_BUS = 1,
+    TT_DEVICE_ATTR_PCI_DEVICE = 2,
+    TT_DEVICE_ATTR_PCI_FUNCTION = 3,
+    TT_DEVICE_ATTR_PCI_VENDOR_ID = 4,
+    TT_DEVICE_ATTR_PCI_DEVICE_ID = 5,
+    TT_DEVICE_ATTR_PCI_SUBSYSTEM_ID = 6,
+    TT_DEVICE_ATTR_CHIP_ARCH = 7,
+    TT_DEVICE_ATTR_NUM_1M_TLBS = 8,
+    TT_DEVICE_ATTR_NUM_2M_TLBS = 9,
+    TT_DEVICE_ATTR_NUM_16M_TLBS = 10,
+    TT_DEVICE_ATTR_NUM_4G_TLBS = 11,
+};
+
+/**
+ * @brief Queryable attributes of the Tenstorrent driver.
+ */
+enum tt_driver_attr {
+    TT_DRIVER_API_VERSION = 0,
+    TT_DRIVER_SEMVER_MAJOR = 1,
+    TT_DRIVER_SEMVER_MINOR = 2,
+    TT_DRIVER_SEMVER_PATCH = 3,
+};
+
+/**
+ * @brief Caching modes for TLB windows mapped to the NOC.
+ */
+enum tt_tlb_cache_mode {
+    TT_MMIO_CACHE_MODE_UC = 0, /**< Uncached; use for register accesses */
+    TT_MMIO_CACHE_MODE_WC = 1, /**< Write Combined; use for memory accesses */
+};
+
+/**
+ * @brief Ordering modes for NOC transactions.
+ */
+enum tt_noc_ordering {
+    TT_NOC_ORDERING_RELAXED         = 0,    /**< Relaxed (no read-after-write hazard) */
+    TT_NOC_ORDERING_STRICT          = 1,    /**< Full AXI ordering */
+    TT_NOC_ORDERING_POSTED          = 2,    /**< May have read-after-write hazard */
+    TT_NOC_ORDERING_POSTED_STRICT   = 3     /**< BH only, Unicast only */
+};
+
+/**
+ * @brief Supported TLB window sizes.
+ */
+#define TT_TLB_SIZE_1M  (1ULL << 20)  /**< 1 MiB TLB window (WH only) */
+#define TT_TLB_SIZE_2M  (1ULL << 21)  /**< 2 MiB TLB window (WH and BH) */
+#define TT_TLB_SIZE_16M (1ULL << 24)  /**< 16 MiB TLB window (WH only) */
+#define TT_TLB_SIZE_4G  (1ULL << 32)  /**< 4 GiB TLB window (BH only) */
+
+/**
+ * @brief Open a Tenstorrent device.
+ *
+ * @param chardev_path e.g. "/dev/tenstorrent/0"
+ * @param out_dev Device handle
+ */
+int tt_device_open(const char* chardev_path, tt_device_t** out_dev);
+
+/**
+ * @brief Close a Tenstorrent device.
+ *
+ * @param dev Device handle
+ */
+int tt_device_close(tt_device_t* dev);
+
+/**
+ * @brief Query device attributes.
+ *
+ * @param dev Device handle
+ * @param attr Attribute to query
+ * @param out_value Attribute value
+ * @return 0 on success, error code on failure
+ */
+int tt_device_get_attr(tt_device_t* dev, enum tt_device_attr attr, uint64_t* out_value);
+
+/**
+ * @brief Query driver attributes.
+ *
+ * @param dev Device handle; may be NULL for API version query
+ * @param attr Attribute to query
+ * @param out_value Attribute value
+ * @return 0 on success, error code on failure
+ */
+int tt_driver_get_attr(tt_device_t* dev, enum tt_driver_attr attr, uint64_t* out_value);
+
+/**
+ * @brief Convenience function to read a 32-bit value from a device NOC address.
+ *
+ * Appropriate for reading device registers or memory.
+ * Inefficient due to resource lifecycle management overhead.
+ *
+ * @param dev Device handle
+ * @param x NOC0 x-coordinate
+ * @param y NOC0 y-coordinate
+ * @param addr NOC address
+ * @param value Pointer to store the read value
+ * @return int 0 on success, error code on failure
+ */
+int tt_noc_read32(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, uint32_t* value);
+
+/**
+ * @brief Convenience function to write a 32-bit value to a device NOC address.
+ *
+ * Appropriate for writing device registers or memory.
+ * Inefficient due to resource lifecycle management overhead.
+ *
+ * @param dev Device handle
+ * @param x NOC0 x-coordinate
+ * @param y NOC0 y-coordinate
+ * @param addr NOC address
+ * @param value Value to write
+ * @return int 0 on success, error code on failure
+ */
+int tt_noc_write32(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, uint32_t value);
+
+/**
+ * @brief Convenience function for reading from the device NOC.
+ *
+ * Appropriate for reading device memory (L1/DRAM).
+ * Inefficient due to resource lifecycle management overhead.
+ *
+ * @param dev Device handle
+ * @param x NOC0 x-coordinate
+ * @param y NOC0 y-coordinate
+ * @param addr NOC address
+ * @param dst Pointer to store the read data
+ * @param len Number of bytes to read
+ * @return int 0 on success, error code on failure
+ */
+int tt_noc_read(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, void* dst, size_t len);
+
+/**
+ * @brief Convenience function for writing to the device NOC.
+ *
+ * Appropriate for writing device memory (L1/DRAM).
+ * Inefficient due to resource lifecycle management overhead.
+ *
+ * @param dev Device handle
+ * @param x NOC0 x-coordinate
+ * @param y NOC0 y-coordinate
+ * @param addr NOC address
+ * @param src Pointer to the data to write
+ * @param len Number of bytes to write
+ * @return int 0 on success, error code on failure
+ */
+int tt_noc_write(tt_device_t* dev, uint8_t x, uint8_t y, uint64_t addr, const void* src, size_t len);
+
+/**
+ * @brief Flags to control how a host memory buffer is mapped for device access.
+ *
+ * These flags are used with `tt_dma_map()` to control how a NOC address is
+ * generated for the host memory buffer.
+ *
+ * `TT_DMA_FLAG_NOC` and `TT_DMA_FLAG_NOC_TOP_DOWN` are mutually exclusive.
+ */
+enum tt_dma_map_flags {
+    /**
+     * @brief Do not request a mapping in the device's NOC-to-host aperture.
+     */
+    TT_DMA_FLAG_NONE = 0,
+
+    /**
+     * @brief Requests a mapping in the device's NOC-to-host aperture, allocated
+     * from the bottom up.
+     *
+     * This flag instructs the driver to reserve a region within the PCIe tile's
+     * NOC-to-host address space, mapping it to the pinned host memory. The
+     * driver allocates the lowest available address range within the aperture.
+     *
+     * This technique is intended for applications that have expectations about
+     * the NOC address (i.e. hard-coded in device-side software). Because the
+     * aperture is a shared resource among all clients, the application MUST
+     * validate the address returned by `tt_dma_get_noc_addr()` to ensure it
+     * matches its expectation.
+     */
+    TT_DMA_FLAG_NOC = 1 << 0,
+
+    /**
+     * @brief Requests a mapping in the device's NOC-to-host aperture, allocated
+     * from the top down.
+     *
+     * This flag acts similarly to `TT_DMA_FLAG_NOC`, but allocates from the
+     * highest available address range within the aperture.
+     *
+     * It is intended for tools and runtime components, allowing them to avoid
+     * collisions with bottom-up application mappings. This separation is useful
+     * on Wormhole devices due to their more constrained aperture. While this
+     * flag is supported on Blackhole for consistency, its use is less critical
+     * given Blackhole's larger address space.
+     */
+    TT_DMA_FLAG_NOC_TOP_DOWN = 1 << 1,
+};
+
+/**
+ * @brief Pins a host memory buffer and maps it for device access.
+ *
+ * This function makes a region of host memory accessible to a Tenstorrent
+ * device. It can be used to prepare a buffer for access by the hardware DMA
+ * engine or by device-side software via NOC transactions. If the system IOMMU
+ * is not active, the buffer must be physically contiguous.
+ *
+ * `TT_DMA_FLAG_NOC` or `TT_DMA_FLAG_NOC_TOP_DOWN` flags impose constraints:
+ * WH:
+ * - Per-buffer size: 0x1000 <= len <= 0xFFFE_0000
+ * - Cumulative mapping size limit: 0xFFFE_0000
+ * - Maximum mappings: 16 simultaneous
+ * BH:
+ * - Per-buffer size: 0x1000 <= len <= 0xFFFF_F000
+ * - Maximum mappings: 16 simultaneous
+ *
+ * @param dev Device handle
+ * @param addr Virtual address of memory to map; must be page-aligned
+ * @param len Number of bytes; must be a multiple of the page size
+ * @param flags Bitmask of flags from `enum tt_dma_map_flags`
+ * @param out_dma On success, a handle for the pinned mapping
+ * @return 0 on success, error code on failure
+ */
+int tt_dma_map(tt_device_t* dev, void* addr, size_t len, int flags, tt_dma_t** out_dma);
+
+/**
+ * @brief Unpins a previously mapped memory region.
+ *
+ * Releases all resources associated with the mapping.
+ *
+ * @param dev Device handle
+ * @param dma DMA handle from `tt_dma_map()`
+ * @return 0 on success, error code on failure
+ */
+int tt_dma_unmap(tt_device_t* dev, tt_dma_t* dma);
+
+/**
+ * @brief Gets the DMA address for a mapped memory region.
+ *
+ * The address will be an I/O Virtual Address (IOVA) if an IOMMU is active on
+ * the system, or a physical address (PA) otherwise. The address is always
+ * available and is suitable for programming the hardware PCIe DMA engine.
+ *
+ * @param dma DMA handle from `tt_dma_map()`
+ * @param out_dma_addr DMA address (IOVA or PA) for PCIe DMA operations
+ * @return 0 on success, error code on failure
+ */
+int tt_dma_get_dma_addr(tt_dma_t* dma, uint64_t* out_dma_addr);
+
+/**
+ * @brief Gets the NOC-accessible address for a mapped memory region.
+ *
+ * Returns the address that device-side software must use to access the pinned
+ * host buffer via the NOC.
+ *
+ * @param dma DMA handle from `tt_dma_map()`
+ * @param out_noc_addr NOC address for device-side software access
+ * @return 0 on success, error code on failure
+ */
+int tt_dma_get_noc_addr(tt_dma_t* dma, uint64_t* out_noc_addr);
+
+/**
+ * @brief Allocates a TLB window.
+ *
+ * Quantities and sizes of TLB windows vary by device architecture:
+ *
+ * Wormhole:
+ *   156x  1 MiB windows
+ *    10x  2 MiB windows
+ *    20x 16 MiB windows
+ * Blackhole:
+ *   202x  2 MiB windows
+ *     8x  4 GiB windows
+ *
+ * The driver may reserve one or more TLB windows for internal use.
+ *
+ * @param dev Device handle
+ * @param size 1, 2, or 16 MiB (WH); 2 MiB or 4 GiB (BH)
+ * @param cache Caching attribute; see `enum tt_tlb_cache_mode`
+ * @param out_tlb On success, a handle to the allocated TLB window
+ * @return 0 on success, error code on failure
+ */
+int tt_tlb_alloc(tt_device_t* dev, size_t size, enum tt_tlb_cache_mode cache, tt_tlb_t** out_tlb);
+
+/**
+ * @brief Releases a TLB window.
+ *
+ * @param dev Device handle
+ * @param tlb TLB window to release
+ * @return 0 on success, error code on failure
+ */
+int tt_tlb_free(tt_device_t* dev, tt_tlb_t* tlb);
+
+/**
+ * @brief Get a pointer to the MMIO region of a TLB window.
+ *
+ * Loads/stores using this pointer will access the device NOC according to the
+ * TLB window's configuration. Dereferencing the pointer after calling
+ * `tt_tlb_free()` on the TLB handle will invoke undefined behavior.
+ *
+ * @param tlb TLB window handle from `tt_tlb_alloc()`
+ * @param out_mmio Pointer to the MMIO region of the TLB window
+ * @return 0 on success, error code on failure
+ */
+int tt_tlb_get_mmio(tt_tlb_t* tlb, void** out_mmio);
+
+/**
+ * @brief Maps a TLB window to a NOC endpoint.
+ *
+ * @param dev Device handle
+ * @param tlb TLB window handle from `tt_tlb_alloc()`
+ * @param config NOC address configuration
+ * @return 0 on success, error code on failure
+ */
+int tt_tlb_map(tt_device_t* dev, tt_tlb_t* tlb, tt_noc_addr_config_t* config);
+
+/**
+ * @brief Maps a TLB window to a NOC endpoint.
+ *
+ * This is a convenience function for a common operation. See `tt_tlb_map()`.
+ *
+ * @param dev Device handle
+ * @param tlb TLB window handle from `tt_tlb_alloc()`
+ * @param x NOC0 x-coordinate
+ * @param y NOC0 y-coordinate
+ * @param addr Address in the tile; must be a multiple of the TLB size
+ * @return 0 on success, error code on failure
+ */
+int tt_tlb_map_unicast(tt_device_t* dev, tt_tlb_t* tlb, uint8_t x, uint8_t y, uint64_t addr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TTKMD_H_

--- a/module.c
+++ b/module.c
@@ -10,6 +10,7 @@
 #include "enumerate.h"
 
 #include "module.h"
+#include "version.h"
 
 #define TENSTORRENT_DRIVER_VERSION_STRING \
 	__stringify(TENSTORRENT_DRIVER_VERSION_MAJOR) "." \

--- a/module.h
+++ b/module.h
@@ -7,11 +7,6 @@
 #include <linux/types.h>
 #include <linux/pci.h>
 
-#define TENSTORRENT_DRIVER_VERSION_MAJOR 2
-#define TENSTORRENT_DRIVER_VERSION_MINOR 3
-#define TENSTORRENT_DRIVER_VERSION_PATCH 0
-#define TENSTORRENT_DRIVER_VERSION_SUFFIX ""    // e.g. "-rc1"
-
 // Module options that need to be passed to other files
 extern uint dma_address_bits;
 extern uint reset_limit;

--- a/version.h
+++ b/version.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef TTDRIVER_VERSION_H_INCLUDED
+#define TTDRIVER_VERSION_H_INCLUDED
+
+#define TENSTORRENT_DRIVER_VERSION_MAJOR 2
+#define TENSTORRENT_DRIVER_VERSION_MINOR 3
+#define TENSTORRENT_DRIVER_VERSION_PATCH 0
+#define TENSTORRENT_DRIVER_VERSION_SUFFIX ""    // e.g. "-rc1"
+
+#endif


### PR DESCRIPTION
This commit introduces a C userspace library, `libttkmd`, which provides a stable, low-level API for interacting with the Tenstorrent kernel-mode driver. This library abstracts the underlying ioctl interface, offering a cleaner mechanism for userspace applications to manage Tenstorrent devices.

The library includes functionality for:
- Opening and closing device handles
- Querying device and driver attributes
- Allocating, mapping, freeing TLB windows for access to the device NOC
- Pinning and unpinning host memory (DMA buffers) for device access, with support for NOC-addressable mappings
- Convenience functions for 32-bit and block I/O operations on the NOC

To demonstrate usage and provide a basic functional test, an example program is included. It enumerates all available devices and runs a series of tests against each one:
- Queries and prints device/driver attributes
- Verifies NOC node IDs for all cores
- Performs block read/write tests to device memory
- Tests writing to host DMA buffers from the device via the NOC

Finally, a Makefile is added to build the shared library and the example program. It also includes standard `install`, `uninstall`, and `clean` targets to support integration into a system.