### PR TITLE
Prevent MRISC PHY power toggling on BH Galaxy

### DIFF
--- a/blackhole.h
+++ b/blackhole.h
@@ -20,6 +20,7 @@ struct blackhole_device {
 	u64 *sysfs_attr_addrs;
 
 	u8 saved_mps;
+	bool is_galaxy;	// True for galaxy-blackhole systems (card_type 0x47)
 };
 
 #define tt_dev_to_bh_dev(ttdev) \

--- a/module.c
+++ b/module.c
@@ -46,6 +46,11 @@ bool power_policy = true;
 module_param(power_policy, bool, 0444);
 MODULE_PARM_DESC(power_policy, "Enable power policy: low power at probe, re-aggregate on close (default=on).");
 
+bool allow_galaxy_mrisc_toggle = false;
+module_param(allow_galaxy_mrisc_toggle, bool, 0644);
+MODULE_PARM_DESC(allow_galaxy_mrisc_toggle,
+	"Allow MRISC PHY power state toggling on galaxy-blackhole systems (default: false)");
+
 const struct pci_device_id tenstorrent_ids[] = {
 	{ PCI_DEVICE(PCI_VENDOR_ID_TENSTORRENT, PCI_DEVICE_ID_GRAYSKULL),
 	  .driver_data=(kernel_ulong_t)NULL}, // Deprecated

--- a/module.h
+++ b/module.h
@@ -17,6 +17,7 @@ extern uint dma_address_bits;
 extern uint reset_limit;
 extern unsigned char auto_reset_timeout;
 extern bool power_policy;
+extern bool allow_galaxy_mrisc_toggle;
 
 extern struct tenstorrent_device_class wormhole_class;
 extern struct tenstorrent_device_class blackhole_class;


### PR DESCRIPTION
Blackhole Galaxy systems (card_type 0x47) break if the MRISC PHY state is toggled during idle power management. This adds protection to keep MRISC PHY always awake on these systems.

Changes:
- Detect galaxy-blackhole during telemetry init via board_id card_type
- Force TT_POWER_FLAG_MRISC_PHY_WAKEUP in blackhole_set_power_state() for galaxy systems
- Add allow_galaxy_mrisc_toggle module parameter (default: false) to permit toggling for testing purposes

The module parameter can be changed at runtime:
  echo 1 > /sys/module/tenstorrent/parameters/allow_galaxy_mrisc_toggle