### PR TITLE
Make device removal robust during hot-plug

### DIFF
--- a/chardev.c
+++ b/chardev.c
@@ -332,6 +332,9 @@ static long tt_cdev_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
 	long ret = -EINVAL;
 	struct chardev_private *priv = f->private_data;
 
+	if (priv->device->detached)
+		return -ENODEV;
+
 	switch (cmd) {
 		case TENSTORRENT_IOCTL_GET_DEVICE_INFO:
 			ret = ioctl_get_device_info(priv, (struct tenstorrent_get_device_info __user *)arg);
@@ -462,7 +465,7 @@ static int tt_cdev_release(struct inode *inode, struct file *file)
 	struct tenstorrent_device *tt_dev = priv->device;
 	unsigned int bitpos;
 
-	if (priv->noc_cleanup.enabled) {
+	if (!tt_dev->detached && priv->noc_cleanup.enabled) {
 		tt_dev->dev_class->noc_write32(
 			tt_dev,
 			priv->noc_cleanup.x,

--- a/device.h
+++ b/device.h
@@ -24,6 +24,7 @@ struct tenstorrent_device {
 	struct cdev chardev;
 	struct pci_dev *pdev;
 	const struct tenstorrent_device_class *dev_class;
+	bool detached; // No longer valid for hardware access
 
 	unsigned int ordinal;
 	bool dma_capable;
@@ -64,8 +65,8 @@ struct tenstorrent_device_class {
 	bool (*init_device)(struct tenstorrent_device *ttdev);
 	bool (*init_hardware)(struct tenstorrent_device *ttdev);
 	bool (*post_hardware_init)(struct tenstorrent_device *ttdev);
-	void (*cleanup_hardware)(struct tenstorrent_device *ttdev);
-	void (*cleanup_device)(struct tenstorrent_device *ttdev);
+	void (*cleanup_hardware)(struct tenstorrent_device *ttdev); // Touches hardware.
+	void (*cleanup_device)(struct tenstorrent_device *ttdev); // Does not touch hardware.
 	void (*first_open_cb)(struct tenstorrent_device *ttdev);
 	void (*last_release_cb)(struct tenstorrent_device *ttdev);
 	void (*reboot)(struct tenstorrent_device *ttdev);

--- a/memory.c
+++ b/memory.c
@@ -329,7 +329,9 @@ static void teardown_outbound_iatu(struct chardev_private *priv, int iatu_region
 	mutex_lock(&tt_dev->iatu_mutex);
 
 	region = &priv->device->outbound_iatus[iatu_region];
-	tt_dev->dev_class->configure_outbound_atu(tt_dev, iatu_region, 0, 0, 0);
+
+	if (!tt_dev->detached)
+		tt_dev->dev_class->configure_outbound_atu(tt_dev, iatu_region, 0, 0, 0);
 
 	region->priv = NULL;
 	region->base = 0;


### PR DESCRIPTION
When a device is removed, its `pci_remove` function is invoked. However, userspace applications may still hold open file descriptors or active memory mappings to the device. These handles maintain a reference to the `tenstorrent_device` struct.

When these userspace handles are eventually closed, their corresponding cleanup routines in the driver (`tt_cdev_release`, memory cleanup, etc.) are executed. This creates a race condition: the cleanup code may attempt to access the hardware after the hardware is already gone, leading to system instability.

This patch introduces a `detached` flag to the `tenstorrent_device` struct to solve this problem.

The flag is set to `true` as the first action in `tenstorrent_pci_remove`. All subsequent hardware-touching code paths now check this flag and will safely skip hardware access if the device is detached. This includes:
- `tt_cdev_ioctl`: Immediately returns `-ENODEV`.
- `tt_cdev_release`: Skips the final NOC cleanup write.
- `teardown_outbound_iatu`: Skips disabling the hardware iATU region.
- `tt_dev_release`: Skips calling `cleanup_hardware` and disabling the PCI device, while still allowing software resource cleanup.

This ensures that once removal begins, no further hardware access is attempted from any lingering driver references.