### PR TITLE
Store struct pid instead of pid_t for namespace-correct display

### DIFF
--- a/chardev.c
+++ b/chardev.c
@@ -619,7 +619,7 @@ static int tt_cdev_open(struct inode *inode, struct file *file)
 	private_data->open_reset_gen = atomic_long_read(&tt_dev->reset_gen);
 	file->private_data = private_data;
 
-	private_data->pid = task_tgid_vnr(current);
+	private_data->pid = get_pid(task_pid(current->group_leader));
 	get_task_comm(private_data->comm, current);
 
 	// Legacy client: default to AICLK=Low, everything else enabled.
@@ -683,6 +683,7 @@ static int tt_cdev_release(struct inode *inode, struct file *file)
 		tenstorrent_set_aggregated_power_state(tt_dev);
 
 	tenstorrent_device_put(tt_dev);
+	put_pid(priv->pid);
 	kfree(file->private_data);
 	file->private_data = NULL;
 	return 0;

--- a/chardev_private.h
+++ b/chardev_private.h
@@ -47,7 +47,7 @@ struct chardev_private {
 	struct list_head peer_mappings; // struct peer_resource_mapping.list
 	struct list_head bar_mappings;	// struct bar_mapping.list
 
-	pid_t pid;
+	struct pid *pid;
 	char comm[TASK_COMM_LEN];
 
 	DECLARE_BITMAP(resource_lock, TENSTORRENT_RESOURCE_LOCK_COUNT);


### PR DESCRIPTION
The mappings (debugfs) and pids (procfs) files display the PID of each process with an open file descriptor. Previously, we stored the numeric PID as seen from the opener's namespace at open time. When these files were read from a different PID namespace (e.g., host viewing container processes), this resulted in mysterious pids that either didn't exist or referred to unrelated processes in the reader's namespace.

Fix this by storing a reference-counted struct pid pointer and translating to a numeric PID via pid_vnr() at read time. This displays the correct PID from the reader's perspective, regardless of namespace boundaries.