### PR TITLE
Fail gracefully when PCI BARs are unassigned

### DIFF
--- a/memory.c
+++ b/memory.c
@@ -1215,6 +1215,11 @@ static int map_tlb_window(struct chardev_private *priv, struct vm_area_struct *v
 		goto unlock;
 	}
 
+	if (tlb_desc.bar_offset + size > pci_resource_len(tt_dev->pdev, tlb_desc.bar)) {
+		ret = -ENXIO;
+		goto unlock;
+	}
+
 	bar_start = pci_resource_start(tt_dev->pdev, tlb_desc.bar);
 	pfn = (bar_start + tlb_desc.bar_offset) >> PAGE_SHIFT;
 


### PR DESCRIPTION
When a device has unassigned BAR regions the driver would previously
crash:

- Probe called save_reset_state() unconditionally, causing a page fault
  when bar4_mapping was NULL (Wormhole)
- TLB mmap would attempt to map physical address 0

Now probe fails with -EIO if init_device() fails, and TLB mmap returns
-ENXIO for unassigned or unexpectedly shrunken BARs.

Fixes https://github.com/tenstorrent/tt-kmd/issues/193