### PR TITLE
ci: retry apt-get update until lock is released

### DIFF
--- a/.github/workflows/hardware-test.yml
+++ b/.github/workflows/hardware-test.yml
@@ -33,8 +33,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install build dependencies
+      shell: bash
       run: |
-        sudo apt-get update -qq
+        until sudo apt-get update -qq; do :; done
         sudo apt-get install -y build-essential linux-headers-$(uname -r) dkms
 
     - name: Run hardware tests


### PR DESCRIPTION
Fixes intermittent CI failures caused by background apt processes holding the dpkg lock on self-hosted runners.

Example: https://github.com/tenstorrent/tt-kmd/actions/runs/18959560228/job/54143870206