### PR TITLE
Invalidate userspace mappings on device reset

### DIFF
--- a/device.h
+++ b/device.h
@@ -52,7 +52,6 @@ struct tenstorrent_device {
 	struct list_head open_fds_list;	// List of struct chardev_private, linked through open_fds field
 
 	DECLARE_BITMAP(tlbs, TENSTORRENT_MAX_INBOUND_TLBS);
-	atomic_t tlb_refs[TENSTORRENT_MAX_INBOUND_TLBS];	// TLB mapping refecounts
 	u32 tlb_counts[MAX_TLB_KINDS];	// Per-device TLB counts (may differ from dev_class defaults)
 
 	struct mutex iatu_mutex;

--- a/memory.h
+++ b/memory.h
@@ -10,6 +10,7 @@
 #define MAX_DMA_BUF_SIZE_LOG2 28
 
 struct chardev_private;
+struct tenstorrent_device;
 struct tenstorrent_query_mappings;
 struct tenstorrent_allocate_dma_buf;
 struct tenstorrent_free_dma_buf;
@@ -51,6 +52,7 @@ long ioctl_configure_tlb(struct chardev_private *priv,
 
 int tenstorrent_mmap(struct chardev_private *priv, struct vm_area_struct *vma);
 void tenstorrent_memory_cleanup(struct chardev_private *priv);
+void tenstorrent_vma_zap(struct tenstorrent_device *tt_dev);
 bool is_iommu_translated(struct device *dev);
 
 #define TENSTORRENT_MAX_OUTBOUND_IATU_REGIONS 16


### PR DESCRIPTION
This is an attempt to solve https://github.com/tenstorrent/tt-kmd/issues/174; see the commit message for implementation details.