### PR TITLE
fix(blackhole): Correctly disable outbound ATU

### DIFF
--- a/blackhole.c
+++ b/blackhole.c
@@ -924,7 +924,7 @@ static int blackhole_configure_outbound_atu(struct tenstorrent_device *tt_dev, u
 	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
 	u64 size = limit - base + 1;
 	u32 region_ctrl_1 = 0;
-	u32 region_ctrl_2 = REGION_EN;
+	u32 region_ctrl_2 = (limit == 0) ? 0 : REGION_EN;
 	u32 region_ctrl_3 = 0;
 	u32 lower_base = lower_32_bits(base);
 	u32 upper_base = upper_32_bits(base);


### PR DESCRIPTION
The `blackhole_configure_outbound_atu` function defectively set the `REGION_EN` bit unconditionally.

To disable a region, a caller passes `limit=0`. However, the hardware has a minimum region size of 4KB. Writing a value of 0 to the limit register results in the hardware interpreting it as 0xFFF (4095), which incorrectly configures and enables a 4KB region instead of disabling it.

This change fixes the issue by checking if `limit` is 0. If it is, the `REGION_EN` bit is explicitly cleared, ensuring the ATU region is properly disabled as intended and avoiding the creation of an erroneous mapping.