### PR TITLE
Asahi

### DIFF
--- a/.github/workflows/asahi-release.yml
+++ b/.github/workflows/asahi-release.yml
@@ -25,8 +25,9 @@ jobs:
           spectool -C ~/rpmbuild/SOURCES/ -g ~/rpmbuild/SPECS/*.spec
           rpmbuild -ba ~/rpmbuild/SPECS/*.spec
           RPM_PATH=$(find ~/rpmbuild/RPMS -name "*.rpm" | head -n 1)
+          export RPM_PATH
           sudo mkdir -p /github/workspace/artifacts
-          sudo cp "$RPM_PATH" /github/workspace/artifacts/
+          sudo -E cp "$RPM_PATH" /github/workspace/artifacts/
 
       - name: Upload RPM artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/asahi-release.yml
+++ b/.github/workflows/asahi-release.yml
@@ -42,9 +42,9 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          path: ./artifacts
+          path: /github/workspace/artifacts
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          files: ./artifacts/**/*.rpm
+          files: /github/workspace/artifacts/**/*.rpm

--- a/.github/workflows/asahi-release.yml
+++ b/.github/workflows/asahi-release.yml
@@ -25,8 +25,8 @@ jobs:
           spectool -C ~/rpmbuild/SOURCES/ -g ~/rpmbuild/SPECS/*.spec
           rpmbuild -ba ~/rpmbuild/SPECS/*.spec
           RPM_PATH=$(find ~/rpmbuild/RPMS -name "*.rpm" | head -n 1)
-          mkdir -p /github/workspace/artifacts
-          cp "$RPM_PATH" /github/workspace/artifacts/
+          sudo mkdir -p /github/workspace/artifacts
+          sudo cp "$RPM_PATH" /github/workspace/artifacts/
 
       - name: Upload RPM artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/asahi-release.yml
+++ b/.github/workflows/asahi-release.yml
@@ -18,8 +18,8 @@ jobs:
 
       - name:
         run: |
-          dnf -y update
-          dnf -y install rpmdevtools kernel-16k-devel kernel-headers dkms
+          sudo dnf -y update
+          sudo dnf -y install rpmdevtools kernel-16k-devel kernel-headers dkms
           rpmdev-setuptree
           cp SPECS/asahi-tt-kmd.spec ~/rpmbuild/SPECS/tt-kmd.spec
           spectool -C ~/rpmbuild/SOURCES/ -g ~/rpmbuild/SPECS/*.spec

--- a/.github/workflows/asahi-release.yml
+++ b/.github/workflows/asahi-release.yml
@@ -1,0 +1,49 @@
+name: tt-kmd dkms rpm release for Asahi
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-image:
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name:
+        run: |
+          dnf -y update
+          dnf -y install rpmdevtools kernel-16k-devel kernel-headers dkms
+          rpmdev-setuptree
+          cp SPECS/asahi-tt-kmd.spec ~/rpmbuild/SPECS/tt-kmd.spec
+          spectool -C ~/rpmbuild/SOURCES/ -g ~/rpmbuild/SPECS/*.spec
+          rpmbuild -ba ~/rpmbuild/SPECS/*.spec
+          RPM_PATH=$(find ~/rpmbuild/RPMS -name "*.rpm" | head -n 1)
+          mkdir -p /github/workspace/artifacts
+          cp "$RPM_PATH" /github/workspace/artifacts/
+
+      - name: Upload RPM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tt-kmd
+          path: artifacts/*.rpm
+
+  release:
+    needs: build-rpm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./artifacts/**/*.rpm

--- a/.github/workflows/asahi-release.yml
+++ b/.github/workflows/asahi-release.yml
@@ -27,7 +27,7 @@ jobs:
           RPM_PATH=$(find ~/rpmbuild/RPMS -name "*.rpm" | head -n 1)
           export RPM_PATH
           sudo mkdir -p /github/workspace/artifacts
