### PR TITLE
Wormhole new telemetry

### DIFF
--- a/blackhole.c
+++ b/blackhole.c
@@ -244,13 +244,6 @@ static void noc_write32(struct blackhole_device *bh, u32 x, u32 y, u64 addr, u32
 	mutex_unlock(&bh->kernel_tlb_mutex);
 }
 
-#define ARC_CSM_BASE 0x10000000
-#define ARC_CSM_SIZE (1 << 19)
-static bool is_range_within_csm(u64 addr, size_t len)
-{
-	return (addr >= ARC_CSM_BASE) && (addr <= (ARC_CSM_BASE + ARC_CSM_SIZE) - len);
-}
-
 static int csm_read32(struct blackhole_device *bh, u64 addr, u32 *value)
 {
 	if (!is_range_within_csm(addr, sizeof(u32)))

--- a/device.h
+++ b/device.h
@@ -38,7 +38,8 @@ struct tenstorrent_device {
 
 	struct tt_hwmon_context hwmon_context;
 
-	const struct tt_attribute_data *attributes;
+	const struct tt_attribute_data *attributes;	// TODO: remove this.
+	const struct tenstorrent_sysfs_attr *sysfs_attrs;
 
 	struct list_head open_fds_list;	// List of struct chardev_private, linked through open_fds field
 

--- a/device.h
+++ b/device.h
@@ -38,7 +38,6 @@ struct tenstorrent_device {
 
 	struct tt_hwmon_context hwmon_context;
 
-	const struct tt_attribute_data *attributes;	// TODO: remove this.
 	const struct tenstorrent_sysfs_attr *sysfs_attrs;
 
 	struct list_head open_fds_list;	// List of struct chardev_private, linked through open_fds field

--- a/enumerate.c
+++ b/enumerate.c
@@ -17,6 +17,7 @@
 #include "module.h"
 #include "memory.h"
 #include "chardev_private.h"
+#include "telemetry.h"
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0)
 #define pci_enable_pcie_error_reporting(dev) do { } while (0)
@@ -137,6 +138,12 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 			device_create_file(&tt_dev->dev, &data->attr);
 	}
 
+	if (tt_dev->sysfs_attrs) {
+		const struct tenstorrent_sysfs_attr *data = tt_dev->sysfs_attrs;
+		for (; data->attr.attr.name; data++)
+			device_create_file(&tt_dev->dev, &data->attr);
+	}
+
 	if (device_class->create_sysfs_groups)
 		device_class->create_sysfs_groups(tt_dev);
 
@@ -154,6 +161,12 @@ static void tenstorrent_pci_remove(struct pci_dev *dev)
 
 	if (tt_dev->attributes) {
 		const struct tt_attribute_data *data = tt_dev->attributes;
+		for (; data->attr.attr.name; data++)
+			device_remove_file(&tt_dev->dev, &data->attr);
+	}
+
+	if (tt_dev->sysfs_attrs) {
+		const struct tenstorrent_sysfs_attr *data = tt_dev->sysfs_attrs;
 		for (; data->attr.attr.name; data++)
 			device_remove_file(&tt_dev->dev, &data->attr);
 	}

--- a/enumerate.c
+++ b/enumerate.c
@@ -132,12 +132,6 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 		register_reboot_notifier(&tt_dev->reboot_notifier);
 	}
 
