### PR TITLE
Adopt VFIO-style ioctl extensibility pattern

### DIFF
--- a/chardev.c
+++ b/chardev.c
@@ -336,24 +336,32 @@ static long ioctl_lock_ctl(struct chardev_private *priv, struct tenstorrent_lock
 static long ioctl_set_noc_cleanup(struct chardev_private *priv,
 			   struct tenstorrent_set_noc_cleanup __user *arg)
 {
+	const size_t minsz = offsetofend(struct tenstorrent_set_noc_cleanup, data);
 	struct tenstorrent_device *tt_dev = priv->device;
 	struct tenstorrent_set_noc_cleanup data = {0};
+	size_t copysz;
 
-	// First, ensure the underlying device class supports this operation.
 	if (!tt_dev->dev_class->noc_write32)
 		return -EOPNOTSUPP;
 
-	if (copy_from_user(&data, arg, sizeof(data)) != 0)
+	if (get_user(data.argsz, &arg->argsz))
 		return -EFAULT;
 
-	// The `argsz` field allows the kernel to validate that the userspace caller
-	// has the same understanding of the structure size. For this specific
-	// version of the API, we require an exact match.
-	if (data.argsz != sizeof(data))
+	if (data.argsz < minsz)
 		return -EINVAL;
 
-	// Validate reserved fields to ensure future compatibility.
-	if (data.flags != 0)
+	copysz = min_t(size_t, data.argsz, sizeof(data));
+
+	if (copy_from_user(&data, arg, copysz))
+		return -EFAULT;
+
+	if (data.argsz > sizeof(data)) {
+		if (check_zeroed_user((char __user *)arg + sizeof(data),
+				      data.argsz - sizeof(data)) <= 0)
+			return -E2BIG;
+	}
+
+	if (data.flags != 0 || data.reserved0 != 0)
 		return -EINVAL;
 
 	// The `enabled` field acts as a boolean; reject other values.
@@ -443,14 +451,27 @@ int tenstorrent_set_aggregated_power_state(struct tenstorrent_device *tt_dev)
 
 static long ioctl_set_power_state(struct chardev_private *priv, struct tenstorrent_power_state __user *arg)
 {
+	const size_t minsz = offsetofend(struct tenstorrent_power_state, power_settings);
 	struct tenstorrent_device *tt_dev = priv->device;
 	struct tenstorrent_power_state data = {0};
+	size_t copysz;
 
-	if (copy_from_user(&data, arg, sizeof(data)) != 0)
+	if (get_user(data.argsz, &arg->argsz))
 		return -EFAULT;
 
-	if (data.argsz != sizeof(data))
+	if (data.argsz < minsz)
 		return -EINVAL;
+
+	copysz = min_t(size_t, data.argsz, sizeof(data));
+
+	if (copy_from_user(&data, arg, copysz))
+		return -EFAULT;
+
+	if (data.argsz > sizeof(data)) {
+		if (check_zeroed_user((char __user *)arg + sizeof(data),
+				      data.argsz - sizeof(data)) <= 0)
+			return -E2BIG;
+	}
 
 	if (data.flags != 0 || data.reserved0 != 0)
 		return -EINVAL;

--- a/docs/ioctl-design.md
+++ b/docs/ioctl-design.md
@@ -1,0 +1,281 @@
+# Ioctl Interface Design
+
+This document describes the extensibility strategy for the tt-kmd ioctl
+interface: how to add new ioctls, how to extend existing ones, and the
+rationale behind the design choices.
+
+The approach is based on the VFIO pattern from the Linux kernel. For
+background on what goes wrong when you get ioctls wrong, read
+[Botching up ioctls](https://docs.kernel.org/process/botching-up-ioctls.html),
+and for general kernel ioctl guidance see
+[ioctl based interfaces](https://docs.kernel.org/driver-api/ioctl.html).
+
+
+## The Problem
+
+tt-kmd is an out-of-tree DKMS module. Users install it from a .deb or build
+it themselves. Userspace tools (tt-smi, tt-topology, UMD, custom programs)
+are built and deployed independently. This means:
+
+- A newer userspace tool may run against an older installed kernel module.
+- A newer kernel module may be loaded under older userspace tools.
+
+Both directions must work gracefully. A version mismatch should never crash,
+corrupt state, or silently ignore new fields that the caller expected to take
+effect. The interface must either handle the mismatch transparently or fail
+with a clear error.
+
+
+## The Pattern
+
+Every new ioctl struct starts with `argsz` and `flags`:
+
+```c
+struct tenstorrent_example {
+    __u32 argsz;        /* sizeof(struct tenstorrent_example) */
+    __u32 flags;        /* reserved, must be 0 */
+    /* ... fields ... */
+};
+```
+
+`argsz` is set by the caller to the size of the struct it was compiled against.
+The kernel uses this to determine which version of the struct the caller has.
+
+`flags` is reserved for future behavioral variations. The kernel must
+reject nonzero values it does not recognize. This prevents callers from
+accidentally relying on ignored flags and ensures that old kernels give a
+clear `EINVAL` when new userspace requests a feature they don't support.
+
+The ioctl command number is defined with `_IO()` (no size encoded):
+
+```c
+#define TENSTORRENT_IOCTL_EXAMPLE  _IO(TENSTORRENT_IOCTL_MAGIC, N)
+```
+
+This is deliberate. `_IOW`/`_IOR`/`_IOWR` encode struct size into the command
+number, which defeats the purpose of runtime size negotiation via `argsz`.
+VFIO uses the same approach for the same reason.
+
+
+## Kernel-Side Handling
+
+The kernel handler follows a strict sequence. Here it is in full, annotated:
+
+```c
+static long ioctl_example(struct chardev_private *priv,
+                          struct tenstorrent_example __user *arg)
+{
+    /* Minimum size this kernel version requires. When the struct is
+     * extended, this stays pinned to the original size so that old
+     * callers still work. */
+    const size_t minsz = offsetofend(struct tenstorrent_example, last_original_field);
+
+    struct tenstorrent_example data = {};
+    size_t copysz;
+
+    /* Step 1: Read argsz from userspace. */
+    if (get_user(data.argsz, &arg->argsz))
+        return -EFAULT;
+
+    /* Step 2: Reject if caller's struct is smaller than the minimum. */
+    if (data.argsz < minsz)
+        return -EINVAL;
+
+    /* Step 3: Compute the overlap between caller's struct and ours.
+     * This is the number of bytes we can safely exchange. */
+    copysz = min_t(size_t, data.argsz, sizeof(data));
+
+    /* Step 4: Copy the overlapping portion. The rest of `data` stays
+     * zero-initialized, providing safe defaults for any fields the
+     * caller's older struct didn't include. */
+    if (copy_from_user(&data, arg, copysz))
+        return -EFAULT;
+
+    /* Step 5: Reject unknown trailing bytes that are nonzero.
+     * This catches new-userspace-on-old-kernel: if the caller set a
+     * field that this kernel doesn't know about, fail loudly rather
+     * than silently ignoring it. */
+    if (data.argsz > sizeof(data)) {
+        if (check_zeroed_user((char __user *)arg + sizeof(data),
+                              data.argsz - sizeof(data)) <= 0)
+            return -E2BIG;
+    }
+
+    /* Step 6: Reject unknown flags and nonzero reserved fields.
+     * Once flag bits are defined for this ioctl, check only the
+     * unknown bits: if (data.flags & ~KNOWN_FLAGS) return -EINVAL; */
+    if (data.flags != 0)
+        return -EINVAL;
+    if (data.reserved0 != 0)
+        return -EINVAL;
+
+    /* ... do the work ... */
+
+    /* Step 7: Write back only the overlap. Never write past what the
+     * caller allocated. Skip this step for input-only ioctls. */
+    if (copy_to_user(arg, &data, copysz))
+        return -EFAULT;
+
+    return 0;
+}
+```
+
+### Why `offsetofend` for `minsz`?
+
+When you add a new field, you do **not** update `minsz`. It remains pinned
+to the last field of the *original* struct definition. This is what allows
+old userspace to keep working: their smaller `argsz` is still `>= minsz`,
+so they pass the check. The new fields are zero in `data` (from `= {}`).
+The kernel does not use these fields unless the caller sets the
+corresponding flag bit — see [Extending an Existing Ioctl](#extending-an-existing-ioctl).
+
+### Why `check_zeroed_user`?
+
+Without this check, new userspace that sets a newly added field would get
+silent success from an old kernel that doesn't know about that field. The
+caller thinks it requested something; the kernel ignored it. This is
+especially dangerous for a DKMS driver where mismatched versions are common.
+
+With the check, the caller gets `-E2BIG`, which is a clear signal: "you
+passed fields I don't understand." The caller can then fall back or report
+a version mismatch.
+
+This is stricter than what VFIO does (VFIO silently ignores the tail).
+The kernel's `copy_struct_from_user()` helper uses the same strict approach.
+For an out-of-tree driver where version skew is routine, strict is better.
+
+
+## Extending an Existing Ioctl
+
+To add a field to an existing argsz-style struct:
+
+1. **Append** the new field to the end of the struct in `ioctl.h`. Never
+   reorder, remove, or resize existing fields.
+
+2. **Add a flag bit** for each new field, whether input or output. The
+   flag means "the caller knows about this field." For input fields, the
+   kernel reads the field only when the flag is set, distinguishing
+   "caller set the field to zero on purpose" from "caller doesn't know
+   this field exists." For output fields, the kernel fills the field only
+   when the flag is set. If an old kernel encounters an unknown flag, it
+   rejects the ioctl with `EINVAL`, giving the caller a clear signal
+   that the feature is not supported.
+   New flag bits are defined in `ioctl.h` alongside the struct.
+
+3. **Do not change `minsz`** in the handler. It stays at the original struct
+   size. The handler checks the flag for intent, then cross-checks `copysz`
+   to confirm the field is actually present (this catches stack garbage in
+   flags from old userspace whose struct is too small to contain the field):
+
+   ```c
+   if (data.flags & TENSTORRENT_EXAMPLE_USE_NEW_FIELD) {
+       if (copysz < offsetofend(struct tenstorrent_example, new_field))
+           return -EINVAL;
+       /* use data.new_field */
+   }
+   ```
+
+4. **Zero-initialize on the kernel side** (`= {}`). This prevents leaking
+   kernel stack contents and ensures fields not covered by the caller's
+   struct are predictable. The handler must not interpret zero as a
+   sentinel; it reads new fields only when the corresponding flag is set.
+
+5. **Update the doc comment** for the struct in `ioctl.h`.
+
+### Output-only fields
+
+Output fields use the same flag mechanism as input fields. The caller sets
+the flag to request the output; the kernel fills the field if the flag is
+set and `copysz` is large enough:
+
+   ```c
+   if (data.flags & TENSTORRENT_EXAMPLE_GET_NEW_OUTPUT) {
+       if (copysz < offsetofend(struct tenstorrent_example, new_output))
+           return -EINVAL;
+       data.new_output = compute_something();
+   }
+   ```
+
+If the caller sets the flag but the kernel doesn't recognize it, the
+unknown-flags check rejects the ioctl with `EINVAL`. The caller can then fall
+back (retry without the flag) or report a version mismatch. This is unambiguous:
+either the ioctl succeeds and the field is filled, or it fails because the
+kernel doesn't support it.
+
+
+## Rules
+
+These apply to all ioctl structs, not just argsz-style ones:
+
+- **Fixed-width types only.** Use `__u32`, `__u64`, `__s32`, etc. Never
+  `int`, `long`, `size_t`, or `enum`.
+
+- **Natural alignment with explicit padding.** Every field must be aligned
+  to its size. Insert explicit `reserved` padding fields rather than letting
+  the compiler pad. The struct's total size must be a multiple of its largest
+  member's size.
+
+- **Validate all reserved fields and padding.** Reject the ioctl if any
+  reserved field is nonzero. This preserves the ability to give those
+  fields meaning later. If you skip this check, someone will pass stack
+  garbage in the reserved field, it will work, and you can never use that
+  field for anything else.
+
+- **Zero-initialize kernel-side structs.** Use `= {}` or `= {0}`. This
+  prevents leaking kernel stack contents to userspace (information leak)
+  and ensures fields not present in the caller's struct contain a
+  predictable value rather than garbage.
+
+- **Never write past `argsz`.** Always compute
+  `min_t(size_t, argsz, sizeof(data))` and use that as the copy-to-user
+  size.
+
+- **Pointers are `__u64`.** Cast to/from `uintptr_t` in userspace,
+  `u64_to_user_ptr()` in kernel. This avoids 32/64-bit compat issues.
+
+
+## Legacy Ioctls
+
+The older ioctls in tt-kmd use two patterns that predate the argsz approach.
+
+### The `output_size_bytes` pattern
+
+Used by `GET_DEVICE_INFO`, `GET_DRIVER_INFO`, `RESET_DEVICE`, `PIN_PAGES`,
+`LOCK_CTL`. `QUERY_MAPPINGS` uses a variant where the caller provides an
+element count
+(`output_mapping_count`) instead of a byte size, but the principle is the
+same.
+
+```c
+struct tenstorrent_get_device_info_in {
+    __u32 output_size_bytes;
+};
+struct tenstorrent_get_device_info_out {
+    __u32 output_size_bytes;
+    /* ... fields ... */
+};
+```
+
+The caller says how large its output buffer is. The kernel writes
+`min(output_size_bytes, sizeof(out))` bytes back, and sets
+`out.output_size_bytes` to the kernel's full output size so the caller can
+detect truncation.
+
+This provides forward compatibility for outputs. The input struct has no
+size negotiation.
+
+### The fixed-struct pattern
+
+Used by `ALLOCATE_DMA_BUF`, `FREE_DMA_BUF`, `MAP_PEER_BAR`, `ALLOCATE_TLB`,
+`FREE_TLB`, `CONFIGURE_TLB`, `UNPIN_PAGES`.
+
+No size negotiation. Any struct layout change is an ABI break. Some include
+`reserved` fields that can absorb limited future use.
+
+### Extending legacy ioctls
+
+If a legacy ioctl needs new functionality that cannot be expressed through
+its existing reserved fields, add a new ioctl number with an argsz-style
+struct rather than modifying the existing struct layout. The old ioctl
+stays as-is for compatibility.
+

--- a/ioctl.h
+++ b/ioctl.h
@@ -335,12 +335,13 @@ struct tenstorrent_configure_tlb {
  *
  * A previously registered action can be cleared by setting @enabled to 0.
  *
- * @argsz: Must be sizeof(struct tenstorrent_set_noc_cleanup).
+ * @argsz: Must be at least sizeof(struct tenstorrent_set_noc_cleanup).
  * @flags: Reserved for future use, must be 0.
  * @enabled: Set to 1 to register the action, or 0 to clear it.
  * @x: X coordinate of the NOC tile to write to.
  * @y: Y coordinate of the NOC tile to write to.
  * @noc: NOC ID to write to; must be 0 or 1.
+ * @reserved0: Must be 0.
  * @addr: NOC address to write to; must be 4-byte aligned.
  * @data: Data to write to the NOC tile; upper 32 bits are ignored.
  */
@@ -380,7 +381,7 @@ struct tenstorrent_set_noc_cleanup {
  *   last client closes, the device will return to low power.
  * - If power_policy is disabled, no aggregation is triggered on close.
  *
- * @argsz: Must be sizeof(struct tenstorrent_power_state).
+ * @argsz: Must be at least sizeof(struct tenstorrent_power_state).
  * @flags: Reserved for future use, must be 0.
  * @reserved0: Must be 0.
  * @validity: Defines which flags in power_flags and which entries in

--- a/test/Makefile
+++ b/test/Makefile
@@ -7,8 +7,8 @@ PROG := ttkmd_test
 
 TEST_SOURCES := get_driver_info.cpp get_device_info.cpp query_mappings.cpp \
 	dma_buf.cpp pin_pages.cpp config_space.cpp lock.cpp hwmon.cpp map_peer_bar.cpp \
-	ioctl_overrun.cpp ioctl_zeroing.cpp tlbs.cpp release.cpp mappings_debugfs.cpp \
-	procfs_pids.cpp
+	ioctl_overrun.cpp ioctl_zeroing.cpp ioctl_argsz.cpp tlbs.cpp release.cpp \
+	mappings_debugfs.cpp procfs_pids.cpp
 
 CORE_SOURCES := enumeration.cpp util.cpp devfd.cpp main.cpp test_failure.cpp
 SOURCES := $(CORE_SOURCES) $(TEST_SOURCES)

--- a/test/ioctl_argsz.cpp
+++ b/test/ioctl_argsz.cpp
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Test the VFIO-style argsz protocol for SET_NOC_CLEANUP and SET_POWER_STATE.
+// Verifies size negotiation (undersized, exact, oversized), trailing byte
+// rejection (check_zeroed_user), reserved field validation, unknown flag
+// rejection, and overrun protection.
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <cerrno>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+
+#include "devfd.h"
+#include "enumeration.h"
+#include "ioctl.h"
+#include "test_failure.h"
+#include "util.h"
+
+namespace
+{
+
+void expect_errno(int fd, unsigned long code, const char *name, void *arg, int expected_errno, const char *scenario)
+{
+	if (ioctl(fd, code, arg) == 0)
+		THROW_TEST_FAILURE(std::string(name) + ": " + scenario + " was not rejected");
+	if (errno != expected_errno)
+		THROW_TEST_FAILURE(std::string(name) + ": " + scenario + " expected errno " + std::to_string(expected_errno) +
+				   ", got " + std::to_string(errno));
+}
+
+void expect_ok(int fd, unsigned long code, const char *name, void *arg,
+	       const char *scenario)
+{
+	if (ioctl(fd, code, arg) != 0)
+		THROW_TEST_FAILURE(std::string(name) + ": " + scenario + " failed with errno " + std::to_string(errno));
+}
+
+// Generic argsz protocol tests are templated over struct type.
+template <class T>
+void TestArgszZero(int fd, unsigned long code, const char *name, T valid)
+{
+	valid.argsz = 0;
+	expect_errno(fd, code, name, &valid, EINVAL, "argsz=0");
+}
+
+template <class T>
+void TestArgszTooSmall(int fd, unsigned long code, const char *name, T valid)
+{
+	valid.argsz = sizeof(T) - 1;
+	expect_errno(fd, code, name, &valid, EINVAL, "argsz too small");
+}
+
+template <class T>
+void TestArgszExact(int fd, unsigned long code, const char *name, T valid)
+{
+	expect_ok(fd, code, name, &valid, "argsz exact");
+}
+
+template <class T>
+void TestArgszOversizedZeroTail(int fd, unsigned long code, const char *name, T valid)
+{
+	const size_t extra = 64;
+	std::vector<unsigned char> buf(sizeof(T) + extra, 0);
+
+	std::memcpy(buf.data(), &valid, sizeof(T));
+	__u32 argsz = static_cast<__u32>(buf.size());
+	std::memcpy(buf.data(), &argsz, sizeof(argsz));
+
+	expect_ok(fd, code, name, buf.data(), "oversized argsz with zero tail");
+}
+
+template <class T>
+void TestArgszOversizedNonzeroTail(int fd, unsigned long code, const char *name, T valid)
+{
+	const size_t extra = 64;
+	std::vector<unsigned char> buf(sizeof(T) + extra, 0);
+
+	std::memcpy(buf.data(), &valid, sizeof(T));
+	__u32 argsz = static_cast<__u32>(buf.size());
+	std::memcpy(buf.data(), &argsz, sizeof(argsz));
+	buf.back() = 0xFF;
+
+	expect_errno(fd, code, name, buf.data(), E2BIG, "oversized argsz with nonzero tail");
+}
+
+template <class T>
+void TestArgszOverrun(int fd, unsigned long code, const char *name, T valid)
+{
+	size_t ps = page_size();
+	size_t alloc = round_up(sizeof(T), ps) + ps;
+
+	void *mapping = mmap(nullptr, alloc, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+	if (mapping == MAP_FAILED)
+		throw_system_error(std::string(name) + " overrun test: mmap");
+
+	void *guard = reinterpret_cast<void *>(reinterpret_cast<std::uintptr_t>(mapping) + alloc - ps);
+	if (mprotect(guard, ps, PROT_NONE) != 0) {
+		munmap(mapping, alloc);
+		throw_system_error(std::string(name) + " overrun test: mprotect");
+	}
+
+	void *p = reinterpret_cast<void *>(reinterpret_cast<std::uintptr_t>(guard) - sizeof(T));
+	T *s = new (p) T(valid);
+
+	int result = ioctl(fd, code, s);
+	int saved_errno = errno;
+
+	munmap(mapping, alloc);
+
+	if (result != 0 && saved_errno == EFAULT)
+		THROW_TEST_FAILURE(std::string(name) + " overrun: kernel accessed past argsz");
+}
+
+template <class T>
+void TestArgszUnknownFlags(int fd, unsigned long code, const char *name, T valid)
+{
+	valid.flags = 0xFFFFFFFF;
+	expect_errno(fd, code, name, &valid, EINVAL, "unknown flags");
+}
+
+void TestSetNocCleanupArgsz(int fd)
+{
+	tenstorrent_set_noc_cleanup s = {};
+	s.argsz = sizeof(s);
+
+	const auto code = TENSTORRENT_IOCTL_SET_NOC_CLEANUP;
+	const char *name = "SET_NOC_CLEANUP";
+
+	if (ioctl(fd, code, &s) != 0 && errno == EOPNOTSUPP)
+		return;
+
+	TestArgszZero(fd, code, name, s);
+	TestArgszTooSmall(fd, code, name, s);
+	TestArgszExact(fd, code, name, s);
+	TestArgszOversizedZeroTail(fd, code, name, s);
+	TestArgszOversizedNonzeroTail(fd, code, name, s);
+	TestArgszOverrun(fd, code, name, s);
+	TestArgszUnknownFlags(fd, code, name, s);
+
+	tenstorrent_set_noc_cleanup bad_reserved = s;
+	bad_reserved.reserved0 = 1;
+	expect_errno(fd, code, name, &bad_reserved, EINVAL, "nonzero reserved0");
+}
+
+void TestSetPowerStateArgsz(int fd)
+{
+	tenstorrent_power_state s = {};
+	s.argsz = sizeof(s);
+
+	const auto code = TENSTORRENT_IOCTL_SET_POWER_STATE;
+	const char *name = "SET_POWER_STATE";
+
+	// These fail argsz/flags/reserved validation before reaching firmware.
+	TestArgszZero(fd, code, name, s);
+	TestArgszTooSmall(fd, code, name, s);
+	TestArgszOversizedNonzeroTail(fd, code, name, s);
+	TestArgszOverrun(fd, code, name, s);
+	TestArgszUnknownFlags(fd, code, name, s);
+
+	tenstorrent_power_state bad_reserved = s;
+	bad_reserved.reserved0 = 1;
+	expect_errno(fd, code, name, &bad_reserved, EINVAL, "nonzero reserved0");
+
+	// These need firmware to accept the power state. On WH without
+	// queue-capable firmware, send_arc_message fails and the ioctl
+	// returns -EINVAL even though argsz validation passed.
+	if (ioctl(fd, code, &s) == 0) {
+		TestArgszExact(fd, code, name, s);
+		TestArgszOversizedZeroTail(fd, code, name, s);
+	}
+}
+
+} // namespace
+
+void TestIoctlArgsz(const EnumeratedDevice &dev)
+{
+	DevFd dev_fd(dev.path);
+
+	TestSetNocCleanupArgsz(dev_fd.get());
+	TestSetPowerStateArgsz(dev_fd.get());
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -19,6 +19,7 @@ void TestLock(const EnumeratedDevice &dev);
 void TestHwmon(const EnumeratedDevice &dev);
 void TestIoctlOverrun(const EnumeratedDevice &dev);
 void TestIoctlZeroing(const EnumeratedDevice &dev);
+void TestIoctlArgsz(const EnumeratedDevice &dev);
 void TestMapPeerBar(const EnumeratedDevice &dev1, const EnumeratedDevice &dev2);
 void TestTlbs(const EnumeratedDevice &dev);
 void TestDeviceRelease(const EnumeratedDevice &dev);
@@ -50,6 +51,7 @@ int main(int argc, char *argv[])
         TestHwmon(d);
         TestIoctlOverrun(d);
         TestIoctlZeroing(d);
+        TestIoctlArgsz(d);
         TestTlbs(d);
         TestMappingsDebugfs(d);
         TestProcfsPids(d);


### PR DESCRIPTION
Establishes a forward-compatible ioctl design for tt-kmd based on the VFIO argsz pattern from the Linux kernel. New and existing argsz-style handlers now safely handle version skew between userspace and kernel in both directions.

* docs/ioctl-design.md: design strategy, developer recipe, legacy pattern reference
* chardev.c, ioctl.h: convert SET_NOC_CLEANUP and SET_POWER_STATE to the full pattern
* ~Compat shim for check_zeroed_user on pre-5.4 kernels~