### PR TITLE
makefile: force installation to support downgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ show-version:
 
 dkms:
 	sudo dkms add .
-	sudo dkms install tenstorrent/$(VERSION)
+	sudo dkms install --force tenstorrent/$(VERSION)
 	sudo modprobe tenstorrent
-	
+
 dkms-remove:
 	sudo modprobe -r tenstorrent
 	sudo dkms remove tenstorrent/$(VERSION) --all


### PR DESCRIPTION
Previously, when switching from evaluating v2.4.1 to v2.2.0, I received an error message that resulted in v2.2.0 not being installed via dkms.

```
Error! Module version 2.2.0 for tenstorrent.ko.zst
is not newer than ... already found in kernel 6.8.0-40-generic (2.4.1).
You may override by specifying --force.
```

Add the suggested `--force` argument to the Makefile to allow `make dkms` to work forward and backward by default.

(also removed an extraneous `\t`)