### PR TITLE
Refactor telemetry to improve robustness

### DIFF
--- a/blackhole.c
+++ b/blackhole.c
@@ -400,6 +400,7 @@ static ssize_t sysfs_show_u32_dec(struct device *dev, struct device_attribute *a
 static ssize_t sysfs_show_u64_hex(struct device *dev, struct device_attribute *attr, char *buf);
 static ssize_t sysfs_show_u32_ver(struct device *dev, struct device_attribute *attr, char *buf);
 static ssize_t sysfs_show_card_type(struct device *dev, struct device_attribute *attr, char *buf);
+static umode_t sysfs_telemetry_is_visible(struct kobject *kobj, struct attribute *attr, int n);
 
 static struct tenstorrent_sysfs_attr bh_sysfs_attributes[] = {
 	{ TELEMETRY_AICLK, __ATTR(tt_aiclk,  S_IRUGO, sysfs_show_u32_dec, NULL) },
@@ -498,6 +499,19 @@ static ssize_t sysfs_show_card_type(struct device *dev, struct device_attribute 
 	return scnprintf(buf, PAGE_SIZE, "%s\n", card_name);
 }
 
+static umode_t sysfs_telemetry_is_visible(struct kobject *kobj, struct attribute *attr, int n)
+{
+	struct device *dev = kobj_to_dev(kobj);
+	struct tenstorrent_device *tt_dev = dev_get_drvdata(dev);
+	struct device_attribute *dev_attr = container_of(attr, struct device_attribute, attr);
+	struct tenstorrent_sysfs_attr *ts_attr = container_of(dev_attr, struct tenstorrent_sysfs_attr, attr);
+	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
+	unsigned i = ts_attr - bh_sysfs_attributes;
+	bool visible = bh->sysfs_attr_addrs[i] != 0;
+
+	return visible ? attr->mode : 0;
+}
+
 static umode_t bh_hwmon_is_visible(const void *drvdata, enum hwmon_sensor_types type, u32 attr, int channel) {
 	struct blackhole_device *bh = (struct blackhole_device *)drvdata;
 	int i;
@@ -585,8 +599,8 @@ static const struct hwmon_chip_info bh_hwmon_chip_info = {
 	.info = bh_hwmon_channel_info,
 };
 
-static int telemetry_probe(struct tenstorrent_device *tt_dev) {
-	struct device *hwmon_device;
+static int telemetry_probe(struct tenstorrent_device *tt_dev)
+{
 	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
 	u32 base_addr = noc_read32(bh, ARC_X, ARC_Y, ARC_TELEMETRY_PTR, 0);
 	u32 data_addr = noc_read32(bh, ARC_X, ARC_Y, ARC_TELEMETRY_DATA, 0);
@@ -612,17 +626,6 @@ static int telemetry_probe(struct tenstorrent_device *tt_dev) {
 
 	num_entries = noc_read32(bh, ARC_X, ARC_Y, base_addr + 4, 0);
 
-	bh->hwmon_attr_addrs = kzalloc(sizeof(u64) * ARRAY_SIZE(bh_hwmon_attrs), GFP_KERNEL);
-	if (!bh->hwmon_attr_addrs)
-		return -ENOMEM;
-
-	bh->sysfs_attr_addrs = kzalloc(sizeof(u64) * ARRAY_SIZE(bh_sysfs_attributes), GFP_KERNEL);
-	if (!bh->sysfs_attr_addrs) {
-		kfree(bh->hwmon_attr_addrs);
-		bh->hwmon_attr_addrs = NULL;
-		return -ENOMEM;
-	}
-
 	for (i = 0; i < num_entries; ++i) {
 		u32 tag_entry = noc_read32(bh, ARC_X, ARC_Y, tags_addr + (i * 4), 0);
 		u16 tag_id = tag_entry & 0xFFFF;
@@ -643,18 +646,6 @@ static int telemetry_probe(struct tenstorrent_device *tt_dev) {
 				bh->sysfs_attr_addrs[j] = addr;
 		}
 	}
-
-	hwmon_device = devm_hwmon_device_register_with_info(&bh->tt.pdev->dev, "blackhole", bh, &bh_hwmon_chip_info, NULL);
-
-	if (IS_ERR(hwmon_device)) {
-		kfree(bh->hwmon_attr_addrs);
-		kfree(bh->sysfs_attr_addrs);
-		bh->hwmon_attr_addrs = NULL;
-		bh->sysfs_attr_addrs = NULL;
-		return PTR_ERR(hwmon_device);
-	}
-
-	tt_dev->sysfs_attrs = bh_sysfs_attributes;
 
 	return 0;
 }
@@ -840,8 +831,17 @@ static bool blackhole_reset(struct tenstorrent_device *tt_dev, u32 reset_flag)
 	return false;
 }
 
-static bool blackhole_init(struct tenstorrent_device *tt_dev) {
+static bool blackhole_init(struct tenstorrent_device *tt_dev)
+{
 	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
+	struct device *dev = &tt_dev->pdev->dev;
+
+	bh->hwmon_attr_addrs = devm_kzalloc(dev, sizeof(u64) * ARRAY_SIZE(bh_hwmon_attrs), GFP_KERNEL);
+	bh->sysfs_attr_addrs = devm_kzalloc(dev, sizeof(u64) * ARRAY_SIZE(bh_sysfs_attributes), GFP_KERNEL);
+	bh->telemetry_attrs = devm_kzalloc(dev, sizeof(struct attribute *) * ARRAY_SIZE(bh_sysfs_attributes), GFP_KERNEL);
+
+	if (!bh->hwmon_attr_addrs || !bh->sysfs_attr_addrs || !bh->telemetry_attrs)
+		return false;
 
 	bh->tlb_regs = pci_iomap_range(bh->tt.pdev, 0, TLB_REGS_START, TLB_REGS_LEN);
 	bh->kernel_tlb = pci_iomap_range(bh->tt.pdev, 0, KERNEL_TLB_START, KERNEL_TLB_LEN);
@@ -894,7 +894,30 @@ static bool blackhole_init_hardware(struct tenstorrent_device *tt_dev)
 
 static bool blackhole_init_telemetry(struct tenstorrent_device *tt_dev)
 {
-	telemetry_probe(tt_dev);
+	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
+	struct device *hwmon_device;
+	int r;
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(bh_sysfs_attributes) - 1; ++i)
+		bh->telemetry_attrs[i] = &bh_sysfs_attributes[i].attr.attr;
+	bh->telemetry_group.attrs = bh->telemetry_attrs;
+	bh->telemetry_group.is_visible = sysfs_telemetry_is_visible;
+
+	r = devm_device_add_group(&tt_dev->dev, &bh_pcie_perf_counters_group);
+	if (r)
+		dev_err(&tt_dev->dev, "PCIe perf counters unavailable: %d\n", r);
+
+	r = telemetry_probe(tt_dev);
+	if (!r) {
+		struct device *dev = &tt_dev->pdev->dev;
+		r = devm_device_add_group(&tt_dev->dev, &bh->telemetry_group);
+		hwmon_device = devm_hwmon_device_register_with_info(dev, "blackhole", bh, &bh_hwmon_chip_info, NULL);
+
+		if (r || IS_ERR(hwmon_device))
+			return false;
+	}
+
 	return true;
 }
 
@@ -923,9 +946,6 @@ static void blackhole_cleanup(struct tenstorrent_device *tt_dev)
 		pci_iounmap(tt_dev->pdev, bh->noc2axi_cfg);
 	if (bh->bar2_mapping)
 		pci_iounmap(tt_dev->pdev, bh->bar2_mapping);
-
-	kfree(bh->hwmon_attr_addrs);
-	kfree(bh->sysfs_attr_addrs);
 }
 
 static int blackhole_configure_tlb(struct tenstorrent_device *tt_dev, int tlb,
@@ -995,22 +1015,6 @@ static int blackhole_configure_outbound_atu(struct tenstorrent_device *tt_dev, u
 	return 0;
 }
 
-static void blackhole_create_sysfs_groups(struct tenstorrent_device *tt_dev)
-{
-	int ret = devm_device_add_group(&tt_dev->dev, &bh_pcie_perf_counters_group);
-	if (ret)
-		dev_err(&tt_dev->dev, "PCIe perf counters unavailable: %d\n", ret);
-}
-
-static bool blackhole_is_sysfs_attr_supported(struct tenstorrent_device *tt_dev,
-				 const struct tenstorrent_sysfs_attr *attr)
-{
-	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
-	unsigned i = attr - bh_sysfs_attributes;
-
-	return bh->sysfs_attr_addrs[i] != 0;
-}
-
 static void blackhole_noc_write32(struct tenstorrent_device *tt_dev, u32 x, u32 y, u64 addr, u32 data, int noc)
 {
 	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
@@ -1037,7 +1041,5 @@ struct tenstorrent_device_class blackhole_class = {
 	.save_reset_state = blackhole_save_reset_state,
 	.restore_reset_state = blackhole_restore_reset_state,
 	.configure_outbound_atu = blackhole_configure_outbound_atu,
-	.create_sysfs_groups = blackhole_create_sysfs_groups,
-	.is_sysfs_attr_supported = blackhole_is_sysfs_attr_supported,
 	.noc_write32 = blackhole_noc_write32,
 };

--- a/blackhole.c
+++ b/blackhole.c
@@ -892,7 +892,7 @@ static bool blackhole_init_hardware(struct tenstorrent_device *tt_dev)
 	return true;
 }
 
-static bool blackhole_post_hardware_init(struct tenstorrent_device *tt_dev)
+static bool blackhole_init_telemetry(struct tenstorrent_device *tt_dev)
 {
 	telemetry_probe(tt_dev);
 	return true;
@@ -1029,7 +1029,7 @@ struct tenstorrent_device_class blackhole_class = {
 	.reset = blackhole_reset,
 	.init_device = blackhole_init,
 	.init_hardware = blackhole_init_hardware,
-	.post_hardware_init = blackhole_post_hardware_init,
+	.init_telemetry = blackhole_init_telemetry,
 	.cleanup_hardware = blackhole_cleanup_hardware,
 	.cleanup_device = blackhole_cleanup,
 	.configure_tlb = blackhole_configure_tlb,

--- a/blackhole.h
+++ b/blackhole.h
@@ -18,6 +18,8 @@ struct blackhole_device {
 
 	u64 *hwmon_attr_addrs;
 	u64 *sysfs_attr_addrs;
+	struct attribute **telemetry_attrs;
+	struct attribute_group telemetry_group;
 
 	u8 saved_mps;
 };

--- a/device.h
+++ b/device.h
@@ -40,8 +40,6 @@ struct tenstorrent_device {
 
 	struct tt_hwmon_context hwmon_context;
 
-	const struct tenstorrent_sysfs_attr *sysfs_attrs;
-
 	struct list_head open_fds_list;	// List of struct chardev_private, linked through open_fds field
 
 	DECLARE_BITMAP(tlbs, TENSTORRENT_MAX_INBOUND_TLBS);
@@ -77,8 +75,6 @@ struct tenstorrent_device_class {
 	void (*save_reset_state)(struct tenstorrent_device *ttdev);
 	void (*restore_reset_state)(struct tenstorrent_device *ttdev);
 	int (*configure_outbound_atu)(struct tenstorrent_device *ttdev, u32 region, u64 base, u64 limit, u64 target);
-	void (*create_sysfs_groups)(struct tenstorrent_device *ttdev);
-	bool (*is_sysfs_attr_supported)(struct tenstorrent_device *ttdev, const struct tenstorrent_sysfs_attr *attr);
 	void (*noc_write32)(struct tenstorrent_device *ttdev, u32 x, u32 y, u64 addr, u32 data, int noc);
 };
 

--- a/device.h
+++ b/device.h
@@ -66,7 +66,7 @@ struct tenstorrent_device_class {
 	bool (*reset)(struct tenstorrent_device *ttdev, u32 reset_flag);
 	bool (*init_device)(struct tenstorrent_device *ttdev);
 	bool (*init_hardware)(struct tenstorrent_device *ttdev);
-	bool (*post_hardware_init)(struct tenstorrent_device *ttdev);
+	bool (*init_telemetry)(struct tenstorrent_device *ttdev);
 	void (*cleanup_hardware)(struct tenstorrent_device *ttdev);
 	void (*cleanup_device)(struct tenstorrent_device *ttdev);
 	void (*first_open_cb)(struct tenstorrent_device *ttdev);

--- a/enumerate.c
+++ b/enumerate.c
@@ -59,8 +59,8 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 
 	device_class = (const struct tenstorrent_device_class *)id->driver_data;
 
-	printk(KERN_INFO "Found a Tenstorrent %s device at bus %04x:%d.\n",
-	       device_class->name, (unsigned)pci_domain_nr(dev->bus), (int)dev->bus->number);
+	printk(KERN_INFO "Found a Tenstorrent %s device at bus %04x:%02x.\n",
+	       device_class->name, (unsigned)pci_domain_nr(dev->bus), (unsigned)dev->bus->number);
 
 	// During pre-test, unflashed boards have no class code which trips up __dev_sort_resources.
 	// Assign the proper class code and rerun resource assignment to clear things up.

--- a/enumerate.c
+++ b/enumerate.c
@@ -121,7 +121,7 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 
 	if (device_class->init_device(tt_dev))
 		if (device_class->init_hardware(tt_dev))
-			device_class->post_hardware_init(tt_dev);
+			device_class->init_telemetry(tt_dev);
 	tt_dev->needs_hw_init = false;
 
 	pci_save_state(dev);

--- a/enumerate.c
+++ b/enumerate.c
@@ -18,6 +18,7 @@
 #include "memory.h"
 #include "chardev_private.h"
 #include "telemetry.h"
+#include "wormhole.h"
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0)
 #define pci_enable_pcie_error_reporting(dev) do { } while (0)
@@ -143,6 +144,11 @@ static void tenstorrent_pci_remove(struct pci_dev *dev)
 	struct tenstorrent_device *tt_dev = pci_get_drvdata(dev);
 	struct chardev_private *priv, *tmp;
 	u16 vendor_id;
+
+	if (tt_dev->dev_class == &wormhole_class) {
+		struct wormhole_device *wh = tt_dev_to_wh_dev(tt_dev);
+		cancel_delayed_work_sync(&wh->fw_ready_work);
+	}
 
 	// In a hotplug scenario, the device may not be accessible anymore. Check
 	// if it is still accessible by reading the vendor ID. If it is not, set the

--- a/wormhole.c
+++ b/wormhole.c
@@ -477,7 +477,7 @@ static bool wormhole_init_hardware(struct tenstorrent_device *tt_dev) {
 	return true;
 }
 
-static bool wormhole_post_hardware_init(struct tenstorrent_device *tt_dev) {
+static bool wormhole_init_telemetry(struct tenstorrent_device *tt_dev) {
 	struct wormhole_device *wh_dev = tt_dev_to_wh_dev(tt_dev);
 
 	telemetry_probe(tt_dev);
@@ -754,7 +754,7 @@ struct tenstorrent_device_class wormhole_class = {
 	.reset = wormhole_reset,
 	.init_device = wormhole_init,
 	.init_hardware = wormhole_init_hardware,
-	.post_hardware_init = wormhole_post_hardware_init,
+	.init_telemetry = wormhole_init_telemetry,
 	.cleanup_hardware = wormhole_cleanup_hardware,
 	.cleanup_device = wormhole_cleanup,
 	.reboot = wormhole_cleanup_hardware,

--- a/wormhole.h
+++ b/wormhole.h
@@ -19,6 +19,9 @@ struct wormhole_device {
 	u64 *sysfs_attr_offsets;
 	struct attribute **telemetry_attrs;
 	struct attribute_group telemetry_group;
+
+	struct delayed_work fw_ready_work;
+	int telemetry_retries;
 };
 
 #define tt_dev_to_wh_dev(ttdev) \

--- a/wormhole.h
+++ b/wormhole.h
@@ -17,6 +17,8 @@ struct wormhole_device {
 	u8 saved_mps;
 
 	u64 *sysfs_attr_offsets;
+	struct attribute **telemetry_attrs;
+	struct attribute_group telemetry_group;
 };
 
 #define tt_dev_to_wh_dev(ttdev) \


### PR DESCRIPTION
This PR introduces a series of patches to refactor and improve the robustness of the telemetry and sysfs initialization logic.

Major Changes:
* sysfs: The driver now uses `attribute_group` with an `is_visible` hook instead of creating sysfs files individually. This is more idiomatic and gets sysfs attribute creation/removal out of the probe/remove code paths in enumerate.c. All related memory allocations have been converted to their `devm_*` variants to simplify resource management and cleanup paths.
* deferred telemetry: For Wormhole, a `delayed_work` queue has been added to poll for firmware readiness. This prevents failures during device probe when firmware initialization is slow, making the driver more resilient on certain platforms.
