### PR TITLE
Work around kernel's incorrect Gen1 link speed restriction

### DIFF
--- a/blackhole.c
+++ b/blackhole.c
@@ -49,6 +49,9 @@
 // this points to outbound NOC_TLB_62 configured by CMFW
 #define PCIE_DBI_ADDR 0xF800000000000000ULL
 
+// PCI subsystem device IDs for Blackhole cards
+#define PCI_SUBSYSTEM_DEVICE_GALAXY	0x0047
+
 // ARC owns telemetry
 #define ARC_X 8
 #define ARC_Y 0
@@ -898,6 +901,12 @@ static bool blackhole_init_hardware(struct tenstorrent_device *tt_dev)
 	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
 	struct pci_dev *pdev = tt_dev->pdev;
 	struct arc_msg msg = { 0 };
+	bool is_galaxy = (pdev->subsystem_device == PCI_SUBSYSTEM_DEVICE_GALAXY);
+
+	// Workaround for kernels where pcie_failed_link_retrain() may have
+	// forced the link to Gen1. Retrain to full speed. Only needed on Galaxy.
+	if (is_galaxy)
+		pcie_retrain_link_to_max_speed(pdev);
 
 	pcie_set_readrq(pdev, MAX_MRRS);
 

--- a/pcie.h
+++ b/pcie.h
@@ -13,5 +13,6 @@ bool pcie_hot_reset_and_restore_state(struct pci_dev *pdev);
 bool pcie_timer_interrupt(struct pci_dev *pdev);
 bool set_reset_marker(struct pci_dev *pdev);
 bool is_reset_marker_zero(struct pci_dev *pdev);
+void pcie_retrain_link_to_max_speed(struct pci_dev *pdev);
 
 #endif

--- a/wormhole.c
+++ b/wormhole.c
@@ -15,7 +15,6 @@
 #include "hwmon.h"
 #include "tlb.h"
 #include "telemetry.h"
-#include "pcie.h"
 #include "enumerate.h"
 
 #define TLB_1M_WINDOW_COUNT 156


### PR DESCRIPTION
See the commit message & the following internal tickets for detail.
https://tenstorrent.atlassian.net/browse/PCB-2519
https://ext-tenstorrent.atlassian.net/browse/QUAN-1039