### PR TITLE
Remove secondary bus reset from reset code paths

### DIFF
--- a/blackhole.c
+++ b/blackhole.c
@@ -805,8 +805,6 @@ static bool blackhole_reset(struct tenstorrent_device *tt_dev, u32 reset_flag)
 	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
 	struct pci_dev *pdev = tt_dev->pdev;
 
-	pcie_hot_reset_and_restore_state(pdev);
-
 	if (reset_flag == TENSTORRENT_RESET_DEVICE_ASIC_DMC_RESET) {
 		struct arc_msg msg = { 0 };
 		u16 reset_arg = 3; // Argument for ASIC + M3 reset

--- a/wormhole.c
+++ b/wormhole.c
@@ -323,13 +323,10 @@ static bool wormhole_reset(struct tenstorrent_device *tt_dev, u32 reset_flag)
 	u16 reset_arg = (reset_flag == TENSTORRENT_RESET_DEVICE_ASIC_DMC_RESET) ? 3 : 0;
 	bool responsive;
 
-	// 1. Attempt a secondary bus reset.
-	pcie_hot_reset_and_restore_state(pdev);
-
-	// 2. See if the device is responsive.
+	// See if the device is responsive.
 	responsive = grayskull_send_arc_fw_message(reset_unit_regs(wh_dev), WH_FW_MSG_NOP, 1000, NULL);
 
-	// 3. If not responsive, wait for the watchdog.
+	// If not responsive, wait for the watchdog.
 	if (!responsive) {
 		ktime_t end_time;
 
@@ -352,7 +349,7 @@ static bool wormhole_reset(struct tenstorrent_device *tt_dev, u32 reset_flag)
 		}
 	}
 
-	// 4. If the device is responsive, finalize the reset.
+	// If the device is responsive, finalize the reset.
 	if (responsive) {
 		set_reset_marker(pdev);
 		grayskull_send_arc_fw_message_with_args(reset_unit_regs(wh_dev), WH_FW_MSG_TRIGGER_RESET, reset_arg, 0,


### PR DESCRIPTION
Goal is to reduce the amount of time between device resets.  SBR adds overhead and can be performed for each device prior to triggering the resets.  Suggested change for tools (warning: untested):

```
        for pci_interface in pci_interfaces:
            chip = PciChip(pci_interface=pci_interface)
            bdf = chip.get_pci_bdf()
            bdf_list.append(bdf)
            
            if reset_m3:
                reset_flag = IoctlResetFlags.ASIC_DMC_RESET
            else:
                reset_flag = IoctlResetFlags.ASIC_RESET

            self.reset_device_ioctl(pci_interface, reset_flag)
```

to

```
        for pci_interface in pci_interfaces:
            chip = PciChip(pci_interface=pci_interface)
            bdf = chip.get_pci_bdf()
            bdf_list.append(bdf)

        for pci_interface in pci_interfaces:
             self.reset_device_ioctl(pci_interface, IoctlResetFlags.RESET_PCIE_LINK)

        for pci_interface in pci_interfaces:
            if reset_m3:
                reset_flag = IoctlResetFlags.ASIC_DMC_RESET
            else:
                reset_flag = IoctlResetFlags.ASIC_RESET

            self.reset_device_ioctl(pci_interface, reset_flag)
```