### PR TITLE
Fix inverted return value handling in tenstorrent_resume()

### DIFF
--- a/enumerate.c
+++ b/enumerate.c
@@ -370,13 +370,13 @@ static int tenstorrent_resume(struct device *dev) {
 	struct pci_dev *pdev = to_pci_dev(dev);
 	struct tenstorrent_device *tt_dev = pci_get_drvdata(pdev);
 
-	int ret = tt_dev->dev_class->init_hardware(tt_dev);
+	bool ok = tt_dev->dev_class->init_hardware(tt_dev);
 
 	// Suspend invalidates the saved state.
-	if (ret == 0)
+	if (ok)
 		pci_save_state(pdev);
 
-	return ret;
+	return ok ? 0 : -EIO;
 }
 
 static SIMPLE_DEV_PM_OPS(tenstorrent_pm_ops, tenstorrent_suspend, tenstorrent_resume);


### PR DESCRIPTION
init_hardware() returns bool (true = success), but tenstorrent_resume() was treating it as a kernel-style int (0 = success).