### PR TITLE
Allow compiler to init struct sg_table dma_mapping

### DIFF
--- a/memory.c
+++ b/memory.c
@@ -580,7 +580,7 @@ long ioctl_pin_pages(struct chardev_private *priv,
 	struct page **pages;
 	int pages_pinned;
 	struct pinned_page_range *pinning;
-	struct sg_table dma_mapping = {0};
+	struct sg_table dma_mapping = {};
 	long ret;
 	u32 bytes_to_copy;
 	u64 noc_address = 0;


### PR DESCRIPTION
Fix
```
    tt-kmd/memory.c:583:40: error: positional initialization of field
    in 'struct' declared with 'designated_init' attribute
    [-Werror=designated-init]
      583 |         struct sg_table dma_mapping = {0};
          |                                        ^
```

by declaring an empty struct with no assignment or member definitions to allow the compiler to pick up members (and if so enabled, properly/eagerly initialize them) based on the struct info already known at this point.
    
Permit building for grsec/pax kernels.
    
All credit for the empty struct approach to @bspengler-oss

