### PR TITLE
Fix link retrain reliability on Gen5 x1 links

### DIFF
--- a/pcie.c
+++ b/pcie.c
@@ -195,15 +195,21 @@ static void pcie_clear_lbms(struct pci_dev *dev)
 //
 // This function retrains the link to full speed by setting Target Link Speed
 // to the minimum of device and bridge capabilities and triggering a retrain.
-// Sometimes multiple retrains are needed as the link steps up.
+// Multiple retrains may be needed as the link steps through intermediate
+// speeds (e.g. Gen1 -> Gen3 -> Gen4 -> Gen5). A 500ms pause between attempts
+// has been empirically determined to improve the reliability of the retrain.
 #define PCIE_LINK_RETRAIN_TIMEOUT_MS 1000
+#define PCIE_LINK_RETRAIN_MAX_ATTEMPTS 5
+#define PCIE_LINK_RETRAIN_SETTLE_MS 500
+#define PCIE_DEVICE_ACCESSIBLE_TIMEOUT_MS 500
 
 void pcie_retrain_link_to_max_speed(struct pci_dev *pdev)
 {
 	struct pci_dev *bridge = pci_upstream_bridge(pdev);
 	u32 lnkcap, bridge_lnkcap;
-	u16 lnksta, lnkctl2;
+	u16 lnksta, lnkctl2, vendor_id;
 	u8 dev_max_speed, bridge_max_speed, target_speed, current_speed;
+	ktime_t end_time;
 	int retrain_count;
 
 	if (!bridge)
@@ -211,17 +217,21 @@ void pcie_retrain_link_to_max_speed(struct pci_dev *pdev)
 
 	// Get max link speed from device's LnkCap.
 	pcie_capability_read_dword(pdev, PCI_EXP_LNKCAP, &lnkcap);
+	if (lnkcap == ~0u) {
+		dev_warn(&pdev->dev, "Device not accessible, skipping link retrain\n");
+		return;
+	}
 	dev_max_speed = FIELD_GET(PCI_EXP_LNKCAP_SLS, lnkcap);
 
 	// Get max link speed from bridge's LnkCap.
 	pcie_capability_read_dword(bridge, PCI_EXP_LNKCAP, &bridge_lnkcap);
 	bridge_max_speed = FIELD_GET(PCI_EXP_LNKCAP_SLS, bridge_lnkcap);
 
-	// Target speed is the minimum of device and bridge capabilities.
+	// Target is the minimum of device and bridge capabilities.
 	target_speed = min(dev_max_speed, bridge_max_speed);
 
-	// Get current link speed from LnkSta.
-	pcie_capability_read_word(pdev, PCI_EXP_LNKSTA, &lnksta);
+	// Read current link speed from the bridge.
+	pcie_capability_read_word(bridge, PCI_EXP_LNKSTA, &lnksta);
 	current_speed = FIELD_GET(PCI_EXP_LNKSTA_CLS, lnksta);
 
 	if (current_speed >= target_speed)
@@ -234,36 +244,42 @@ void pcie_retrain_link_to_max_speed(struct pci_dev *pdev)
 	lnkctl2 = (lnkctl2 & ~PCI_EXP_LNKCTL2_TLS) | FIELD_PREP(PCI_EXP_LNKCTL2_TLS, target_speed);
 	pcie_capability_write_word(bridge, PCI_EXP_LNKCTL2, lnkctl2);
 
-	// Retrain up to 3 times. Sometimes the link steps up gradually rather than
-	// jumping directly to max.
-	for (retrain_count = 0; retrain_count < 3; retrain_count++) {
-		// Clear LBMS before triggering retrain so we can detect completion.
+	// Retrain, waiting for completion each time.
+	for (retrain_count = 0; retrain_count < PCIE_LINK_RETRAIN_MAX_ATTEMPTS; retrain_count++) {
 		pcie_clear_lbms(bridge);
-
-		// Trigger link retrain.
 		pcie_capability_set_word(bridge, PCI_EXP_LNKCTL, PCI_EXP_LNKCTL_RL);
 
-		// Wait for retrain to complete by polling for LBMS=1.
 		if (!pcie_wait_for_lbms(bridge, PCIE_LINK_RETRAIN_TIMEOUT_MS)) {
-			dev_warn(&pdev->dev, "Timeout waiting for link retrain to complete\n");
+			dev_warn(&pdev->dev, "Timeout waiting for retrain\n");
 			break;
 		}
 
-		// Check new link speed.
-		pcie_capability_read_word(pdev, PCI_EXP_LNKSTA, &lnksta);
+		// Check new link speed from bridge.
+		pcie_capability_read_word(bridge, PCI_EXP_LNKSTA, &lnksta);
 		current_speed = FIELD_GET(PCI_EXP_LNKSTA_CLS, lnksta);
 
 		if (current_speed >= target_speed)
 			break;
 
-		dev_dbg(&pdev->dev, "Retrain %d: link at Gen%u, target Gen%u\n",
-			retrain_count + 1, current_speed, target_speed);
+		// Let equalization settle before the next attempt.
+		msleep(PCIE_LINK_RETRAIN_SETTLE_MS);
 	}
 
-	// Clear LBMS on both bridge and device so it won't be misinterpreted as a
-	// hardware failure by the kernel's pcie_failed_link_retrain().
+	// Clear LBMS so the kernel quirk won't re-trigger.
 	pcie_clear_lbms(bridge);
 	pcie_clear_lbms(pdev);
+
+	// Verify the device is accessible before returning.
+	end_time = ktime_add_ms(ktime_get(), PCIE_DEVICE_ACCESSIBLE_TIMEOUT_MS);
+	pci_read_config_word(pdev, PCI_VENDOR_ID, &vendor_id);
+	while (vendor_id != PCI_VENDOR_ID_TENSTORRENT) {
+		if (ktime_after(ktime_get(), end_time)) {
+			dev_warn(&pdev->dev, "Device not accessible after retrain\n");
+			break;
+		}
+		msleep(1);
+		pci_read_config_word(pdev, PCI_VENDOR_ID, &vendor_id);
+	}
 
 	if (current_speed >= target_speed)
 		dev_info(&pdev->dev, "Link retrained to Gen%u after %d attempt(s)\n", current_speed, retrain_count + 1);


### PR DESCRIPTION
The post-retrain speed check read PCI_EXP_LNKSTA from the device rather than the upstream bridge. During a retrain the device can be momentarily unreachable, causing the config read to return all-ones (0xFFFF). FIELD_GET extracts 0xF = 15 from this, which passes the "current_speed >= target_speed" check, so the function returns "success" while the device is actually inaccessible.

Fix by reading PCI_EXP_LNKSTA from the bridge, which is always accessible and reports the same negotiated link speed. Also:

- Add a 500ms pause between retrain attempts.
- Guard against all-ones on the device's LnkCap read at entry.
- Poll for device accessibility (vendor ID) after retraining.