### PR TITLE
Fix NULL deref in mappings debugfs, improve output

### DIFF
--- a/memory.c
+++ b/memory.c
@@ -553,7 +553,7 @@ long ioctl_free_dma_buf(struct chardev_private *priv,
 }
 
 
-static bool is_iommu_translated(struct device *dev)
+bool is_iommu_translated(struct device *dev)
 {
 	struct iommu_domain *domain = iommu_get_domain_for_dev(dev);
 	return domain && domain->type != IOMMU_DOMAIN_IDENTITY;

--- a/memory.h
+++ b/memory.h
@@ -51,6 +51,7 @@ long ioctl_configure_tlb(struct chardev_private *priv,
 
 int tenstorrent_mmap(struct chardev_private *priv, struct vm_area_struct *vma);
 void tenstorrent_memory_cleanup(struct chardev_private *priv);
+bool is_iommu_translated(struct device *dev);
 
 #define TENSTORRENT_MAX_OUTBOUND_IATU_REGIONS 16
 struct tenstorrent_outbound_iatu_region {


### PR DESCRIPTION
Fix kernel NULL pointer dereference when reading mappings debugfs file on systems without IOMMU. The code assumed dma_mapping.sgl was always populated, but it's NULL in the non-IOMMU path.

Also improve debugfs output to distinguish between IOVA (IOMMU enabled) and PA (IOMMU disabled) for both pinned pages and DMA buffers. Export is_iommu_translated() to support this.

Fix inconsistent parentheses formatting in TLB entries.