### PR TITLE
ci: Fix permission issues for community-issue-tagging

### DIFF
--- a/.github/workflows/community-issue-tagging.yml
+++ b/.github/workflows/community-issue-tagging.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   call-central-workflow:
     uses: tenstorrent/tt-github-actions/.github/workflows/on-community-issue.yml@main


### PR DESCRIPTION
As seen in https://github.com/tenstorrent/tt-llk/pull/266