### PR TITLE
Wormhole power ioctl support

### DIFF
--- a/wormhole.c
+++ b/wormhole.c
@@ -1049,8 +1049,17 @@ static int wormhole_set_power_state(struct tenstorrent_device *tt_dev, struct te
 						     power_state->validity,
 						     power_state->power_flags,
 						     10000, NULL);
-	if (!ok)
-		pr_warn("Failed to send power state message to firmware\n");
+	if (!ok) {
+		ok = wormhole_send_arc_fw_message_with_args(reset_unit_regs(wh_dev),
+					     WH_FW_MSG_NOP,
+					     0,
+					     0,
+					     10000, NULL);
+		pr_warn("Failed to send power state message to firmware; post NOP okay: %u\n", ok);
+
+		if (!ok)
+			return -EINVAL;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Lets KMD send power ioctl to WH. 

Bit pattern is the same.

FW implementation/behaviour is the same; if we're asked to enable a flag we don't know how to deal with, we still return success.

Tests:

On a WH FW which supports power msg:
A)
Base power on n150 is now 15W (before: 19/20W)

B) 
manual toggling ioctl shows power change.

```
chip.set_power_state("high")
//SMI shows 19W

chip.set_power_state("low")
//smi shows 15W
```

C) burnin does stuff on n150 without crashing (I _think_ it would crash on n300 because [we need to fix multi-chip](https://github.com/tenstorrent/tt-burnin/pull/28))

D) `pytest models/tt_transformers/demo/simple_text_demo.py -k performance-batch-1` happily talks about condiments



On a WH FW which _doesn't_ support power msg:

A) Base power on n150 shows 19W

B) dmesg shows:
[1905294.753311] tenstorrent: Failed to send power state message to firmware

C) tt-burnin runs