-	if (tt_dev->attributes) {
-		const struct tt_attribute_data *data = tt_dev->attributes;
-		for (; data->attr.attr.name; data++)
-			device_create_file(&tt_dev->dev, &data->attr);
-	}
-
 	if (tt_dev->sysfs_attrs) {
 		const struct tenstorrent_sysfs_attr *data = tt_dev->sysfs_attrs;
 		for (; data->attr.attr.name; data++)
@@ -157,12 +151,6 @@ static void tenstorrent_pci_remove(struct pci_dev *dev)
 
 	list_for_each_entry_safe(priv, tmp, &tt_dev->open_fds_list, open_fd) {
 		tenstorrent_memory_cleanup(priv);
-	}
-
-	if (tt_dev->attributes) {
-		const struct tt_attribute_data *data = tt_dev->attributes;
-		for (; data->attr.attr.name; data++)
-			device_remove_file(&tt_dev->dev, &data->attr);
 	}
 
 	if (tt_dev->sysfs_attrs) {

--- a/hwmon.c
+++ b/hwmon.c
@@ -6,7 +6,6 @@
 #include <linux/stat.h>
 #include <asm/io.h>
 
-#include "device.h"
 #include "hwmon.h"
 
 static umode_t tt_hwmon_is_visible(const void *drvdata, enum hwmon_sensor_types type, u32 attr, int channel) {
@@ -70,68 +69,3 @@ const struct hwmon_ops tt_hwmon_ops = {
 	.read = tt_hwmon_read,
 	.read_string = tt_hwmon_read_string,
 };
-
-ssize_t tt_show_attribute(struct device *dev, struct device_attribute *attr, char *buf)
-{
-	struct tenstorrent_device *tt_dev = dev_get_drvdata(dev);
-	struct tt_attribute_data *data = container_of(attr, struct tt_attribute_data, attr);
-	struct tt_hwmon_context *ctx = &tt_dev->hwmon_context;
-	u32 value = ioread32(ctx->telemetry_base + data->reg_offset);
-	value &= data->mask;
-	return sprintf(buf, "%u\n", value);
-}
-
-ssize_t tt_show_card_type(struct device *dev, struct device_attribute *attr, char *buf) {
-	struct tenstorrent_device *tt_dev = dev_get_drvdata(dev);
-	struct tt_attribute_data *data = container_of(attr, struct tt_attribute_data, attr);
-	struct tt_hwmon_context *ctx = &tt_dev->hwmon_context;
-
-	u32 board_id_hi = ioread32(ctx->telemetry_base + data->reg_offset);
-	u16 card_type = (board_id_hi >> 4) & 0xFFFF;
-	char *card_name;
-	switch (card_type) {
-	case 0x3: card_name = "e150"; break;
-	case 0x7: card_name = "e75"; break;
-	case 0x14: card_name = "n300"; break;
-	case 0x18: card_name = "n150"; break;
-	case 0x35: card_name = "galaxy-wormhole"; break;
-	default: card_name = "unknown"; break;
-	}
-
-	return scnprintf(buf, PAGE_SIZE, "%s\n", card_name);
-}
-
-ssize_t tt_show_card_serial(struct device *dev, struct device_attribute *attr, char *buf) {
-	struct tenstorrent_device *tt_dev = dev_get_drvdata(dev);
-	struct tt_attribute_data *data = container_of(attr, struct tt_attribute_data, attr);
-	struct tt_hwmon_context *ctx = &tt_dev->hwmon_context;
-
-	u32 board_id_hi = ioread32(ctx->telemetry_base + data->reg_offset);
-	u32 board_id_lo = ioread32(ctx->telemetry_base + data->reg_offset + 4);
-	return scnprintf(buf, PAGE_SIZE, "%08X%08X\n", board_id_hi, board_id_lo);
-}
-
-ssize_t tt_show_fw_ver(struct device *dev, struct device_attribute *attr, char *buf) {
-	struct tenstorrent_device *tt_dev = dev_get_drvdata(dev);
-	struct tt_attribute_data *data = container_of(attr, struct tt_attribute_data, attr);
-	struct tt_hwmon_context *ctx = &tt_dev->hwmon_context;
-
-	u32 fw_ver = ioread32(ctx->telemetry_base + data->reg_offset);
-	u32 major = (fw_ver >> 24) & 0xFF;
-	u32 minor = (fw_ver >> 16) & 0xFF;
-	u32 patch = (fw_ver >>  8) & 0xFF;
-	u32 ver = fw_ver & 0xFF;
-	return scnprintf(buf, PAGE_SIZE, "%u.%u.%u.%u\n", major, minor, patch, ver);
-}
-
-ssize_t tt_show_eth_fw_ver(struct device *dev, struct device_attribute *attr, char *buf) {
-	struct tenstorrent_device *tt_dev = dev_get_drvdata(dev);
-	struct tt_attribute_data *data = container_of(attr, struct tt_attribute_data, attr);
-	struct tt_hwmon_context *ctx = &tt_dev->hwmon_context;
-
-	u32 fw_ver = ioread32(ctx->telemetry_base + data->reg_offset);
-	u32 major = (fw_ver >> 16) & 0xFF;
-	u32 minor = (fw_ver >> 12) & 0xF;
-	u32 patch = (fw_ver >>  0) & 0xFFF;
-	return scnprintf(buf, PAGE_SIZE, "%u.%u.%u\n", major, minor, patch);
-}

--- a/hwmon.h
+++ b/hwmon.h
@@ -34,17 +34,4 @@ struct tt_hwmon_context {
 
 extern const struct hwmon_ops tt_hwmon_ops;
 
-struct tt_attribute_data {
-	struct device_attribute attr;
-	u32 reg_offset;
-	u32 mask;
-};
-
-ssize_t tt_show_attribute(struct device *dev, struct device_attribute *attr, char *buf);
-ssize_t tt_show_card_type(struct device *dev, struct device_attribute *attr, char *buf);
-ssize_t tt_show_card_serial(struct device *dev, struct device_attribute *attr, char *buf);
-ssize_t tt_show_fw_ver(struct device *dev, struct device_attribute *attr, char *buf);
-ssize_t tt_show_eth_fw_ver(struct device *dev, struct device_attribute *attr, char *buf);
-
-
 #endif

--- a/telemetry.h
+++ b/telemetry.h
@@ -31,5 +31,12 @@ struct tenstorrent_sysfs_attr {
     struct device_attribute attr;
 };
 
+#define ARC_CSM_BASE 0x10000000
+#define ARC_CSM_SIZE (1 << 19)
+static inline bool is_range_within_csm(u64 addr, size_t len)
+{
+	return (addr >= ARC_CSM_BASE) && (addr <= (ARC_CSM_BASE + ARC_CSM_SIZE) - len);
+}
+
 #endif // TTDRIVER_TELEMETRY_H_INCLUDED
 

--- a/telemetry.h
+++ b/telemetry.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef TTDRIVER_TELEMETRY_H_INCLUDED
+#define TTDRIVER_TELEMETRY_H_INCLUDED
+
+#include <linux/types.h>
+#include <linux/device.h>
+
+enum tt_telemetry_tags {
+    TELEMETRY_BOARD_ID = 1,
+    TELEMETRY_VCORE = 6,
+    TELEMETRY_POWER = 7,
+    TELEMETRY_CURRENT = 8,
+    TELEMETRY_ASIC_TEMP = 11,
+    TELEMETRY_AICLK = 14,
+    TELEMETRY_AXICLK = 15,
+    TELEMETRY_ARCCLK = 16,
+    TELEMETRY_ETH_FW_VERSION = 24,
+    TELEMETRY_BM_APP_FW_VERSION = 26,
+    TELEMETRY_BM_BL_FW_VERSION = 27,
+    TELEMETRY_FLASH_BUNDLE_VERSION = 28,
+    TELEMETRY_CM_FW_VERSION = 29,
+    TELEMETRY_FAN_RPM = 41,
+    TELEMETRY_TT_FLASH_VERSION = 58,
+    TELEMETRY_ASIC_ID = 61
+};
+
+struct tenstorrent_sysfs_attr {
+    u32 tag_id;
+    struct device_attribute attr;
+};
+
+#endif // TTDRIVER_TELEMETRY_H_INCLUDED
+

--- a/wormhole.h
+++ b/wormhole.h
@@ -15,6 +15,8 @@ struct wormhole_device {
 	u8 __iomem *bar4_mapping;
 
 	u8 saved_mps;
+
+	u64 *sysfs_attr_offsets;
 };
 
 #define tt_dev_to_wh_dev(ttdev) \


### PR DESCRIPTION
This pull request refactors the driver's sysfs telemetry attributes, replacing a hardcoded offset implementation with an architecture that reads data from a firmware-provided table. The change aligns the sysfs implementation for both Wormhole and Blackhole devices, which now use a common set of definitions from the new telemetry.h header. The existing hwmon attributes and implementation remain unaffected by this change, as the new firmware telemetry system does not yet report the maximum values required by the hwmon interface.