### PR TITLE
Fix NULL pointer dereference in telemetry init

### DIFF
--- a/blackhole.c
+++ b/blackhole.c
@@ -848,9 +848,9 @@ static bool blackhole_init(struct tenstorrent_device *tt_dev)
 	struct device *dev = &tt_dev->pdev->dev;
 	int i;
 
-	bh->hwmon_attr_addrs = devm_kzalloc(dev, sizeof(u64) * ARRAY_SIZE(bh_hwmon_attrs), GFP_KERNEL);
-	bh->sysfs_attr_addrs = devm_kzalloc(dev, sizeof(u64) * ARRAY_SIZE(bh_sysfs_attributes), GFP_KERNEL);
-	tt_dev->telemetry_attrs = devm_kzalloc(dev, sizeof(struct attribute *) * ARRAY_SIZE(bh_sysfs_attributes), GFP_KERNEL);
+	bh->hwmon_attr_addrs = devm_kcalloc(dev, ARRAY_SIZE(bh_hwmon_attrs), sizeof(u64), GFP_KERNEL);
+	bh->sysfs_attr_addrs = devm_kcalloc(dev, ARRAY_SIZE(bh_sysfs_attributes), sizeof(u64), GFP_KERNEL);
+	tt_dev->telemetry_attrs = devm_kcalloc(dev, ARRAY_SIZE(bh_sysfs_attributes) + 1, sizeof(struct attribute *), GFP_KERNEL);
 
 	if (!bh->hwmon_attr_addrs || !bh->sysfs_attr_addrs || !tt_dev->telemetry_attrs)
 		return false;

--- a/wormhole.c
+++ b/wormhole.c
@@ -708,8 +708,8 @@ static bool wormhole_init(struct tenstorrent_device *tt_dev)
 	INIT_DELAYED_WORK(&wh_dev->fw_ready_work, fw_ready_work_func);
 	wh_dev->telemetry_retries = 120;	// If telemetry is not ready, defer initialization for up to 2 minutes.
 
-	wh_dev->sysfs_attr_offsets = devm_kzalloc(dev, sizeof(u64) * ARRAY_SIZE(wh_sysfs_attributes), GFP_KERNEL);
-	tt_dev->telemetry_attrs = devm_kzalloc(dev, sizeof(struct attribute *) * ARRAY_SIZE(wh_sysfs_attributes), GFP_KERNEL);
+	wh_dev->sysfs_attr_offsets = devm_kcalloc(dev, ARRAY_SIZE(wh_sysfs_attributes), sizeof(u64), GFP_KERNEL);
+	tt_dev->telemetry_attrs = devm_kcalloc(dev, ARRAY_SIZE(wh_sysfs_attributes) + 1, sizeof(struct attribute *), GFP_KERNEL);
 
 	if (!wh_dev->sysfs_attr_offsets || !tt_dev->telemetry_attrs)
 		return false;


### PR DESCRIPTION
The sysfs attribute arrays were not NULL-terminated, causing the kernel's sysfs code to read past the end of the array during device initialization. This resulted in a kernel oops when loading the module on ARM64:

Unable to handle kernel NULL pointer dereference at virtual address 000000000000000a Call trace:
  create_files+0xc0/0x248 (P)
  internal_create_group+0x1f4/0x368
  sysfs_create_group+0x24/0x50
  devm_device_add_group+0x5c/0xf8
  blackhole_init_telemetry+0x1ec/0x2d0 [tenstorrent]
  tenstorrent_pci_probe+0x2b0/0x390 [tenstorrent]

The sysfs API requires attribute arrays to be NULL-terminated so it knows where to stop iterating. Fix by allocating space for one additional pointer in the telemetry_attrs arrays (the extra slot is zeroed by devm_kzalloc).

Affected both blackhole and wormhole device initialization.