### PR TITLE
Fix resource leaks when copy_to_user fails after committing resources

### DIFF
--- a/memory.c
+++ b/memory.c
@@ -528,6 +528,7 @@ long ioctl_allocate_dma_buf(struct chardev_private *priv,
 	out.size = in.requested_size;
 
 	if (copy_to_user(&arg->out, &out, sizeof(out)) != 0) {
+		teardown_outbound_iatu(priv, iatu_region);
 		dma_free_coherent(&priv->device->pdev->dev, dmabuf->size,
 				  dmabuf->ptr, dmabuf->phys);
 


### PR DESCRIPTION
Fixes #154

Three ioctls can leak resources if `copy_to_user()` fails after the resource has been committed. Practically unreachable since the same user pointer validated by `copy_from_user()` earlier will almost certainly succeed, but they should still be correct.

- **ioctl_pin_pages**: Move copy_to_user before list_add so the pinning, DMA mapping, and iATU region are cleaned up on failure instead of being leaked until fd close.
- **ioctl_map_peer_bar**: Same approach — move copy_to_user before list_add so the dma_map_resource mapping is cleaned up on failure.
- **ioctl_allocate_dma_buf**: Add missing teardown_outbound_iatu to the copy_to_user failure path. This was the worst of the three — kfree(dmabuf) destroyed the only record of the iATU region, making it a permanent leak not recovered even on fd close.