### PR TITLE
Refcount bar_mapping structs

### DIFF
--- a/chardev_private.h
+++ b/chardev_private.h
@@ -8,6 +8,7 @@
 #include <linux/mutex.h>
 #include <linux/hashtable.h>
 #include <linux/sched.h>
+#include <linux/refcount.h>
 
 #include "ioctl.h"
 
@@ -22,6 +23,7 @@ struct bar_mapping {
 	u64 size;
 	unsigned int bar_index;
 	enum bar_mapping_type type;
+	refcount_t refs;
 };
 
 #define DMABUF_HASHTABLE_BITS 4

--- a/enumerate.c
+++ b/enumerate.c
@@ -118,10 +118,10 @@ static int mappings_seq_show(struct seq_file *s, void *v)
 
 		// BAR mappings.
 		list_for_each_entry(bar_mapping, &priv->bar_mappings, list) {
-			seq_printf(s, "%-8d %-16s %-14s BAR%u %-2s (offset=0x%llx, size=0x%llx)\n", priv->pid,
+			seq_printf(s, "%-8d %-16s %-14s BAR%u %-2s (offset=0x%llx, size=0x%llx, refs=%d)\n", priv->pid,
 				   priv->comm, "BAR", bar_mapping->bar_index,
 				   bar_mapping->type == BAR_MAPPING_WC ? "WC" : "UC", bar_mapping->offset,
-				   bar_mapping->size);
+				   bar_mapping->size, refcount_read(&bar_mapping->refs));
 		}
 
 		// Individual inbound TLB window mappings.


### PR DESCRIPTION
Bug:
- BAR mappings had no .open callback or refcounting
- When a process forked after mmap'ing a BAR, both parent and child VMAs pointed to the same struct bar_mapping
- First process to exit called bar_vma_close() which freed the mapping struct
- Second process to exit triggered use-after-free

Fix:
- Added refcount_t refs to struct bar_mapping
- Implemented .open callback to increment refcount on fork
- Modified .close to only free when refcount reaches zero
- Added refcount display to debugfs mappings file for diagnostics