### PR TITLE
Add synchronous ARC message ioctl

### DIFF
--- a/device.h
+++ b/device.h
@@ -19,6 +19,7 @@
 
 #define MAX_TLB_KINDS 4
 
+struct arc_msg;
 struct tenstorrent_device_class;
 
 struct tenstorrent_device {
@@ -60,6 +61,8 @@ struct tenstorrent_device {
 
 	struct attribute **telemetry_attrs;
 	struct attribute_group telemetry_group;
+
+	struct mutex arc_msg_mutex;
 };
 
 struct tlb_descriptor;
@@ -92,6 +95,7 @@ struct tenstorrent_device_class {
 	int (*csm_read32)(struct tenstorrent_device *ttdev, u64 addr, u32 *value);
 	int (*csm_write32)(struct tenstorrent_device *ttdev, u64 addr, u32 value);
 	int (*set_power_state)(struct tenstorrent_device *ttdev, struct tenstorrent_power_state *power_state);
+	int (*send_arc_msg)(struct tenstorrent_device *ttdev, struct arc_msg *msg);
 };
 
 void tenstorrent_device_put(struct tenstorrent_device *);

--- a/enumerate.c
+++ b/enumerate.c
@@ -262,6 +262,7 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 
 	mutex_init(&tt_dev->chardev_mutex);
 	mutex_init(&tt_dev->iatu_mutex);
+	mutex_init(&tt_dev->arc_msg_mutex);
 
 	// Use dma_address_bits from module parameter or device class for coherent
 	// DMA mask, but use a 64-bit mask for streaming mappings. The problem this

--- a/ioctl.h
+++ b/ioctl.h
@@ -27,6 +27,7 @@
 #define TENSTORRENT_IOCTL_CONFIGURE_TLB		_IO(TENSTORRENT_IOCTL_MAGIC, 13)
 #define TENSTORRENT_IOCTL_SET_NOC_CLEANUP		_IO(TENSTORRENT_IOCTL_MAGIC, 14)
 #define TENSTORRENT_IOCTL_SET_POWER_STATE		_IO(TENSTORRENT_IOCTL_MAGIC, 15)
+#define TENSTORRENT_IOCTL_SEND_ARC_MSG			_IO(TENSTORRENT_IOCTL_MAGIC, 16)
 
 // For tenstorrent_mapping.mapping_id. These are not array indices.
 #define TENSTORRENT_MAPPING_UNUSED		0
@@ -406,6 +407,28 @@ struct tenstorrent_power_state {
 #define TT_POWER_FLAG_TENSIX_ENABLE     (1U << 2) /* 1=Enable Tensix, 0=Clock Gate Tensix */
 #define TT_POWER_FLAG_L2CPU_ENABLE      (1U << 3) /* 1=Enable L2CPU,  0=Clock Gate L2CPU */
 	__u16 power_settings[14];
+};
+
+/**
+ * TENSTORRENT_IOCTL_SEND_ARC_MSG - Send a message to the ARC processor
+ *
+ * Sends a synchronous message to the on-chip ARC management processor via the
+ * firmware message queue. The caller provides an 8-word message and receives
+ * an 8-word response. The driver serializes concurrent callers.
+ *
+ * On success, @message contains the firmware's response.
+ * On firmware error (errno EREMOTEIO), @message still contains the response
+ * (inspect message[0] for the firmware status code).
+ * On transport failure (errno EIO, ETIMEDOUT), @message is undefined.
+ *
+ * @argsz: Must be at least sizeof(struct tenstorrent_send_arc_msg).
+ * @flags: Reserved for future use, must be 0.
+ * @message: 8 x u32 message (request on entry, response on return).
+ */
+struct tenstorrent_send_arc_msg {
+	__u32 argsz;
+	__u32 flags;
+	__u32 message[8];
 };
 
 #endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,7 +8,7 @@ PROG := ttkmd_test
 TEST_SOURCES := get_driver_info.cpp get_device_info.cpp query_mappings.cpp \
 	dma_buf.cpp pin_pages.cpp config_space.cpp lock.cpp hwmon.cpp map_peer_bar.cpp \
 	ioctl_overrun.cpp ioctl_zeroing.cpp tlbs.cpp release.cpp mappings_debugfs.cpp \
-	procfs_pids.cpp
+	procfs_pids.cpp arc_msg.cpp
 
 CORE_SOURCES := enumeration.cpp util.cpp devfd.cpp main.cpp test_failure.cpp
 SOURCES := $(CORE_SOURCES) $(TEST_SOURCES)

--- a/test/arc_msg.cpp
+++ b/test/arc_msg.cpp
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#include <iomanip>
+
+#include <sys/ioctl.h>
+
+#include "ioctl.h"
+
+#include "enumeration.h"
+#include "devfd.h"
+#include "test_failure.h"
+
+namespace
+{
+
+constexpr uint32_t MSG_TYPE_TEST = 0x90;
+
+int send_arc_msg(int fd, tenstorrent_send_arc_msg *msg)
+{
+    msg->argsz = sizeof(*msg);
+    msg->flags = 0;
+    return ioctl(fd, TENSTORRENT_IOCTL_SEND_ARC_MSG, msg);
+}
+
+void TestEcho(int fd)
+{
+    uint32_t prev_serial = 0;
+
+    for (uint32_t i = 1; i <= 10; i++)
+    {
+        tenstorrent_send_arc_msg msg{};
+        msg.message[0] = MSG_TYPE_TEST;
+        msg.message[1] = i;
+
+        if (send_arc_msg(fd, &msg) != 0)
+            THROW_TEST_FAILURE("SEND_ARC_MSG echo failed: " + std::string(std::strerror(errno)));
+
+        if (msg.message[0] != 0)
+            THROW_TEST_FAILURE("SEND_ARC_MSG echo: expected header 0, got " + std::to_string(msg.message[0]));
+
+        if (msg.message[1] != i + 1)
+            THROW_TEST_FAILURE("SEND_ARC_MSG echo: expected " + std::to_string(i + 1)
+                               + ", got " + std::to_string(msg.message[1]));
+
+        // FW returns last_serial+1 in message[2]; verify it advances.
+        uint32_t serial = msg.message[2];
+        if (i > 1 && serial != prev_serial + 1)
+            THROW_TEST_FAILURE("SEND_ARC_MSG echo: serial did not advance (prev="
+                               + std::to_string(prev_serial) + " cur=" + std::to_string(serial) + ")");
+        prev_serial = serial;
+
+        // FW zeroes the response before populating; unused fields must be 0.
+        for (int j = 3; j < 8; j++)
+        {
+            if (msg.message[j] != 0)
+                THROW_TEST_FAILURE("SEND_ARC_MSG echo: expected message[" + std::to_string(j)
+                                   + "] == 0, got " + std::to_string(msg.message[j]));
+        }
+    }
+}
+
+void TestUnrecognizedMessage(int fd)
+{
+    tenstorrent_send_arc_msg msg{};
+    msg.message[0] = 0xFF;
+
+    if (send_arc_msg(fd, &msg) == 0)
+        THROW_TEST_FAILURE("SEND_ARC_MSG should fail for unrecognized message type");
+
+    if (errno != EREMOTEIO)
+        THROW_TEST_FAILURE("SEND_ARC_MSG unrecognized: expected EREMOTEIO, got " + std::string(std::strerror(errno)));
+
+    // Response should be copied back on EREMOTEIO with a nonzero header.
+    // BH FW returns 0xFF, WH FW returns 0xFFFFFFFF — both nonzero.
+    if (msg.message[0] == 0)
+        THROW_TEST_FAILURE("SEND_ARC_MSG unrecognized: expected nonzero response header");
+}
+
+void TestBadArgsz(int fd)
+{
+    tenstorrent_send_arc_msg msg{};
+    msg.argsz = 4;  // Too small
+    msg.flags = 0;
+    msg.message[0] = MSG_TYPE_TEST;
+
+    if (ioctl(fd, TENSTORRENT_IOCTL_SEND_ARC_MSG, &msg) == 0)
+        THROW_TEST_FAILURE("SEND_ARC_MSG should fail with bad argsz");
+
+    if (errno != EINVAL)
+        THROW_TEST_FAILURE("SEND_ARC_MSG bad argsz: expected EINVAL, got " + std::string(std::strerror(errno)));
+}
+
+void TestBadFlags(int fd)
+{
+    tenstorrent_send_arc_msg msg{};
+    msg.argsz = sizeof(msg);
+    msg.flags = 0xFFFFFFFF;
+    msg.message[0] = MSG_TYPE_TEST;
+
+    if (ioctl(fd, TENSTORRENT_IOCTL_SEND_ARC_MSG, &msg) == 0)
+        THROW_TEST_FAILURE("SEND_ARC_MSG should fail with bad flags");
+
+    if (errno != EINVAL)
+        THROW_TEST_FAILURE("SEND_ARC_MSG bad flags: expected EINVAL, got " + std::string(std::strerror(errno)));
+}
+
+void TestRecoveryAfterGarbage(int fd)
+{
+    // Send an unrecognized message to provoke a FW error.
+    tenstorrent_send_arc_msg bad{};
+    bad.message[0] = 0xFF;
+    send_arc_msg(fd, &bad);
+
+    // Now send a valid echo and verify the queue still works.
+    tenstorrent_send_arc_msg msg{};
+    msg.message[0] = MSG_TYPE_TEST;
+    msg.message[1] = 42;
+
+    if (send_arc_msg(fd, &msg) != 0)
+        THROW_TEST_FAILURE("SEND_ARC_MSG failed after garbage: " + std::string(std::strerror(errno)));
+
+    if (msg.message[0] != 0)
+        THROW_TEST_FAILURE("SEND_ARC_MSG after garbage: expected header 0, got " + std::to_string(msg.message[0]));
+
+    if (msg.message[1] != 43)
+        THROW_TEST_FAILURE("SEND_ARC_MSG after garbage: expected 43, got " + std::to_string(msg.message[1]));
+}
+
+using steady_clock = std::chrono::steady_clock;
+using dseconds = std::chrono::duration<double>;
+
+constexpr auto THROUGHPUT_DURATION = std::chrono::seconds(1);
+constexpr int MIN_EXPECTED_MSG_PER_SEC = 1000;
+
+void TestThroughput(int fd)
+{
+    int count = 0;
+    auto start = steady_clock::now();
+
+    for (;;)
+    {
+        tenstorrent_send_arc_msg msg{};
+        msg.message[0] = MSG_TYPE_TEST;
+        msg.message[1] = count;
+
+        if (send_arc_msg(fd, &msg) != 0)
+            THROW_TEST_FAILURE("SEND_ARC_MSG throughput test failed: " + std::string(std::strerror(errno)));
+
+        count++;
+
+        if (steady_clock::now() - start >= THROUGHPUT_DURATION)
+            break;
+    }
+
+    double sec = std::chrono::duration_cast<dseconds>(steady_clock::now() - start).count();
+    int rate = static_cast<int>(count / sec);
+
+    std::cout << "  ARC msg throughput: " << rate << " msg/s"
+              << " (" << count << " in " << std::fixed << std::setprecision(3) << sec << "s)\n";
+
+    if (rate < MIN_EXPECTED_MSG_PER_SEC)
+        THROW_TEST_FAILURE("ARC msg throughput too low: " + std::to_string(rate) + " msg/s");
+}
+
+} // namespace
+
+void TestArcMsg(const EnumeratedDevice &dev)
+{
+    DevFd dev_fd(dev.path);
+
+    // Probe: if the FW doesn't support message queues, skip gracefully.
+    {
+        tenstorrent_send_arc_msg msg{};
+        msg.message[0] = MSG_TYPE_TEST;
+        msg.message[1] = 0;
+
+        if (send_arc_msg(dev_fd.get(), &msg) != 0)
+        {
+            if (errno == EOPNOTSUPP || errno == ETIMEDOUT || errno == EIO)
+            {
+                std::cout << "ARC message queue not available, skipping test.\n";
+                return;
+            }
+            THROW_TEST_FAILURE("SEND_ARC_MSG probe failed: " + std::string(std::strerror(errno)));
+        }
+    }
+
+    TestEcho(dev_fd.get());
+    TestUnrecognizedMessage(dev_fd.get());
+    TestRecoveryAfterGarbage(dev_fd.get());
+    TestBadArgsz(dev_fd.get());
+    TestBadFlags(dev_fd.get());
+    TestThroughput(dev_fd.get());
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -24,6 +24,7 @@ void TestTlbs(const EnumeratedDevice &dev);
 void TestDeviceRelease(const EnumeratedDevice &dev);
 void TestMappingsDebugfs(const EnumeratedDevice &dev);
 void TestProcfsPids(const EnumeratedDevice &dev);
+void TestArcMsg(const EnumeratedDevice &dev);
 
 int main(int argc, char *argv[])
 {
@@ -54,6 +55,7 @@ int main(int argc, char *argv[])
         TestMappingsDebugfs(d);
         TestProcfsPids(d);
         TestDeviceRelease(d);
+        TestArcMsg(d);
 
         at_least_one_device = true;
     }


### PR DESCRIPTION
## Summary

Add `TENSTORRENT_IOCTL_SEND_ARC_MSG`, a synchronous ioctl for userspace to send messages to the ARC management processor via the firmware message queue.

## Changes

- **Add `SEND_ARC_MSG` ioctl** — accepts an 8-word message, forwards it through the ARC message queue, and returns the 8-word response. A per-device mutex serializes all ARC message queue access (both ioctl and internal driver callers).
- **Refactor `send_arc_message()`** in blackhole.c and wormhole.c from `bool` to `int`, returning specific error codes (`-EIO`, `-ETIMEDOUT`, `-EOPNOTSUPP`, `-EREMOTEIO`) instead of a generic failure.
- **Add test** covering echo, firmware error handling, recovery, input validation, and throughput.
- ~**Relax argsz validation** in `SET_NOC_CLEANUP` and `SET_POWER_STATE` from exact-match to minimum-size, allowing newer userspace with appended fields to work against older kernels.~

## Deviation from proposed design

The [proposed design](https://tenstorrent.atlassian.net/wiki/spaces/syseng/pages/537723135/ARC+FW+Messages) specifies an async post/poll/abandon model. ARC processes messages sequentially across all queues, so async just moves the serialization from a host mutex to firmware while adding response-routing complexity. Synchronous is simpler and forward-compatible via `argsz`/`flags`.

