### PR TITLE
fix(tlb): Require exact size on TLB allocation

### DIFF
--- a/memory.c
+++ b/memory.c
@@ -909,7 +909,6 @@ long ioctl_allocate_tlb(struct chardev_private *priv,
 	struct tenstorrent_allocate_tlb_in in = {0};
 	struct tenstorrent_allocate_tlb_out out = {0};
 	struct tlb_descriptor tlb_desc = { 0 };
-	size_t size;
 	int id;
 	u64 encoded_id;
 
@@ -919,8 +918,7 @@ long ioctl_allocate_tlb(struct chardev_private *priv,
 	if (copy_from_user(&in, &arg->in, sizeof(in)))
 		return -EFAULT;
 
-	size = in.size;
-	id = tenstorrent_device_allocate_tlb(tt_dev, &size);
+	id = tenstorrent_device_allocate_tlb(tt_dev, in.size);
 
 	if (id < 0)
 		return id;

--- a/tlb.c
+++ b/tlb.c
@@ -7,7 +7,7 @@
 #include "device.h"
 
 int tenstorrent_device_allocate_tlb(struct tenstorrent_device *tt_dev,
-				    size_t *size)
+				    size_t size)
 {
 	const struct tenstorrent_device_class *dev_class = tt_dev->dev_class;
 	unsigned long id = 0;
@@ -22,8 +22,7 @@ int tenstorrent_device_allocate_tlb(struct tenstorrent_device *tt_dev,
 		long tlb_count = dev_class->tlb_counts[kind];
 		long tlb_size = dev_class->tlb_sizes[kind];
 
-		if (*size <= tlb_size) {
-			*size = tlb_size;
+		if (size == tlb_size) {
 			n = tlb_count;
 			break;
 		}

--- a/tlb.h
+++ b/tlb.h
@@ -16,7 +16,7 @@ struct tlb_descriptor {
 };
 
 int tenstorrent_device_allocate_tlb(struct tenstorrent_device *tt_dev,
-				    size_t *size);
+				    size_t size);
 int tenstorrent_device_free_tlb(struct tenstorrent_device *tt_dev,
 				unsigned int id);
 int tenstorrent_device_configure_tlb(struct tenstorrent_device *tt_dev, int tlb,


### PR DESCRIPTION
The previous TLB allocation logic would accept any size and silently round it up to the next largest available TLB window size. This could mask bugs in userspace code, which should always request a specific, valid TLB window size.

This commit enforces a stricter policy by changing the lookup condition from a less-than-or-equal check to an exact-match check. The driver will now only allocate a TLB window if the requested size precisely matches a valid hardware window size.