### PR TITLE
Fix use-after-free during device removal

### DIFF
--- a/memory.c
+++ b/memory.c
@@ -1279,7 +1279,6 @@ void tenstorrent_memory_cleanup(struct chardev_private *priv)
 	struct dmabuf *dmabuf;
 	unsigned int i;
 	struct peer_resource_mapping *peer_mapping, *tmp_peer_mapping;
-	struct bar_mapping *bar_mapping, *tmp_bar_mapping;
 
 	mutex_lock(&priv->mutex);
 
@@ -1299,11 +1298,6 @@ void tenstorrent_memory_cleanup(struct chardev_private *priv)
 
 		list_del(&peer_mapping->list);
 		kfree(peer_mapping);
-	}
-
-	list_for_each_entry_safe(bar_mapping, tmp_bar_mapping, &priv->bar_mappings, list) {
-		list_del(&bar_mapping->list);
-		kfree(bar_mapping);
 	}
 
 	mutex_unlock(&priv->mutex);


### PR DESCRIPTION
When a PCI device is removed while BAR mappings are active, tenstorrent_memory_cleanup would free all bar_mapping structures. However, these are still referenced by VMAs via vma->vm_private_data, causing a use-after-free crash when bar_vma_close later accesses them.

bar_mapping structures are owned by their VMAs, not by chardev_private. VMAs hold references to vma->vm_file, keeping chardev_private alive until all VMAs close. Remove bar_mappings cleanup from tenstorrent_memory_cleanup and let bar_vma_close free them properly.

bar_mapping contains no device resources requiring forced cleanup - it's purely a tracking structure.