### PR TITLE
Fix incorrect return code for DMA alloc ioctl

### DIFF
--- a/memory.c
+++ b/memory.c
@@ -525,6 +525,7 @@ long ioctl_allocate_dma_buf(struct chardev_private *priv,
 			goto out;
 		}
 		iatu_region = ret;
+		ret = 0;
 	}
 
 	dmabuf->index = in.buf_index;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -13,6 +13,7 @@ void TestGetDeviceInfo(const EnumeratedDevice &dev);
 void TestConfigSpace(const EnumeratedDevice &dev, bool check_aer);
 void TestQueryMappings(const EnumeratedDevice &dev);
 void TestDmaBuf(const EnumeratedDevice &dev);
+void TestNocDmaBuf(const EnumeratedDevice &dev);
 void TestPinPages(const EnumeratedDevice &dev);
 void TestLock(const EnumeratedDevice &dev);
 void TestHwmon(const EnumeratedDevice &dev);
@@ -41,6 +42,7 @@ int main(int argc, char *argv[])
         TestConfigSpace(d, check_aer);
         TestQueryMappings(d);
         TestDmaBuf(d);
+        TestNocDmaBuf(d);
         TestPinPages(d);
         TestLock(d);
         TestHwmon(d);


### PR DESCRIPTION
The ioctl_allocate_dma_buf() function was returning a positive integer on success instead of 0 when the TENSTORRENT_ALLOCATE_DMA_BUF_NOC_DMA flag was specified.

The internal helper setup_noc_dma() returns a non-negative iATU region index on success, which was being propagated as the ioctl's final return value. User-space applications interpret any non-zero return from an ioctl as an error, causing them to incorrectly believe the operation failed.

Reset the return code to 0 after successfully configuring the iATU region to ensure the ioctl correctly signals success.