-          sudo -E cp "$RPM_PATH" /github/workspace/artifacts/
+          sudo -E bash -c "cp -v $RPM_PATH /github/workspace/artifacts/"
 
       - name: Upload RPM artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/asahi-release.yml
+++ b/.github/workflows/asahi-release.yml
@@ -25,15 +25,14 @@ jobs:
           spectool -C ~/rpmbuild/SOURCES/ -g ~/rpmbuild/SPECS/*.spec
           rpmbuild -ba ~/rpmbuild/SPECS/*.spec
           RPM_PATH=$(find ~/rpmbuild/RPMS -name "*.rpm" | head -n 1)
-          export RPM_PATH
-          sudo mkdir -p /github/workspace/artifacts
-          sudo -E bash -c "cp -v $RPM_PATH /github/workspace/artifacts/"
+          mkdir -p ${{ github.workspace }}/artifacts
+          cp -v $RPM_PATH ${{ github.workspace }}/artifacts/
 
       - name: Upload RPM artifact
         uses: actions/upload-artifact@v4
         with:
           name: tt-kmd
-          path: /github/workspace/artifacts/*.rpm
+          path: ${{ github.workspace }}/artifacts/*.rpm
 
   release:
     needs: build-rpm
@@ -42,9 +41,9 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          path: /github/workspace/artifacts
+          path: ${{ github.workspace }}/artifacts
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          files: /github/workspace/artifacts/**/*.rpm
+          files: ${{ github.workspace }}/artifacts/**/*.rpm

--- a/.github/workflows/asahi-release.yml
+++ b/.github/workflows/asahi-release.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: tt-kmd
-          path: artifacts/*.rpm
+          path: /github/workspace/artifacts/*.rpm
 
   release:
     needs: build-rpm

--- a/.github/workflows/asahi-release.yml
+++ b/.github/workflows/asahi-release.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 jobs:
-  build-image:
+  build-rpm:
     runs-on: self-hosted
 
     steps:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The driver registers device files named `/dev/tenstorrent/%d`, one for each enum
 
 * You must have dkms installed.
     * `apt install dkms` (Debian, Ubuntu)
-    * `dnf install dkms` (Fedora)
+    * `dnf install dkms` (Fedora, Asahi)
     * `apk install akms` (Alpine)
     * `dnf install epel-release && dnf install dkms` (Enterprise Linux based)
 ```
@@ -28,6 +28,12 @@ doas akms install .
 doas modeprobe tenstorrent
 ```
 (or reboot, driver will auto-load next boot)
+
+* For Asahi Linux
+```
+sudo dnf install tt-kmd-2.1.0-1.fc42.noarch.rpm
+sudo dkms install tenstorrent/2.1.0
+```
 
 #### With NixOS
 

--- a/SPECS/asahi-tt-kmd.spec
+++ b/SPECS/asahi-tt-kmd.spec
@@ -1,0 +1,34 @@
+Name: tt-kmd
+Version: 2.1.0
+Release: %autorelease
+Summary: Tenstorrent AI Kernel-Mode Driver
+
+License: GPL-2.0
+URL: https://github.com/tenstorrent/tt-kmd
+Source0: %{URL}/archive/refs/tags/ttkmd-%{version}.tar.gz
+
+BuildArch: noarch
+BuildRequires: kernel-16k-devel dkms
+Requires: kernel-16k-devel dkms
+
+%description
+This package provides the %{name} kernel module via DKMS.
+
+%prep
+%setup -q -n %{name}-ttkmd-%{version}
+
+%build
+# No build needed; DKMS handles compilation
+
+%install
+mkdir -p %{buildroot}/usr/src/%{name}-%{version}
+cp -a * %{buildroot}/usr/src/%{name}-%{version}
+
+
+%files
+%defattr(-,root,root,-)
+/usr/src/%{name}-%{version}
+
+%changelog
+%autochangelog
+


### PR DESCRIPTION
This pull request adds support for Asahi.

It creates a SPEC file that build an rpm under github actions. The github action must use a local runner, as github doesn't have native arm64 runners and also doesn't have containers or vms with Asahi.