### PR TITLE
blackhole: Support small BAR4 configurations

### DIFF
--- a/device.h
+++ b/device.h
@@ -15,6 +15,8 @@
 #include "hwmon.h"
 #include "memory.h"
 
+#define MAX_TLB_KINDS 4
+
 struct tenstorrent_device_class;
 
 struct tenstorrent_device {
@@ -46,6 +48,7 @@ struct tenstorrent_device {
 
 	DECLARE_BITMAP(tlbs, TENSTORRENT_MAX_INBOUND_TLBS);
 	atomic_t tlb_refs[TENSTORRENT_MAX_INBOUND_TLBS];	// TLB mapping refecounts
+	u32 tlb_counts[MAX_TLB_KINDS];	// Per-device TLB counts (may differ from dev_class defaults)
 
 	struct mutex iatu_mutex;
 	struct tenstorrent_outbound_iatu_region outbound_iatus[TENSTORRENT_MAX_OUTBOUND_IATU_REGIONS];
@@ -56,7 +59,6 @@ struct tenstorrent_device {
 
 struct tlb_descriptor;
 
-#define MAX_TLB_KINDS 4
 struct tenstorrent_device_class {
 	const char *name;
 	u32 instance_size;

--- a/enumerate.c
+++ b/enumerate.c
@@ -244,6 +244,10 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 	tt_dev->pdev = pci_dev_get(dev);
 	tt_dev->ordinal = ordinal;
 
+	// Initialize per-device TLB counts from device class defaults.
+	// Device-specific init may adjust these.
+	memcpy(tt_dev->tlb_counts, device_class->tlb_counts, sizeof(tt_dev->tlb_counts));
+
 	mutex_init(&tt_dev->chardev_mutex);
 	mutex_init(&tt_dev->iatu_mutex);
 

--- a/memory.c
+++ b/memory.c
@@ -1186,7 +1186,7 @@ static int map_tlb_window(struct chardev_private *priv, struct vm_area_struct *v
 		return -EINVAL;
 
 	for (i = 0; i < tt_dev->dev_class->tlb_kinds; ++i)
-		total_tlbs += tt_dev->dev_class->tlb_counts[i];
+		total_tlbs += tt_dev->tlb_counts[i];
 
 	if (bar4)
 		offset -= BAR0_SIZE;

--- a/tlb.c
+++ b/tlb.c
@@ -19,7 +19,7 @@ int tenstorrent_device_allocate_tlb(struct tenstorrent_device *tt_dev,
 		return -EINVAL;
 
 	for (kind = 0; kind < dev_class->tlb_kinds; ++kind) {
-		long tlb_count = dev_class->tlb_counts[kind];
+		long tlb_count = tt_dev->tlb_counts[kind];
 		long tlb_size = dev_class->tlb_sizes[kind];
 
 		if (size == tlb_size) {
@@ -63,7 +63,7 @@ int tenstorrent_device_free_tlb(struct tenstorrent_device *tt_dev,
 		return -EINVAL;
 
 	for (i = 0; i < dev_class->tlb_kinds; ++i)
-		total_tlbs += dev_class->tlb_counts[i];
+		total_tlbs += tt_dev->tlb_counts[i];
 
 	if (id >= total_tlbs)
 		return -EINVAL;


### PR DESCRIPTION
BAR4 nominally contains 8x 4 GiB TLB windows for a total of 32 GiB, but CMFW can reduce BAR4 size to prevent BAR assignment failures in resource-constrained systems.

The driver's TLB implementation previously hard-coded 8 windows and assumed BAR4 was always 32 GiB.

Implement variable window count based on BAR4 size:
- Query actual BAR4 size via pci_resource_len() during init
- Dynamically set dev_class->tlb_counts[1] to available windows
- Partial windows are not supported (only full 4 GiB windows counted)

Update test suite to handle small BAR4 systems:
- Add blackhole_get_num_4g_windows() helper to query available windows
- Skip 4G TLB tests when no 4G windows are available
- Adapt VerifyTlbQuantities to allocate only available windows

This maintains full functionality on 32 GiB BAR4 systems while gracefully supporting 16/8/4 GiB and smaller configurations.

Fixes #167