### PR TITLE
Suppress hotplug events during reset operations

### DIFF
--- a/pcie.c
+++ b/pcie.c
@@ -60,9 +60,12 @@ bool safe_pci_restore_state(struct pci_dev *pdev) {
 bool pcie_hot_reset_and_restore_state(struct pci_dev *pdev) {
 	struct pci_dev *bridge_dev = pci_upstream_bridge(pdev);
 	u16 bridge_ctrl;
+	bool result;
 
 	if (!bridge_dev)
 		return false;
+
+	pci_ignore_hotplug(pdev);
 
 	// reset link - like pci_reset_secondary_bus, but we don't want the full 1s delay.
 	pci_read_config_word(bridge_dev, PCI_BRIDGE_CONTROL, &bridge_ctrl);
@@ -72,13 +75,14 @@ bool pcie_hot_reset_and_restore_state(struct pci_dev *pdev) {
 	pci_write_config_word(bridge_dev, PCI_BRIDGE_CONTROL, bridge_ctrl);
 	msleep(500);
 
-	if (!poll_pcie_link_up(pdev, 10000))
-		return false;
+	result = poll_pcie_link_up(pdev, 10000) && safe_pci_restore_state(pdev);
 
-	if (!safe_pci_restore_state(pdev))
-		return false;
+	// Re-enable hotplug events. There is no pci_unignore_hotplug(), but the
+	// flag is just a struct member we can clear directly.
+	pdev->ignore_hotplug = 0;
+	bridge_dev->ignore_hotplug = 0;
 
-	return true;
+	return result;
 }
 
 bool wormhole_complete_pcie_init(struct tenstorrent_device *tt_dev, u8 __iomem* reset_unit_regs) {


### PR DESCRIPTION
This change addresses two issues on platforms with PCIe native hotplug enabled:

1. RESET_PCIE_LINK (SBR) is broken

   When asserting Secondary Bus Reset, the link goes down and pciehp immediately triggers device removal. By the time our reset function wakes from msleep(), the old pci_dev has been removed from the PCI topology and a new pci_dev has been enumerated. We continue using the old, now-orphaned pci_dev - config reads return 0xFFFF and the reset fails. This isn't a use-after-free (we hold a reference), but the pci_dev no longer corresponds to actual hardware.

2. ASIC_RESET / DMC_RESET causes device ID shuffling

   When resetting multiple devices simultaneously, each device goes through a remove/probe cycle. The order in which devices re-enumerate is non-deterministic, causing /dev/tenstorrent/N ordinals to shuffle.

Fix both by using pci_ignore_hotplug() to suppress hotplug events during reset. For SBR, suppression is scoped to
pcie_hot_reset_and_restore_state().  For ASIC/DMC resets, suppression starts at reset trigger and is cleared in POST_RESET after the device has recovered.