### PR TITLE
Add asynchronous ARC message ioctl

### DIFF
--- a/blackhole.c
+++ b/blackhole.c
@@ -671,7 +671,7 @@ static int telemetry_probe(struct tenstorrent_device *tt_dev)
 	return 0;
 }
 
-static bool send_arc_message(struct blackhole_device *bh, struct arc_msg *msg)
+static int send_arc_message(struct blackhole_device *bh, struct arc_msg *msg)
 {
 	u32 boot_status;
 	u32 queue_ctrl_addr;
@@ -683,34 +683,32 @@ static bool send_arc_message(struct blackhole_device *bh, struct arc_msg *msg)
 	do {
 		boot_status = noc_read32(bh, ARC_X, ARC_Y, ARC_BOOT_STATUS, 0);
 		if (boot_status == 0xFFFFFFFFu)
-			return false; // NOC is hung
+			return -EIO;
 		if (boot_status & ARC_BOOT_STATUS_READY_FOR_MSG)
 			break;
 	} while (time_before(jiffies, timeout));
 
 	if (!(boot_status & ARC_BOOT_STATUS_READY_FOR_MSG))
-		return false;
+		return -ETIMEDOUT;
 
 	queue_ctrl_addr = noc_read32(bh, ARC_X, ARC_Y, ARC_MSG_QCB_PTR, 0);
 
-	if (csm_read32(bh, queue_ctrl_addr + 0, &queue_base) != 0)
-		return false;
-
-	if (csm_read32(bh, queue_ctrl_addr + 4, &queue_info) != 0)
-		return false;
+	if (csm_read32(bh, queue_ctrl_addr + 0, &queue_base) != 0 ||
+	    csm_read32(bh, queue_ctrl_addr + 4, &queue_info) != 0)
+		return -EIO;
 
 	num_entries = queue_info & 0xFF;
 
 	if (!arc_msg_push(&bh->tt, msg, queue_base, num_entries))
-		return false;
+		return -ETIMEDOUT;
 
 	// Trigger ARC interrupt
 	noc_write32(bh, ARC_X, ARC_Y, ARC_MSI_FIFO, 0, 0);
 
 	if (!arc_msg_pop(&bh->tt, msg, queue_base, num_entries))
-		return false;
+		return -ETIMEDOUT;
 
-	return msg->header == 0;
+	return (msg->header == 0) ? 0 : -EREMOTEIO;
 }
 
 static bool blackhole_reset(struct tenstorrent_device *tt_dev, u32 reset_flag)
@@ -723,7 +721,7 @@ static bool blackhole_reset(struct tenstorrent_device *tt_dev, u32 reset_flag)
 		u16 reset_arg = 3; // Argument for ASIC + M3 reset
 
 		msg.header = ARC_MSG_TYPE_TEST;
-		if (!send_arc_message(bh, &msg)) {
+		if (send_arc_message(bh, &msg) != 0) {
 			dev_warn(&tt_dev->pdev->dev, "Couldn't communicate with firmware; NOC is likely hung.\n");
 			return false;
 		}
@@ -808,13 +806,13 @@ static bool blackhole_init_hardware(struct tenstorrent_device *tt_dev)
 	pcie_set_readrq(pdev, MAX_MRRS);
 
 	msg.header = ARC_MSG_TYPE_ASIC_STATE0;
-	if (!send_arc_message(bh, &msg))
+	if (send_arc_message(bh, &msg) != 0)
 		dev_err(&tt_dev->pdev->dev, "Failed to send ARC message for A0 state\n");
 
 	memset(&msg, 0, sizeof(msg));
 	msg.header = ARC_MSG_TYPE_SET_WDT_TIMEOUT;
 	msg.payload[0] = 1000 * auto_reset_timeout; // Convert seconds to milliseconds
-	if (!send_arc_message(bh, &msg))
+	if (send_arc_message(bh, &msg) != 0)
 		dev_warn(&tt_dev->pdev->dev, "Failed to set ARC watchdog timeout (this is normal for old FW)\n");
 
 	return true;
@@ -882,7 +880,7 @@ static void blackhole_cleanup_hardware(struct tenstorrent_device *tt_dev)
 		return;
 
 	msg.header = ARC_MSG_TYPE_ASIC_STATE3;
-	if (!send_arc_message(bh, &msg))
+	if (send_arc_message(bh, &msg) != 0)
 		dev_err(&tt_dev->dev, "Failed to send ARC message for A3 state\n");
 }
 
@@ -976,17 +974,12 @@ static int blackhole_set_power_state(struct tenstorrent_device *tt_dev, struct t
 {
 	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
 	struct arc_msg msg = {0};
-	bool ok;
 
 	msg.header = ARC_MSG_TYPE_POWER_SETTING | (power_state->validity << 8) | (power_state->power_flags << 16);
 	BUILD_BUG_ON(sizeof(power_state->power_settings) != sizeof(msg.payload));
 	memcpy(msg.payload, power_state->power_settings, sizeof(msg.payload));
 
-	ok = send_arc_message(bh, &msg);
-	if (!ok)
-		return -EINVAL;
-
-	return 0;
+	return send_arc_message(bh, &msg);
 }
 
 struct tenstorrent_device_class blackhole_class = {

--- a/blackhole.c
+++ b/blackhole.c
@@ -1027,6 +1027,13 @@ static int blackhole_set_power_state(struct tenstorrent_device *tt_dev, struct t
 	return send_arc_message(bh, &msg);
 }
 
+static void blackhole_arc_msg_trigger(struct tenstorrent_device *tt_dev)
+{
+	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
+
+	noc_write32(bh, ARC_X, ARC_Y, ARC_MSI_FIFO, 0, 0);
+}
+
 struct tenstorrent_device_class blackhole_class = {
 	.name = "Blackhole",
 	.instance_size = sizeof(struct blackhole_device),
@@ -1052,4 +1059,5 @@ struct tenstorrent_device_class blackhole_class = {
 	.csm_read32 = blackhole_csm_read32,
 	.csm_write32 = blackhole_csm_write32,
 	.set_power_state = blackhole_set_power_state,
+	.arc_msg_trigger = blackhole_arc_msg_trigger,
 };

--- a/blackhole.c
+++ b/blackhole.c
@@ -809,9 +809,34 @@ static bool blackhole_init(struct tenstorrent_device *tt_dev)
 	return true;
 }
 
-static bool blackhole_init_hardware(struct tenstorrent_device *tt_dev)
+// Wait for ARC readiness and cache the message queue parameters.
+static void blackhole_init_arc_msg_queue(struct tenstorrent_device *tt_dev)
 {
 	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
+	unsigned long timeout = jiffies + msecs_to_jiffies(ARC_MSG_READY_MS);
+	u32 boot_status, queue_ctrl_addr, queue_base, queue_info;
+
+	do {
+		boot_status = noc_read32(bh, ARC_X, ARC_Y, ARC_BOOT_STATUS, 0);
+		if (boot_status == 0xFFFFFFFFu)
+			return; // NOC is hung
+		if (boot_status & ARC_BOOT_STATUS_READY_FOR_MSG)
+			break;
+	} while (time_before(jiffies, timeout));
+
+	if (!(boot_status & ARC_BOOT_STATUS_READY_FOR_MSG))
+		return;
+
+	queue_ctrl_addr = noc_read32(bh, ARC_X, ARC_Y, ARC_MSG_QCB_PTR, 0);
+	if (csm_read32(bh, queue_ctrl_addr, &queue_base) == 0 &&
+	    csm_read32(bh, queue_ctrl_addr + 4, &queue_info) == 0) {
+		tt_dev->arc_msg_queue_base = queue_base;
+		tt_dev->arc_msg_num_entries = queue_info & 0xFF;
+	}
+}
+
+static bool blackhole_init_hardware(struct tenstorrent_device *tt_dev)
+{
 	struct pci_dev *pdev = tt_dev->pdev;
 	struct arc_msg msg = { 0 };
 	bool is_galaxy = (pdev->subsystem_device == PCI_SUBSYSTEM_DEVICE_GALAXY);
@@ -832,6 +857,8 @@ static bool blackhole_init_hardware(struct tenstorrent_device *tt_dev)
 	msg.payload[0] = 1000 * auto_reset_timeout; // Convert seconds to milliseconds
 	if (send_arc_message(bh, &msg) != 0)
 		dev_warn(&tt_dev->pdev->dev, "Failed to set ARC watchdog timeout (this is normal for old FW)\n");
+
+	blackhole_init_arc_msg_queue(tt_dev);
 
 	return true;
 }

--- a/blackhole.c
+++ b/blackhole.c
@@ -678,37 +678,55 @@ static int send_arc_message(struct blackhole_device *bh, struct arc_msg *msg)
 	u32 queue_base;
 	u32 queue_info;
 	u32 num_entries;
-	unsigned long timeout = jiffies + msecs_to_jiffies(ARC_MSG_READY_MS);
+	int ret;
+	unsigned long timeout;
 
+	mutex_lock(&bh->tt.arc_msg_mutex);
+
+	timeout = jiffies + msecs_to_jiffies(ARC_MSG_READY_MS);
 	do {
 		boot_status = noc_read32(bh, ARC_X, ARC_Y, ARC_BOOT_STATUS, 0);
-		if (boot_status == 0xFFFFFFFFu)
-			return -EIO;
+		if (boot_status == 0xFFFFFFFFu) {
+			ret = -EIO; // NOC is hung
+			goto out;
+		}
 		if (boot_status & ARC_BOOT_STATUS_READY_FOR_MSG)
 			break;
 	} while (time_before(jiffies, timeout));
 
-	if (!(boot_status & ARC_BOOT_STATUS_READY_FOR_MSG))
-		return -ETIMEDOUT;
+	if (!(boot_status & ARC_BOOT_STATUS_READY_FOR_MSG)) {
+		ret = -ETIMEDOUT;
+		goto out;
+	}
 
 	queue_ctrl_addr = noc_read32(bh, ARC_X, ARC_Y, ARC_MSG_QCB_PTR, 0);
 
 	if (csm_read32(bh, queue_ctrl_addr + 0, &queue_base) != 0 ||
-	    csm_read32(bh, queue_ctrl_addr + 4, &queue_info) != 0)
-		return -EIO;
+	    csm_read32(bh, queue_ctrl_addr + 4, &queue_info) != 0) {
+		ret = -EIO;
+		goto out;
+	}
 
 	num_entries = queue_info & 0xFF;
 
-	if (!arc_msg_push(&bh->tt, msg, queue_base, num_entries))
-		return -ETIMEDOUT;
+	if (!arc_msg_push(&bh->tt, msg, queue_base, num_entries)) {
+		ret = -ETIMEDOUT;
+		goto out;
+	}
 
 	// Trigger ARC interrupt
 	noc_write32(bh, ARC_X, ARC_Y, ARC_MSI_FIFO, 0, 0);
 
-	if (!arc_msg_pop(&bh->tt, msg, queue_base, num_entries))
-		return -ETIMEDOUT;
+	if (!arc_msg_pop(&bh->tt, msg, queue_base, num_entries)) {
+		ret = -ETIMEDOUT;
+		goto out;
+	}
 
-	return (msg->header == 0) ? 0 : -EREMOTEIO;
+	ret = (msg->header == 0) ? 0 : -EREMOTEIO;
+
+out:
+	mutex_unlock(&bh->tt.arc_msg_mutex);
+	return ret;
 }
 
 static bool blackhole_reset(struct tenstorrent_device *tt_dev, u32 reset_flag)

--- a/blackhole.c
+++ b/blackhole.c
@@ -671,67 +671,8 @@ static int telemetry_probe(struct tenstorrent_device *tt_dev)
 	return 0;
 }
 
-static int send_arc_message(struct blackhole_device *bh, struct arc_msg *msg)
-{
-	u32 boot_status;
-	u32 queue_ctrl_addr;
-	u32 queue_base;
-	u32 queue_info;
-	u32 num_entries;
-	int ret;
-	unsigned long timeout;
-
-	mutex_lock(&bh->tt.arc_msg_mutex);
-
-	timeout = jiffies + msecs_to_jiffies(ARC_MSG_READY_MS);
-	do {
-		boot_status = noc_read32(bh, ARC_X, ARC_Y, ARC_BOOT_STATUS, 0);
-		if (boot_status == 0xFFFFFFFFu) {
-			ret = -EIO; // NOC is hung
-			goto out;
-		}
-		if (boot_status & ARC_BOOT_STATUS_READY_FOR_MSG)
-			break;
-	} while (time_before(jiffies, timeout));
-
-	if (!(boot_status & ARC_BOOT_STATUS_READY_FOR_MSG)) {
-		ret = -ETIMEDOUT;
-		goto out;
-	}
-
-	queue_ctrl_addr = noc_read32(bh, ARC_X, ARC_Y, ARC_MSG_QCB_PTR, 0);
-
-	if (csm_read32(bh, queue_ctrl_addr + 0, &queue_base) != 0 ||
-	    csm_read32(bh, queue_ctrl_addr + 4, &queue_info) != 0) {
-		ret = -EIO;
-		goto out;
-	}
-
-	num_entries = queue_info & 0xFF;
-
-	if (!arc_msg_push(&bh->tt, msg, queue_base, num_entries)) {
-		ret = -ETIMEDOUT;
-		goto out;
-	}
-
-	// Trigger ARC interrupt
-	noc_write32(bh, ARC_X, ARC_Y, ARC_MSI_FIFO, 0, 0);
-
-	if (!arc_msg_pop(&bh->tt, msg, queue_base, num_entries)) {
-		ret = -ETIMEDOUT;
-		goto out;
-	}
-
-	ret = (msg->header == 0) ? 0 : -EREMOTEIO;
-
-out:
-	mutex_unlock(&bh->tt.arc_msg_mutex);
-	return ret;
-}
-
 static bool blackhole_reset(struct tenstorrent_device *tt_dev, u32 reset_flag)
 {
-	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
 	struct pci_dev *pdev = tt_dev->pdev;
 
 	if (reset_flag == TENSTORRENT_RESET_DEVICE_ASIC_DMC_RESET) {
@@ -739,7 +680,7 @@ static bool blackhole_reset(struct tenstorrent_device *tt_dev, u32 reset_flag)
 		u16 reset_arg = 3; // Argument for ASIC + M3 reset
 
 		msg.header = ARC_MSG_TYPE_TEST;
-		if (send_arc_message(bh, &msg) != 0) {
+		if (arc_msg_send_sync(tt_dev, &msg, ARC_MSG_TIMEOUT_MS) != 0) {
 			dev_warn(&tt_dev->pdev->dev, "Couldn't communicate with firmware; NOC is likely hung.\n");
 			return false;
 		}
@@ -749,7 +690,7 @@ static bool blackhole_reset(struct tenstorrent_device *tt_dev, u32 reset_flag)
 		memset(&msg, 0, sizeof(msg));
 		msg.header = ARC_MSG_TYPE_TRIGGER_RESET;
 		msg.payload[0] = reset_arg;
-		send_arc_message(bh, &msg);
+		arc_msg_send_sync(tt_dev, &msg, ARC_MSG_TIMEOUT_MS);
 		return true; // Possibly a lie...
 	} else if (reset_flag == TENSTORRENT_RESET_DEVICE_ASIC_RESET) {
 		set_reset_marker(pdev);
@@ -848,17 +789,17 @@ static bool blackhole_init_hardware(struct tenstorrent_device *tt_dev)
 
 	pcie_set_readrq(pdev, MAX_MRRS);
 
+	blackhole_init_arc_msg_queue(tt_dev);
+
 	msg.header = ARC_MSG_TYPE_ASIC_STATE0;
-	if (send_arc_message(bh, &msg) != 0)
+	if (arc_msg_send_sync(tt_dev, &msg, ARC_MSG_TIMEOUT_MS) != 0)
 		dev_err(&tt_dev->pdev->dev, "Failed to send ARC message for A0 state\n");
 
 	memset(&msg, 0, sizeof(msg));
 	msg.header = ARC_MSG_TYPE_SET_WDT_TIMEOUT;
 	msg.payload[0] = 1000 * auto_reset_timeout; // Convert seconds to milliseconds
-	if (send_arc_message(bh, &msg) != 0)
+	if (arc_msg_send_sync(tt_dev, &msg, ARC_MSG_TIMEOUT_MS) != 0)
 		dev_warn(&tt_dev->pdev->dev, "Failed to set ARC watchdog timeout (this is normal for old FW)\n");
-
-	blackhole_init_arc_msg_queue(tt_dev);
 
 	return true;
 }
@@ -918,14 +859,13 @@ static void blackhole_cleanup_telemetry(struct tenstorrent_device *tt_dev)
 
 static void blackhole_cleanup_hardware(struct tenstorrent_device *tt_dev)
 {
-	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
 	struct arc_msg msg = { 0 };
 
 	if (tt_dev->detached)
 		return;
 
 	msg.header = ARC_MSG_TYPE_ASIC_STATE3;
-	if (send_arc_message(bh, &msg) != 0)
+	if (arc_msg_send_sync(tt_dev, &msg, ARC_MSG_TIMEOUT_MS) != 0)
 		dev_err(&tt_dev->dev, "Failed to send ARC message for A3 state\n");
 }
 
@@ -1017,14 +957,13 @@ static void blackhole_noc_write32(struct tenstorrent_device *tt_dev, u32 x, u32 
 
 static int blackhole_set_power_state(struct tenstorrent_device *tt_dev, struct tenstorrent_power_state *power_state)
 {
-	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
 	struct arc_msg msg = {0};
 
 	msg.header = ARC_MSG_TYPE_POWER_SETTING | (power_state->validity << 8) | (power_state->power_flags << 16);
 	BUILD_BUG_ON(sizeof(power_state->power_settings) != sizeof(msg.payload));
 	memcpy(msg.payload, power_state->power_settings, sizeof(msg.payload));
 
-	return send_arc_message(bh, &msg);
+	return arc_msg_send_sync(tt_dev, &msg, ARC_MSG_TIMEOUT_MS);
 }
 
 static void blackhole_arc_msg_trigger(struct tenstorrent_device *tt_dev)

--- a/chardev.c
+++ b/chardev.c
@@ -12,6 +12,8 @@
 #include <linux/cdev.h>
 #include <linux/slab.h>
 #include <linux/pci.h>
+#include <linux/delay.h>
+#include <linux/jiffies.h>
 #include <linux/uaccess.h>
 #include <linux/version.h>
 #include <linux/debugfs.h>
@@ -21,6 +23,7 @@
 #include "device.h"
 #include "enumerate.h"
 #include "ioctl.h"
+#include "msgqueue.h"
 #include "pcie.h"
 #include "memory.h"
 #include "module.h"
@@ -462,6 +465,138 @@ static long ioctl_set_power_state(struct chardev_private *priv, struct tenstorre
 	return tenstorrent_set_aggregated_power_state(tt_dev);
 }
 
+#define TENSTORRENT_ARC_MSG_OP_MASK (TENSTORRENT_ARC_MSG_POST | TENSTORRENT_ARC_MSG_POLL | TENSTORRENT_ARC_MSG_ABANDON)
+
+static long ioctl_arc_msg(struct chardev_private *priv, struct tenstorrent_arc_msg __user *arg)
+{
+	const size_t minsz = offsetofend(struct tenstorrent_arc_msg, message);
+	struct tenstorrent_device *tt_dev = priv->device;
+	struct chardev_msg *msg = &priv->msg;
+	struct tenstorrent_arc_msg data = {0};
+	size_t copysz;
+	u32 op;
+	long ret;
+
+	// Step 1: read argsz.
+	if (get_user(data.argsz, &arg->argsz))
+		return -EFAULT;
+
+	if (data.argsz < minsz)
+		return -EINVAL;
+
+	// Step 2: copy the overlapping portion.
+	copysz = min_t(size_t, data.argsz, sizeof(data));
+	if (copy_from_user(&data, arg, copysz))
+		return -EFAULT;
+
+	// Step 3: reject unknown trailing bytes.
+	if (data.argsz > sizeof(data)) {
+		if (check_zeroed_user((char __user *)arg + sizeof(data), data.argsz - sizeof(data)) <= 0)
+			return -E2BIG;
+	}
+
+	// Step 4: validate flags — reject unknown bits and invalid combinations.
+	op = data.flags & TENSTORRENT_ARC_MSG_OP_MASK;
+	if (data.flags != op)
+		return -EINVAL;
+
+	if (op == 0)
+		return -EINVAL;
+
+	// ABANDON is mutually exclusive with POST and POLL.
+	if ((op & TENSTORRENT_ARC_MSG_ABANDON) && (op & ~TENSTORRENT_ARC_MSG_ABANDON))
+		return -EINVAL;
+
+	// Step 5: validate reserved fields.
+	if (data.queue_index != 0)
+		return -EINVAL;
+
+	if (data.reserved0 != 0)
+		return -EINVAL;
+
+	// Check that the queue is available.
+	if (tt_dev->arc_msg_queue_base == 0)
+		return -EOPNOTSUPP;
+
+	mutex_lock(&tt_dev->arc_msg_mutex);
+
+	// ABANDON
+	if (op & TENSTORRENT_ARC_MSG_ABANDON) {
+		arc_msg_abandon(tt_dev, msg);
+		mutex_unlock(&tt_dev->arc_msg_mutex);
+		return 0;
+	}
+
+	// POST
+	if (op & TENSTORRENT_ARC_MSG_POST) {
+		if (msg->state != ARC_MSG_IDLE) {
+			mutex_unlock(&tt_dev->arc_msg_mutex);
+			return -EBUSY;
+		}
+
+		BUILD_BUG_ON(sizeof(data.message) != sizeof(msg->request));
+		memcpy(&msg->request, data.message, sizeof(msg->request));
+		msg->state = ARC_MSG_QUEUED;
+		list_add_tail(&msg->link, &tt_dev->arc_msg_queue);
+
+		arc_msg_pump(tt_dev);
+
+		// For POST|POLL, poll for up to the default timeout so fast messages
+		// complete in a single syscall.
+		if (op & TENSTORRENT_ARC_MSG_POLL) {
+			unsigned long deadline = jiffies + msecs_to_jiffies(ARC_MSG_TIMEOUT_MS);
+
+			while (msg->state != ARC_MSG_COMPLETED) {
+				mutex_unlock(&tt_dev->arc_msg_mutex);
+				usleep_range(100, 200);
+				mutex_lock(&tt_dev->arc_msg_mutex);
+				arc_msg_pump(tt_dev);
+				if (time_after(jiffies, deadline))
+					break;
+			}
+		}
+	}
+
+	// POLL (standalone or as part of POST|POLL)
+	if (op & TENSTORRENT_ARC_MSG_POLL) {
+		arc_msg_pump(tt_dev);
+
+		switch (msg->state) {
+		case ARC_MSG_COMPLETED:
+			memcpy(data.message, &msg->response, sizeof(data.message));
+			ret = (msg->response.header == 0) ? 0 : -EREMOTEIO;
+			msg->state = ARC_MSG_IDLE;
+			break;
+		case ARC_MSG_QUEUED:
+		case ARC_MSG_SUBMITTED:
+			ret = -EAGAIN;
+			break;
+		case ARC_MSG_IDLE:
+			// IDLE after standalone POLL means no message was posted.
+			// IDLE after POST|POLL can't happen (POST just set QUEUED).
+			ret = (op & TENSTORRENT_ARC_MSG_POST) ? -EAGAIN : -ESRCH;
+			break;
+		default:
+			ret = -EINVAL;
+			break;
+		}
+
+		mutex_unlock(&tt_dev->arc_msg_mutex);
+
+		// Copy response back on success or EREMOTEIO.
+		if (ret == 0 || ret == -EREMOTEIO) {
+			if (copy_to_user(arg, &data, copysz))
+				return -EFAULT;
+		}
+
+		return ret;
+	}
+
+	// POST-only (no POLL flag) — already done.
+	mutex_unlock(&tt_dev->arc_msg_mutex);
+	return 0;
+}
+
 static long tt_cdev_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
 {
 	struct chardev_private *priv = f->private_data;
@@ -561,6 +696,10 @@ static long tt_cdev_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
 			ret = ioctl_set_power_state(priv, (struct tenstorrent_power_state __user *)arg);
 			break;
 
+		case TENSTORRENT_IOCTL_ARC_MSG:
+			ret = ioctl_arc_msg(priv, (struct tenstorrent_arc_msg __user *)arg);
+			break;
+
 		default:
 			ret = -EINVAL;
 			break;
@@ -642,6 +781,7 @@ static int tt_cdev_open(struct inode *inode, struct file *file)
 	INIT_LIST_HEAD(&private_data->pinnings);
 	INIT_LIST_HEAD(&private_data->peer_mappings);
 	INIT_LIST_HEAD(&private_data->vma_list);
+	INIT_LIST_HEAD(&private_data->msg.link);
 	mutex_init(&private_data->vma_lock);
 
 	kref_get(&tt_dev->kref);
@@ -709,6 +849,11 @@ static int tt_cdev_release(struct inode *inode, struct file *file)
 	// Release all TLBs held by this file descriptor.
 	for_each_set_bit(bitpos, priv->tlbs, TENSTORRENT_MAX_INBOUND_TLBS)
 		tenstorrent_device_free_tlb(tt_dev, bitpos);
+
+	// Abandon any outstanding ARC message before freeing the fd.
+	mutex_lock(&tt_dev->arc_msg_mutex);
+	arc_msg_abandon(tt_dev, &priv->msg);
+	mutex_unlock(&tt_dev->arc_msg_mutex);
 
 	mutex_lock(&tt_dev->chardev_mutex);
 	list_del(&priv->open_fd);

--- a/chardev_private.h
+++ b/chardev_private.h
@@ -11,6 +11,7 @@
 #include <linux/refcount.h>
 
 #include "ioctl.h"
+#include "msgqueue.h"
 
 struct file;
 struct tenstorrent_device;
@@ -50,6 +51,21 @@ struct dmabuf {
 	int outbound_iatu_region;
 };
 
+enum arc_msg_state {
+	ARC_MSG_IDLE,
+	ARC_MSG_QUEUED,
+	ARC_MSG_SUBMITTED,
+	ARC_MSG_COMPLETED,
+};
+
+// Per-fd async ARC message state. Protected by device->arc_msg_mutex.
+struct chardev_msg {
+	enum arc_msg_state state;
+	struct arc_msg request;
+	struct arc_msg response;
+	struct list_head link;		// node in tenstorrent_device.arc_msg_queue
+};
+
 // This is our device-private data assocated with each open character device fd.
 // Accessed through struct file::private_data.
 struct chardev_private {
@@ -75,6 +91,8 @@ struct chardev_private {
 	struct tenstorrent_power_state power_state; // Power state for this fd
 
 	long open_reset_gen; // Reset generation at open time
+
+	struct chardev_msg msg;		// Async ARC message state
 };
 
 struct chardev_private *get_tenstorrent_priv(struct file *f);

--- a/device.h
+++ b/device.h
@@ -19,6 +19,7 @@
 
 #define MAX_TLB_KINDS 4
 
+struct chardev_msg;
 struct tenstorrent_device_class;
 
 struct tenstorrent_device {
@@ -64,6 +65,9 @@ struct tenstorrent_device {
 	struct mutex arc_msg_mutex;
 	u32 arc_msg_queue_base;		// CSM address of the message queue, 0 = not available
 	u32 arc_msg_num_entries;	// Number of slots per queue
+	struct list_head arc_msg_queue;	// SW queue of chardev_msg in QUEUED state
+	struct chardev_msg *arc_msg_inflight;	// Message currently in FW queue, or NULL
+	bool arc_msg_inflight_abandoned;	// Inflight message was abandoned by user
 };
 
 struct tlb_descriptor;

--- a/device.h
+++ b/device.h
@@ -96,6 +96,7 @@ struct tenstorrent_device_class {
 	int (*csm_read32)(struct tenstorrent_device *ttdev, u64 addr, u32 *value);
 	int (*csm_write32)(struct tenstorrent_device *ttdev, u64 addr, u32 value);
 	int (*set_power_state)(struct tenstorrent_device *ttdev, struct tenstorrent_power_state *power_state);
+	void (*arc_msg_trigger)(struct tenstorrent_device *ttdev);
 };
 
 void tenstorrent_device_put(struct tenstorrent_device *);

--- a/device.h
+++ b/device.h
@@ -60,6 +60,8 @@ struct tenstorrent_device {
 
 	struct attribute **telemetry_attrs;
 	struct attribute_group telemetry_group;
+
+	struct mutex arc_msg_mutex;
 };
 
 struct tlb_descriptor;

--- a/device.h
+++ b/device.h
@@ -62,6 +62,8 @@ struct tenstorrent_device {
 	struct attribute_group telemetry_group;
 
 	struct mutex arc_msg_mutex;
+	u32 arc_msg_queue_base;		// CSM address of the message queue, 0 = not available
+	u32 arc_msg_num_entries;	// Number of slots per queue
 };
 
 struct tlb_descriptor;

--- a/enumerate.c
+++ b/enumerate.c
@@ -261,6 +261,7 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 	memcpy(tt_dev->tlb_counts, device_class->tlb_counts, sizeof(tt_dev->tlb_counts));
 
 	mutex_init(&tt_dev->chardev_mutex);
+	mutex_init(&tt_dev->arc_msg_mutex);
 	mutex_init(&tt_dev->iatu_mutex);
 
 	// Use dma_address_bits from module parameter or device class for coherent

--- a/enumerate.c
+++ b/enumerate.c
@@ -262,6 +262,7 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 
 	mutex_init(&tt_dev->chardev_mutex);
 	mutex_init(&tt_dev->arc_msg_mutex);
+	INIT_LIST_HEAD(&tt_dev->arc_msg_queue);
 	mutex_init(&tt_dev->iatu_mutex);
 
 	// Use dma_address_bits from module parameter or device class for coherent

--- a/ioctl.h
+++ b/ioctl.h
@@ -27,6 +27,7 @@
 #define TENSTORRENT_IOCTL_CONFIGURE_TLB		_IO(TENSTORRENT_IOCTL_MAGIC, 13)
 #define TENSTORRENT_IOCTL_SET_NOC_CLEANUP		_IO(TENSTORRENT_IOCTL_MAGIC, 14)
 #define TENSTORRENT_IOCTL_SET_POWER_STATE		_IO(TENSTORRENT_IOCTL_MAGIC, 15)
+#define TENSTORRENT_IOCTL_ARC_MSG			_IO(TENSTORRENT_IOCTL_MAGIC, 16)
 
 // For tenstorrent_mapping.mapping_id. These are not array indices.
 #define TENSTORRENT_MAPPING_UNUSED		0
@@ -406,6 +407,52 @@ struct tenstorrent_power_state {
 #define TT_POWER_FLAG_TENSIX_ENABLE     (1U << 2) /* 1=Enable Tensix, 0=Clock Gate Tensix */
 #define TT_POWER_FLAG_L2CPU_ENABLE      (1U << 3) /* 1=Enable L2CPU,  0=Clock Gate L2CPU */
 	__u16 power_settings[14];
+};
+
+/**
+ * TENSTORRENT_IOCTL_ARC_MSG - Asynchronous ARC firmware messaging
+ *
+ * Asynchronous interface for communicating with the on-chip ARC management
+ * processor via the firmware message queue. Each fd may have at most one
+ * outstanding message. The @flags field selects the operation:
+ *
+ * POST: Submit @message to the firmware queue. Returns -EBUSY if this fd
+ *   already has an outstanding message.
+ *
+ * POLL: Check for a firmware response. On success or -EREMOTEIO, the
+ *   response is written into @message. Returns -EAGAIN if the message is
+ *   still pending, -ESRCH if no message is outstanding.
+ *
+ * POST|POLL: Submit and try to return the response in one call. A brief
+ *   kernel-side wait gives the firmware time to process fast operations.
+ *   Returns -EAGAIN if the response is not yet ready.
+ *
+ * ABANDON: Cancel any outstanding message for this fd. If the message is
+ *   already in the firmware queue, the response will be silently discarded
+ *   when it arrives. Always returns 0.
+ *
+ * On -EREMOTEIO the firmware returned a nonzero status; @message still
+ * contains the response (inspect message[0] for the firmware status code).
+ * On other errors @message is undefined.
+ *
+ * An outstanding message is implicitly abandoned when the fd is closed.
+ *
+ * @argsz: Must be at least sizeof(struct tenstorrent_arc_msg).
+ * @flags: TENSTORRENT_ARC_MSG_POST/POLL/ABANDON, bitwise OR. See above.
+ * @queue_index: Firmware queue to target. Must be 0 (reserved for future
+ *   multi-queue support).
+ * @reserved0: Must be 0.
+ * @message: 8 x u32 request (POST) or response (POLL).
+ */
+struct tenstorrent_arc_msg {
+	__u32 argsz;
+	__u32 flags;
+#define TENSTORRENT_ARC_MSG_POST	(1 << 0)
+#define TENSTORRENT_ARC_MSG_POLL	(1 << 1)
+#define TENSTORRENT_ARC_MSG_ABANDON	(1 << 2)
+	__u32 queue_index;
+	__u32 reserved0;
+	__u32 message[8];
 };
 
 #endif

--- a/msgqueue.c
+++ b/msgqueue.c
@@ -110,3 +110,86 @@ bool arc_msg_pop(struct tenstorrent_device *tt_dev, struct arc_msg *msg, u32 que
 
 	return true;
 }
+
+int arc_msg_try_push(struct tenstorrent_device *tt_dev, const struct arc_msg *msg)
+{
+	const struct tenstorrent_device_class *cls = tt_dev->dev_class;
+	u32 queue_base = tt_dev->arc_msg_queue_base;
+	u32 num_entries = tt_dev->arc_msg_num_entries;
+	u32 request_base = queue_base + ARC_MSG_QUEUE_HEADER_SIZE;
+	u32 wptr, rptr, num_occupied;
+	u32 slot, req_offset;
+	int i, ret;
+
+	if (queue_base == 0)
+		return -EOPNOTSUPP;
+
+	ret = cls->csm_read32(tt_dev, ARC_MSG_QUEUE_REQ_WPTR(queue_base), &wptr);
+	if (ret)
+		return ret;
+
+	ret = cls->csm_read32(tt_dev, ARC_MSG_QUEUE_REQ_RPTR(queue_base), &rptr);
+	if (ret)
+		return ret;
+
+	num_occupied = (wptr - rptr) % (2 * num_entries);
+	if (num_occupied >= num_entries)
+		return -EAGAIN;
+
+	slot = wptr % num_entries;
+	req_offset = slot * sizeof(struct arc_msg);
+	for (i = 0; i < 8; ++i) {
+		u32 addr = request_base + req_offset + (i * sizeof(u32));
+		u32 value = (i == 0) ? msg->header : msg->payload[i - 1];
+
+		ret = cls->csm_write32(tt_dev, addr, value);
+		if (ret)
+			return ret;
+	}
+
+	wptr = (wptr + 1) % (2 * num_entries);
+	return cls->csm_write32(tt_dev, ARC_MSG_QUEUE_REQ_WPTR(queue_base), wptr);
+}
+
+int arc_msg_try_pop(struct tenstorrent_device *tt_dev, struct arc_msg *msg)
+{
+	const struct tenstorrent_device_class *cls = tt_dev->dev_class;
+	u32 queue_base = tt_dev->arc_msg_queue_base;
+	u32 num_entries = tt_dev->arc_msg_num_entries;
+	u32 response_base = queue_base + ARC_MSG_QUEUE_HEADER_SIZE + (num_entries * sizeof(struct arc_msg));
+	u32 rptr, wptr, num_occupied;
+	u32 slot, response_offset;
+	int i, ret;
+
+	if (queue_base == 0)
+		return -EOPNOTSUPP;
+
+	ret = cls->csm_read32(tt_dev, ARC_MSG_QUEUE_RES_RPTR(queue_base), &rptr);
+	if (ret)
+		return ret;
+
+	ret = cls->csm_read32(tt_dev, ARC_MSG_QUEUE_RES_WPTR(queue_base), &wptr);
+	if (ret)
+		return ret;
+
+	num_occupied = (wptr - rptr) % (2 * num_entries);
+	if (num_occupied == 0)
+		return -EAGAIN;
+
+	slot = rptr % num_entries;
+	response_offset = slot * sizeof(struct arc_msg);
+	ret = cls->csm_read32(tt_dev, response_base + response_offset, &msg->header);
+	if (ret)
+		return ret;
+
+	for (i = 0; i < 7; ++i) {
+		u32 addr = response_base + response_offset + ((i + 1) * sizeof(u32));
+
+		ret = cls->csm_read32(tt_dev, addr, &msg->payload[i]);
+		if (ret)
+			return ret;
+	}
+
+	rptr = (rptr + 1) % (2 * num_entries);
+	return cls->csm_write32(tt_dev, ARC_MSG_QUEUE_RES_RPTR(queue_base), rptr);
+}

--- a/msgqueue.c
+++ b/msgqueue.c
@@ -11,108 +11,6 @@
 #include "chardev_private.h"
 #include "device.h"
 
-bool arc_msg_push(struct tenstorrent_device *tt_dev, const struct arc_msg *msg, u32 queue_base, u32 num_entries)
-{
-	const struct tenstorrent_device_class *cls = tt_dev->dev_class;
-	u32 request_base = queue_base + ARC_MSG_QUEUE_HEADER_SIZE;
-	unsigned long timeout;
-	u32 wptr;
-	u32 slot;
-	u32 req_offset;
-	int i;
-
-	if (cls->csm_read32(tt_dev, ARC_MSG_QUEUE_REQ_WPTR(queue_base), &wptr) != 0)
-		return false;
-
-	timeout = jiffies + msecs_to_jiffies(ARC_MSG_TIMEOUT_MS);
-	for (;;) {
-		u32 rptr;
-		u32 num_occupied;
-
-		if (cls->csm_read32(tt_dev, ARC_MSG_QUEUE_REQ_RPTR(queue_base), &rptr) != 0)
-			return false;
-
-		num_occupied = (wptr - rptr) % (2 * num_entries);
-		if (num_occupied < num_entries)
-			break;
-
-		if (time_after(jiffies, timeout)) {
-			dev_err(&tt_dev->pdev->dev, "Timeout waiting for space in ARC message queue\n");
-			return false;
-		}
-
-		usleep_range(100, 200);
-	}
-
-	slot = wptr % num_entries;
-	req_offset = slot * sizeof(struct arc_msg);
-	for (i = 0; i < 8; ++i) {
-		u32 addr = request_base + req_offset + (i * sizeof(u32));
-		u32 value = (i == 0) ? msg->header : msg->payload[i - 1];
-
-		if (cls->csm_write32(tt_dev, addr, value) != 0)
-			return false;
-	}
-
-	wptr = (wptr + 1) % (2 * num_entries);
-	if (cls->csm_write32(tt_dev, ARC_MSG_QUEUE_REQ_WPTR(queue_base), wptr) != 0)
-		return false;
-
-	return true;
-}
-
-bool arc_msg_pop(struct tenstorrent_device *tt_dev, struct arc_msg *msg, u32 queue_base, u32 num_entries)
-{
-	const struct tenstorrent_device_class *cls = tt_dev->dev_class;
-	u32 response_base = queue_base + ARC_MSG_QUEUE_HEADER_SIZE + (num_entries * sizeof(struct arc_msg));
-	unsigned long timeout;
-	u32 rptr;
-	u32 slot;
-	u32 response_offset;
-	int i;
-
-	if (cls->csm_read32(tt_dev, ARC_MSG_QUEUE_RES_RPTR(queue_base), &rptr) != 0)
-		return false;
-
-	timeout = jiffies + msecs_to_jiffies(ARC_MSG_TIMEOUT_MS);
-	for (;;) {
-		u32 wptr;
-		u32 num_occupied;
-
-		if (cls->csm_read32(tt_dev, ARC_MSG_QUEUE_RES_WPTR(queue_base), &wptr) != 0)
-			return false;
-
-		num_occupied = (wptr - rptr) % (2 * num_entries);
-		if (num_occupied > 0)
-			break;
-
-		if (time_after(jiffies, timeout)) {
-			dev_err(&tt_dev->pdev->dev, "Timeout waiting for ARC response\n");
-			return false;
-		}
-
-		usleep_range(100, 200);
-	}
-
-	slot = rptr % num_entries;
-	response_offset = slot * sizeof(struct arc_msg);
-	if (cls->csm_read32(tt_dev, response_base + response_offset, &msg->header) != 0)
-		return false;
-
-	for (i = 0; i < 7; ++i) {
-		u32 addr = response_base + response_offset + ((i + 1) * sizeof(u32));
-
-		if (cls->csm_read32(tt_dev, addr, &msg->payload[i]) != 0)
-			return false;
-	}
-
-	rptr = (rptr + 1) % (2 * num_entries);
-	if (cls->csm_write32(tt_dev, ARC_MSG_QUEUE_RES_RPTR(queue_base), rptr) != 0)
-		return false;
-
-	return true;
-}
-
 int arc_msg_try_push(struct tenstorrent_device *tt_dev, const struct arc_msg *msg)
 {
 	const struct tenstorrent_device_class *cls = tt_dev->dev_class;
@@ -294,4 +192,92 @@ void arc_msg_pump(struct tenstorrent_device *tt_dev)
 	list_del_init(&next->link);
 	next->state = ARC_MSG_SUBMITTED;
 	tt_dev->arc_msg_inflight = next;
+}
+
+// Synchronous ARC message send for internal kernel callers. Preempts the user
+// SW queue: only waits for the single message currently in the FW queue (if
+// any), then pushes directly. User QUEUED messages are not advanced — the
+// kernel message jumps ahead of them.
+//
+// timeout_ms covers the total wall time including draining any prior inflight
+// message and waiting for the firmware response.
+//
+// Returns 0 on success, -EREMOTEIO if FW returned a nonzero status, -ETIMEDOUT
+// if the deadline expired, or a negative errno from try_push/try_pop on CSM
+// failure.
+int arc_msg_send_sync(struct tenstorrent_device *tt_dev, struct arc_msg *msg, unsigned int timeout_ms)
+{
+	unsigned long deadline = jiffies + msecs_to_jiffies(timeout_ms);
+	struct arc_msg response;
+	int ret;
+
+	if (tt_dev->arc_msg_queue_base == 0)
+		return -EOPNOTSUPP;
+
+	mutex_lock(&tt_dev->arc_msg_mutex);
+
+	// Drain the inflight slot without advancing the SW queue. The mutex is held
+	// for the entire duration (drain + push + response wait) so no user message
+	// can interleave on the FW queue.
+	//
+	// We don't call arc_msg_pump() here because its step 2 would submit the
+	// next user message from the SW queue.
+	while (tt_dev->arc_msg_inflight || tt_dev->arc_msg_inflight_abandoned) {
+		ret = arc_msg_try_pop(tt_dev, &response);
+		if (ret == 0) {
+			struct chardev_msg *inflight = tt_dev->arc_msg_inflight;
+
+			if (tt_dev->arc_msg_inflight_abandoned) {
+				tt_dev->arc_msg_inflight_abandoned = false;
+			} else {
+				inflight->response = response;
+				inflight->state = ARC_MSG_COMPLETED;
+				tt_dev->arc_msg_inflight = NULL;
+			}
+			continue;
+		}
+		if (ret != -EAGAIN)
+			goto out;
+		if (time_after(jiffies, deadline)) {
+			ret = -ETIMEDOUT;
+			goto out;
+		}
+		usleep_range(100, 200);
+	}
+
+	// Push directly to FW, bypassing the SW queue.
+	ret = arc_msg_try_push(tt_dev, msg);
+	if (ret)
+		goto out;
+
+	tt_dev->dev_class->arc_msg_trigger(tt_dev);
+
+	// Poll for the response. The mutex is held throughout so no user message
+	// can interleave and steal our response from the FIFO.
+	//
+	// If we bail without popping (timeout or CSM error), the FW may still write
+	// a response later. Set the abandoned flag so the next caller drains it
+	// before using the queue.
+	for (;;) {
+		ret = arc_msg_try_pop(tt_dev, &response);
+		if (ret == 0)
+			break;
+		if (ret != -EAGAIN) {
+			tt_dev->arc_msg_inflight_abandoned = true;
+			goto out;
+		}
+		if (time_after(jiffies, deadline)) {
+			ret = -ETIMEDOUT;
+			tt_dev->arc_msg_inflight_abandoned = true;
+			goto out;
+		}
+		usleep_range(100, 200);
+	}
+
+	*msg = response;
+	ret = (response.header == 0) ? 0 : -EREMOTEIO;
+
+out:
+	mutex_unlock(&tt_dev->arc_msg_mutex);
+	return ret;
 }

--- a/msgqueue.c
+++ b/msgqueue.c
@@ -5,8 +5,10 @@
 
 #include <linux/jiffies.h>
 #include <linux/delay.h>
+#include <linux/list.h>
 #include <linux/pci.h>
 
+#include "chardev_private.h"
 #include "device.h"
 
 bool arc_msg_push(struct tenstorrent_device *tt_dev, const struct arc_msg *msg, u32 queue_base, u32 num_entries)
@@ -192,4 +194,104 @@ int arc_msg_try_pop(struct tenstorrent_device *tt_dev, struct arc_msg *msg)
 
 	rptr = (rptr + 1) % (2 * num_entries);
 	return cls->csm_write32(tt_dev, ARC_MSG_QUEUE_RES_RPTR(queue_base), rptr);
+}
+
+// Abandon any outstanding ARC message for this fd.  Must be called with
+// arc_msg_mutex held.  Safe to call in any state (no-op if IDLE).
+void arc_msg_abandon(struct tenstorrent_device *tt_dev, struct chardev_msg *msg)
+{
+	switch (msg->state) {
+	case ARC_MSG_IDLE:
+		break;
+	case ARC_MSG_QUEUED:
+		list_del_init(&msg->link);
+		msg->state = ARC_MSG_IDLE;
+		break;
+	case ARC_MSG_SUBMITTED:
+		// Message is in the FW queue.  We can't pull it back, so clear
+		// the inflight pointer and let the pump discard the response
+		// when it arrives.  The fd is free to POST a new message
+		// immediately.
+		tt_dev->arc_msg_inflight = NULL;
+		tt_dev->arc_msg_inflight_abandoned = true;
+		msg->state = ARC_MSG_IDLE;
+		break;
+	case ARC_MSG_COMPLETED:
+		msg->state = ARC_MSG_IDLE;
+		break;
+	}
+}
+
+// Pump the ARC message queue.  Must be called with arc_msg_mutex held.
+//
+// The driver keeps at most one message in the FW queue at a time.  This
+// simplifies response matching: the next response always belongs to
+// arc_msg_inflight.
+//
+// Step 1: if a message is in the FW queue, try to collect its response.
+//   - No response yet (-EAGAIN): nothing to do, return.
+//   - Response arrived: deliver it to the owning chardev_msg, or discard
+//     it if the user called ABANDON while it was in flight.
+//   - CSM error: the queue is in an unknown state.  Mark the message
+//     completed with a synthetic error header and clear the inflight slot
+//     so the queue can make progress.
+//
+// Step 2: if the FW queue is free and the SW queue is non-empty, take the
+//   head of the SW queue, push it to the FW queue, trigger the ARC
+//   interrupt, and mark it SUBMITTED.
+void arc_msg_pump(struct tenstorrent_device *tt_dev)
+{
+	struct chardev_msg *inflight = tt_dev->arc_msg_inflight;
+	struct arc_msg response;
+	struct chardev_msg *next;
+	int ret;
+
+	// Step 1: try to collect a response for the message in the FW queue.
+	// The FW queue is occupied if either inflight points to an owner or
+	// the abandoned flag is set (owner detached, response still pending).
+	if (inflight || tt_dev->arc_msg_inflight_abandoned) {
+		ret = arc_msg_try_pop(tt_dev, &response);
+
+		// FW hasn't responded yet — nothing more we can do this cycle.
+		if (ret == -EAGAIN)
+			return;
+
+		if (ret)
+			dev_err(&tt_dev->pdev->dev, "ARC message queue CSM error: %d\n", ret);
+
+		if (tt_dev->arc_msg_inflight_abandoned) {
+			// User called ABANDON (or closed the fd) while this message was in
+			// FW. The response (if any) is discarded. inflight is already NULL
+			// (cleared by the abandon operation).
+			tt_dev->arc_msg_inflight_abandoned = false;
+		} else if (ret == 0) {
+			// Normal completion — deliver the FW response.
+			inflight->response = response;
+			inflight->state = ARC_MSG_COMPLETED;
+			tt_dev->arc_msg_inflight = NULL;
+		} else {
+			// CSM error. We don't have a real response, but we must move the
+			// message to COMPLETED so POLL can report the failure rather than
+			// hanging on -EAGAIN.
+			inflight->response.header = 0xFFFFFFFF;
+			inflight->state = ARC_MSG_COMPLETED;
+			tt_dev->arc_msg_inflight = NULL;
+		}
+	}
+
+	// Step 2: submit the next queued message to the FW.
+	if (list_empty(&tt_dev->arc_msg_queue))
+		return;
+
+	next = list_first_entry(&tt_dev->arc_msg_queue, struct chardev_msg, link);
+
+	ret = arc_msg_try_push(tt_dev, &next->request);
+	if (ret)
+		return;
+
+	tt_dev->dev_class->arc_msg_trigger(tt_dev);
+
+	list_del_init(&next->link);
+	next->state = ARC_MSG_SUBMITTED;
+	tt_dev->arc_msg_inflight = next;
 }

--- a/msgqueue.h
+++ b/msgqueue.h
@@ -22,13 +22,11 @@ struct arc_msg {
 #define ARC_MSG_QUEUE_REQ_RPTR(base) ((base) + 0x10)
 #define ARC_MSG_QUEUE_RES_WPTR(base) ((base) + 0x14)
 
-bool arc_msg_push(struct tenstorrent_device *tt_dev, const struct arc_msg *msg, u32 queue_base, u32 num_entries);
-bool arc_msg_pop(struct tenstorrent_device *tt_dev, struct arc_msg *msg, u32 queue_base, u32 num_entries);
-
 int arc_msg_try_push(struct tenstorrent_device *tt_dev, const struct arc_msg *msg);
 int arc_msg_try_pop(struct tenstorrent_device *tt_dev, struct arc_msg *msg);
 
 void arc_msg_pump(struct tenstorrent_device *tt_dev);
 void arc_msg_abandon(struct tenstorrent_device *tt_dev, struct chardev_msg *msg);
+int arc_msg_send_sync(struct tenstorrent_device *tt_dev, struct arc_msg *msg, unsigned int timeout_ms);
 
 #endif

--- a/msgqueue.h
+++ b/msgqueue.h
@@ -24,4 +24,7 @@ struct arc_msg {
 bool arc_msg_push(struct tenstorrent_device *tt_dev, const struct arc_msg *msg, u32 queue_base, u32 num_entries);
 bool arc_msg_pop(struct tenstorrent_device *tt_dev, struct arc_msg *msg, u32 queue_base, u32 num_entries);
 
+int arc_msg_try_push(struct tenstorrent_device *tt_dev, const struct arc_msg *msg);
+int arc_msg_try_pop(struct tenstorrent_device *tt_dev, struct arc_msg *msg);
+
 #endif

--- a/msgqueue.h
+++ b/msgqueue.h
@@ -6,6 +6,7 @@
 
 #include <linux/types.h>
 
+struct chardev_msg;
 struct tenstorrent_device;
 
 struct arc_msg {
@@ -26,5 +27,8 @@ bool arc_msg_pop(struct tenstorrent_device *tt_dev, struct arc_msg *msg, u32 que
 
 int arc_msg_try_push(struct tenstorrent_device *tt_dev, const struct arc_msg *msg);
 int arc_msg_try_pop(struct tenstorrent_device *tt_dev, struct arc_msg *msg);
+
+void arc_msg_pump(struct tenstorrent_device *tt_dev);
+void arc_msg_abandon(struct tenstorrent_device *tt_dev, struct chardev_msg *msg);
 
 #endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,7 +8,7 @@ PROG := ttkmd_test
 TEST_SOURCES := get_driver_info.cpp get_device_info.cpp query_mappings.cpp \
 	dma_buf.cpp pin_pages.cpp config_space.cpp lock.cpp hwmon.cpp map_peer_bar.cpp \
 	ioctl_overrun.cpp ioctl_zeroing.cpp tlbs.cpp release.cpp mappings_debugfs.cpp \
-	procfs_pids.cpp
+	procfs_pids.cpp arc_msg.cpp
 
 CORE_SOURCES := enumeration.cpp util.cpp devfd.cpp main.cpp test_failure.cpp
 SOURCES := $(CORE_SOURCES) $(TEST_SOURCES)

--- a/test/arc_msg.cpp
+++ b/test/arc_msg.cpp
@@ -1,0 +1,486 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "ioctl.h"
+
+#include "enumeration.h"
+#include "devfd.h"
+#include "test_failure.h"
+
+namespace
+{
+
+constexpr uint32_t MSG_TYPE_TEST = 0x90;
+
+// Helper: call ARC_MSG ioctl with the given flags and message content.
+int arc_msg_ioctl(int fd, uint32_t flags, uint32_t *message)
+{
+    tenstorrent_arc_msg msg{};
+    msg.argsz = sizeof(msg);
+    msg.flags = flags;
+    msg.queue_index = 0;
+
+    if (message)
+        memcpy(msg.message, message, sizeof(msg.message));
+
+    int ret = ioctl(fd, TENSTORRENT_IOCTL_ARC_MSG, &msg);
+
+    if (message)
+        memcpy(message, msg.message, sizeof(msg.message));
+
+    return ret;
+}
+
+// Helper: POST|POLL a message and return the ioctl result.
+int post_poll(int fd, uint32_t *message)
+{
+    return arc_msg_ioctl(fd, TENSTORRENT_ARC_MSG_POST | TENSTORRENT_ARC_MSG_POLL, message);
+}
+
+// Helper: standalone POLL.
+int poll_msg(int fd, uint32_t *message)
+{
+    return arc_msg_ioctl(fd, TENSTORRENT_ARC_MSG_POLL, message);
+}
+
+// Helper: standalone POST.
+int post_msg(int fd, uint32_t *message)
+{
+    return arc_msg_ioctl(fd, TENSTORRENT_ARC_MSG_POST, message);
+}
+
+// Helper: ABANDON.
+int abandon_msg(int fd)
+{
+    return arc_msg_ioctl(fd, TENSTORRENT_ARC_MSG_ABANDON, nullptr);
+}
+
+// --- Ioctl contract tests ---
+
+void TestBadArgsz(int fd)
+{
+    tenstorrent_arc_msg msg{};
+    msg.argsz = 4;  // Too small
+    msg.flags = TENSTORRENT_ARC_MSG_POST | TENSTORRENT_ARC_MSG_POLL;
+    msg.message[0] = MSG_TYPE_TEST;
+
+    if (ioctl(fd, TENSTORRENT_IOCTL_ARC_MSG, &msg) == 0)
+        THROW_TEST_FAILURE("ARC_MSG should fail with bad argsz");
+
+    if (errno != EINVAL)
+        THROW_TEST_FAILURE("ARC_MSG bad argsz: expected EINVAL, got " + std::string(std::strerror(errno)));
+}
+
+void TestBadFlags(int fd)
+{
+    tenstorrent_arc_msg msg{};
+    msg.argsz = sizeof(msg);
+    msg.flags = 0xFF;
+    msg.message[0] = MSG_TYPE_TEST;
+
+    if (ioctl(fd, TENSTORRENT_IOCTL_ARC_MSG, &msg) == 0)
+        THROW_TEST_FAILURE("ARC_MSG should fail with unknown flags");
+
+    if (errno != EINVAL)
+        THROW_TEST_FAILURE("ARC_MSG bad flags: expected EINVAL, got " + std::string(std::strerror(errno)));
+}
+
+void TestZeroFlags(int fd)
+{
+    tenstorrent_arc_msg msg{};
+    msg.argsz = sizeof(msg);
+    msg.flags = 0;
+
+    if (ioctl(fd, TENSTORRENT_IOCTL_ARC_MSG, &msg) == 0)
+        THROW_TEST_FAILURE("ARC_MSG should fail with flags == 0");
+
+    if (errno != EINVAL)
+        THROW_TEST_FAILURE("ARC_MSG zero flags: expected EINVAL, got " + std::string(std::strerror(errno)));
+}
+
+void TestInvalidFlagCombinations(int fd)
+{
+    tenstorrent_arc_msg msg{};
+    msg.argsz = sizeof(msg);
+
+    // ABANDON | POST
+    msg.flags = TENSTORRENT_ARC_MSG_ABANDON | TENSTORRENT_ARC_MSG_POST;
+    if (ioctl(fd, TENSTORRENT_IOCTL_ARC_MSG, &msg) == 0)
+        THROW_TEST_FAILURE("ARC_MSG should fail with ABANDON|POST");
+    if (errno != EINVAL)
+        THROW_TEST_FAILURE("ARC_MSG ABANDON|POST: expected EINVAL, got " + std::string(std::strerror(errno)));
+
+    // ABANDON | POLL
+    msg.flags = TENSTORRENT_ARC_MSG_ABANDON | TENSTORRENT_ARC_MSG_POLL;
+    if (ioctl(fd, TENSTORRENT_IOCTL_ARC_MSG, &msg) == 0)
+        THROW_TEST_FAILURE("ARC_MSG should fail with ABANDON|POLL");
+    if (errno != EINVAL)
+        THROW_TEST_FAILURE("ARC_MSG ABANDON|POLL: expected EINVAL, got " + std::string(std::strerror(errno)));
+}
+
+void TestBadQueueIndex(int fd)
+{
+    tenstorrent_arc_msg msg{};
+    msg.argsz = sizeof(msg);
+    msg.flags = TENSTORRENT_ARC_MSG_POST | TENSTORRENT_ARC_MSG_POLL;
+    msg.queue_index = 1;
+    msg.message[0] = MSG_TYPE_TEST;
+
+    if (ioctl(fd, TENSTORRENT_IOCTL_ARC_MSG, &msg) == 0)
+        THROW_TEST_FAILURE("ARC_MSG should fail with queue_index != 0");
+
+    if (errno != EINVAL)
+        THROW_TEST_FAILURE("ARC_MSG bad queue_index: expected EINVAL, got " + std::string(std::strerror(errno)));
+}
+
+void TestPollWithNoMessage(int fd)
+{
+    uint32_t message[8] = {};
+    int ret = poll_msg(fd, message);
+
+    if (ret == 0)
+        THROW_TEST_FAILURE("POLL with no message should not return success");
+
+    if (errno != ESRCH)
+        THROW_TEST_FAILURE("POLL with no message: expected ESRCH, got " + std::string(std::strerror(errno)));
+}
+
+void TestAbandonWithNoMessage(int fd)
+{
+    if (abandon_msg(fd) != 0)
+        THROW_TEST_FAILURE("ABANDON with no message should succeed, got " + std::string(std::strerror(errno)));
+}
+
+void TestDoublePOST(int fd)
+{
+    uint32_t message[8] = {};
+    message[0] = MSG_TYPE_TEST;
+
+    // First POST should succeed.
+    if (post_msg(fd, message) != 0)
+        THROW_TEST_FAILURE("First POST failed: " + std::string(std::strerror(errno)));
+
+    // Second POST should fail with EBUSY.
+    message[0] = MSG_TYPE_TEST;
+    if (post_msg(fd, message) == 0)
+        THROW_TEST_FAILURE("Second POST should fail with EBUSY");
+
+    if (errno != EBUSY)
+        THROW_TEST_FAILURE("Double POST: expected EBUSY, got " + std::string(std::strerror(errno)));
+
+    // Clean up: poll until complete, then abandon as fallback.
+    for (int i = 0; i < 1000; i++) {
+        if (poll_msg(fd, message) == 0)
+            return;
+        usleep(100);
+    }
+    abandon_msg(fd);
+}
+
+// --- Hardware integration tests ---
+
+void TestPostPollEcho(int fd)
+{
+    for (uint32_t i = 1; i <= 10; i++) {
+        uint32_t message[8] = {};
+        message[0] = MSG_TYPE_TEST;
+        message[1] = i;
+
+        if (post_poll(fd, message) != 0)
+            THROW_TEST_FAILURE("POST|POLL echo failed: " + std::string(std::strerror(errno)));
+
+        if (message[0] != 0)
+            THROW_TEST_FAILURE("POST|POLL echo: expected header 0, got " + std::to_string(message[0]));
+
+        if (message[1] != i + 1)
+            THROW_TEST_FAILURE("POST|POLL echo: expected " + std::to_string(i + 1) + ", got " + std::to_string(message[1]));
+    }
+}
+
+void TestPostThenPoll(int fd)
+{
+    uint32_t message[8] = {};
+    message[0] = MSG_TYPE_TEST;
+    message[1] = 42;
+
+    if (post_msg(fd, message) != 0)
+        THROW_TEST_FAILURE("POST failed: " + std::string(std::strerror(errno)));
+
+    // Poll until complete.
+    for (int i = 0; i < 10000; i++) {
+        int ret = poll_msg(fd, message);
+        if (ret == 0) {
+            if (message[0] != 0)
+                THROW_TEST_FAILURE("POST then POLL: expected header 0, got " + std::to_string(message[0]));
+            if (message[1] != 43)
+                THROW_TEST_FAILURE("POST then POLL: expected 43, got " + std::to_string(message[1]));
+            return;
+        }
+        if (errno != EAGAIN)
+            THROW_TEST_FAILURE("POLL unexpected error: " + std::string(std::strerror(errno)));
+        usleep(100);
+    }
+
+    THROW_TEST_FAILURE("POST then POLL: timed out waiting for response");
+}
+
+void TestPollDrainsResponse(int fd)
+{
+    uint32_t message[8] = {};
+    message[0] = MSG_TYPE_TEST;
+
+    if (post_poll(fd, message) != 0)
+        THROW_TEST_FAILURE("POST|POLL failed: " + std::string(std::strerror(errno)));
+
+    // fd should now be IDLE.  POLL should return ESRCH.
+    if (poll_msg(fd, message) == 0)
+        THROW_TEST_FAILURE("POLL after drain should not succeed");
+    if (errno != ESRCH)
+        THROW_TEST_FAILURE("POLL after drain: expected ESRCH, got " + std::string(std::strerror(errno)));
+
+    // A new POST should succeed.
+    message[0] = MSG_TYPE_TEST;
+    if (post_poll(fd, message) != 0)
+        THROW_TEST_FAILURE("POST after drain failed: " + std::string(std::strerror(errno)));
+}
+
+void TestPostAbandonPost(int fd)
+{
+    uint32_t message[8] = {};
+    message[0] = MSG_TYPE_TEST;
+    message[1] = 100;
+
+    if (post_msg(fd, message) != 0)
+        THROW_TEST_FAILURE("First POST failed: " + std::string(std::strerror(errno)));
+
+    if (abandon_msg(fd) != 0)
+        THROW_TEST_FAILURE("ABANDON failed: " + std::string(std::strerror(errno)));
+
+    // Second POST should succeed now that the fd is back to IDLE.
+    message[0] = MSG_TYPE_TEST;
+    message[1] = 200;
+
+    if (post_poll(fd, message) != 0)
+        THROW_TEST_FAILURE("POST after ABANDON failed: " + std::string(std::strerror(errno)));
+
+    if (message[0] != 0)
+        THROW_TEST_FAILURE("POST after ABANDON: expected header 0, got " + std::to_string(message[0]));
+    if (message[1] != 201)
+        THROW_TEST_FAILURE("POST after ABANDON: expected 201, got " + std::to_string(message[1]));
+}
+
+void TestCloseAbandonsInflight(const EnumeratedDevice &dev)
+{
+    pid_t pid = fork();
+    if (pid == -1)
+        THROW_TEST_FAILURE("fork() failed");
+
+    if (pid == 0) {
+        // Child: open fd, POST a message, exit without polling or abandoning.
+        DevFd child_fd(dev.path);
+        uint32_t message[8] = {};
+        message[0] = MSG_TYPE_TEST;
+        post_msg(child_fd.get(), message);
+        _exit(0);
+    }
+
+    int status;
+    if (waitpid(pid, &status, 0) == -1)
+        THROW_TEST_FAILURE("waitpid() failed");
+
+    // Queue should be healthy.  Verify by sending a message on a new fd.
+    DevFd fd(dev.path);
+    uint32_t message[8] = {};
+    message[0] = MSG_TYPE_TEST;
+    message[1] = 99;
+
+    if (post_poll(fd.get(), message) != 0)
+        THROW_TEST_FAILURE("POST|POLL after child exit failed: " + std::string(std::strerror(errno)));
+
+    if (message[1] != 100)
+        THROW_TEST_FAILURE("POST|POLL after child exit: expected 100, got " + std::to_string(message[1]));
+}
+
+void TestUnrecognizedMessage(int fd)
+{
+    uint32_t message[8] = {};
+    message[0] = 0xFF;
+
+    if (post_poll(fd, message) == 0)
+        THROW_TEST_FAILURE("POST|POLL should fail for unrecognized message type");
+
+    if (errno != EREMOTEIO)
+        THROW_TEST_FAILURE("Unrecognized message: expected EREMOTEIO, got " + std::string(std::strerror(errno)));
+
+    // Response should be copied back with a nonzero header.
+    if (message[0] == 0)
+        THROW_TEST_FAILURE("Unrecognized message: expected nonzero response header");
+}
+
+void TestRecoveryAfterError(int fd)
+{
+    // Send an unrecognized message to provoke a FW error.
+    uint32_t message[8] = {};
+    message[0] = 0xFF;
+    post_poll(fd, message);
+
+    // Now send a valid echo and verify the queue still works.
+    memset(message, 0, sizeof(message));
+    message[0] = MSG_TYPE_TEST;
+    message[1] = 42;
+
+    if (post_poll(fd, message) != 0)
+        THROW_TEST_FAILURE("POST|POLL after error failed: " + std::string(std::strerror(errno)));
+
+    if (message[0] != 0)
+        THROW_TEST_FAILURE("Recovery: expected header 0, got " + std::to_string(message[0]));
+    if (message[1] != 43)
+        THROW_TEST_FAILURE("Recovery: expected 43, got " + std::to_string(message[1]));
+}
+
+void TestThroughput(int fd)
+{
+    int count = 0;
+    auto start = std::chrono::steady_clock::now();
+    auto end = start + std::chrono::seconds(1);
+
+    while (std::chrono::steady_clock::now() < end) {
+        uint32_t message[8] = {};
+        message[0] = MSG_TYPE_TEST;
+        message[1] = count;
+
+        if (post_poll(fd, message) != 0)
+            THROW_TEST_FAILURE("Throughput POST|POLL failed: " + std::string(std::strerror(errno)));
+
+        count++;
+    }
+
+    double sec = std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+    int rate = static_cast<int>(count / sec);
+
+    std::cout << "  ARC msg throughput: " << rate << " msg/s"
+              << " (" << count << " in " << std::fixed << std::setprecision(3) << sec << "s)\n";
+
+    if (rate < 1000)
+        THROW_TEST_FAILURE("ARC msg throughput too low: " + std::to_string(rate) + " msg/s");
+}
+
+void TestAbandonBeforeSubmit(const EnumeratedDevice &dev)
+{
+    // Use two fds: fd2 occupies the inflight slot so fd1's message stays
+    // QUEUED in the SW queue.  Abandon fd1's message while still QUEUED.
+    DevFd fd1(dev.path);
+    DevFd fd2(dev.path);
+
+    for (int i = 0; i < 100; i++) {
+        // fd2 posts to occupy the inflight slot.
+        uint32_t msg2[8] = {};
+        msg2[0] = MSG_TYPE_TEST;
+        if (post_msg(fd2.get(), msg2) != 0)
+            THROW_TEST_FAILURE("fd2 POST failed: " + std::string(std::strerror(errno)));
+
+        // fd1 posts — should stay QUEUED behind fd2's message.
+        uint32_t msg1[8] = {};
+        msg1[0] = MSG_TYPE_TEST;
+        if (post_msg(fd1.get(), msg1) != 0) {
+            // Clean up fd2.
+            uint32_t drain[8] = {};
+            post_poll(fd2.get(), drain);
+            THROW_TEST_FAILURE("fd1 POST failed: " + std::string(std::strerror(errno)));
+        }
+
+        // Abandon fd1's message while it's still in the SW queue.
+        if (abandon_msg(fd1.get()) != 0)
+            THROW_TEST_FAILURE("ABANDON of QUEUED message failed: " + std::string(std::strerror(errno)));
+
+        // Drain fd2's message.
+        uint32_t drain[8] = {};
+        for (int j = 0; j < 10000; j++) {
+            if (poll_msg(fd2.get(), drain) == 0)
+                break;
+            if (errno != EAGAIN)
+                THROW_TEST_FAILURE("fd2 POLL error: " + std::string(std::strerror(errno)));
+            usleep(100);
+        }
+    }
+}
+
+void TestRapidPostAbandon(int fd)
+{
+    for (int i = 0; i < 10000; i++) {
+        uint32_t message[8] = {};
+        message[0] = MSG_TYPE_TEST;
+        message[1] = i;
+
+        if (post_msg(fd, message) != 0)
+            THROW_TEST_FAILURE("Rapid POST failed at " + std::to_string(i) + ": " + std::string(std::strerror(errno)));
+
+        if (abandon_msg(fd) != 0)
+            THROW_TEST_FAILURE("Rapid ABANDON failed at " + std::to_string(i) + ": " + std::string(std::strerror(errno)));
+    }
+
+    // Verify the fd is still healthy after the storm.
+    uint32_t message[8] = {};
+    message[0] = MSG_TYPE_TEST;
+    message[1] = 0xDEAD;
+
+    if (post_poll(fd, message) != 0)
+        THROW_TEST_FAILURE("POST|POLL after rapid abandon storm failed: " + std::string(std::strerror(errno)));
+
+    if (message[1] != 0xDEAE)
+        THROW_TEST_FAILURE("Echo mismatch after storm: expected 0xDEAE, got " + std::to_string(message[1]));
+}
+
+} // namespace
+
+void TestArcMsg(const EnumeratedDevice &dev)
+{
+    DevFd dev_fd(dev.path);
+
+    // Ioctl contract tests — these exercise the validation layer and work
+    // regardless of whether the FW supports message queues.
+    TestBadArgsz(dev_fd.get());
+    TestBadFlags(dev_fd.get());
+    TestZeroFlags(dev_fd.get());
+    TestInvalidFlagCombinations(dev_fd.get());
+    TestBadQueueIndex(dev_fd.get());
+
+    // Probe: if the FW doesn't support message queues, skip the rest.
+    {
+        uint32_t message[8] = {};
+        message[0] = MSG_TYPE_TEST;
+
+        if (post_poll(dev_fd.get(), message) != 0) {
+            if (errno == EOPNOTSUPP) {
+                std::cout << "  ARC message queue not available, skipping HW tests.\n";
+                return;
+            }
+            THROW_TEST_FAILURE("ARC_MSG probe failed: " + std::string(std::strerror(errno)));
+        }
+    }
+
+    TestPollWithNoMessage(dev_fd.get());
+    TestAbandonWithNoMessage(dev_fd.get());
+    TestPostPollEcho(dev_fd.get());
+    TestPostThenPoll(dev_fd.get());
+    TestPollDrainsResponse(dev_fd.get());
+    TestDoublePOST(dev_fd.get());
+    TestPostAbandonPost(dev_fd.get());
+    TestUnrecognizedMessage(dev_fd.get());
+    TestRecoveryAfterError(dev_fd.get());
+    TestCloseAbandonsInflight(dev);
+    TestThroughput(dev_fd.get());
+    TestAbandonBeforeSubmit(dev);
+    TestRapidPostAbandon(dev_fd.get());
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -24,6 +24,7 @@ void TestTlbs(const EnumeratedDevice &dev);
 void TestDeviceRelease(const EnumeratedDevice &dev);
 void TestMappingsDebugfs(const EnumeratedDevice &dev);
 void TestProcfsPids(const EnumeratedDevice &dev);
+void TestArcMsg(const EnumeratedDevice &dev);
 
 int main(int argc, char *argv[])
 {
@@ -54,6 +55,7 @@ int main(int argc, char *argv[])
         TestMappingsDebugfs(d);
         TestProcfsPids(d);
         TestDeviceRelease(d);
+        TestArcMsg(d);
 
         at_least_one_device = true;
     }

--- a/wormhole.c
+++ b/wormhole.c
@@ -252,73 +252,6 @@ static bool wormhole_read_fw_telemetry_offset(u8 __iomem *reset_unit_regs, u32 *
 	return true;
 }
 
-static int send_arc_message(struct wormhole_device *wh, struct arc_msg *msg)
-{
-	u8 __iomem *regs = wh->bar4_mapping + RESET_UNIT_START;
-	u32 qcb_ptr;
-	u32 queue_base;
-	u32 queue_info;
-	u32 num_entries;
-	u32 arc_misc_cntl;
-	int ret;
-	unsigned long timeout;
-
-	mutex_lock(&wh->tt.arc_msg_mutex);
-
-	// Wait for ARC L2 to be running.
-	timeout = jiffies + msecs_to_jiffies(ARC_MSG_READY_MS);
-	do {
-		if (arc_l2_is_running(regs))
-			break;
-	} while (time_before(jiffies, timeout));
-
-	if (!arc_l2_is_running(regs)) {
-		ret = -ETIMEDOUT;
-		goto out;
-	}
-
-	// Read QCB pointer from NOC_NODEID_X_1. Zero means FW doesn't support queues.
-	qcb_ptr = ioread32(wh->bar4_mapping + ARC_MSG_QCB_PTR);
-	if (qcb_ptr == 0) {
-		dev_warn_once(&wh->tt.pdev->dev, "ARC message queue not available (this is normal for old FW)\n");
-		ret = -EOPNOTSUPP;
-		goto out;
-	}
-	if (!is_range_within_csm(qcb_ptr, sizeof(u32))) {
-		ret = -EIO;
-		goto out;
-	}
-
-	if (csm_read32(wh, qcb_ptr + 0, &queue_base) != 0 ||
-	    csm_read32(wh, qcb_ptr + 4, &queue_info) != 0) {
-		ret = -EIO;
-		goto out;
-	}
-
-	queue_base += ARC_CSM_BASE;
-	num_entries = queue_info & 0xFF;
-
-	if (!arc_msg_push(&wh->tt, msg, queue_base, num_entries)) {
-		ret = -ETIMEDOUT;
-		goto out;
-	}
-
-	// Trigger ARC interrupt via IRQ0.
-	arc_misc_cntl = ioread32(regs + ARC_MISC_CNTL_REG);
-	iowrite32(arc_misc_cntl | ARC_MISC_CNTL_IRQ0_MASK, regs + ARC_MISC_CNTL_REG);
-
-	if (!arc_msg_pop(&wh->tt, msg, queue_base, num_entries)) {
-		ret = -ETIMEDOUT;
-		goto out;
-	}
-
-	ret = (msg->header == 0) ? 0 : -EREMOTEIO;
-
-out:
-	mutex_unlock(&wh->tt.arc_msg_mutex);
-	return ret;
-}
-
 static bool wormhole_shutdown_firmware(struct pci_dev *pdev, u8 __iomem *reset_unit_regs)
 {
 	if (is_hardware_hung(pdev, reset_unit_regs))
@@ -1153,16 +1086,17 @@ static int wormhole_csm_write32(struct tenstorrent_device *tt_dev, u64 addr, u32
 	return csm_write32(tt_dev_to_wh_dev(tt_dev), addr, value);
 }
 
+#define WH_POWER_MSG_TIMEOUT_MS 2500
+
 static int wormhole_set_power_state(struct tenstorrent_device *tt_dev, struct tenstorrent_power_state *power_state)
 {
-	struct wormhole_device *wh = tt_dev_to_wh_dev(tt_dev);
 	struct arc_msg msg = {0};
 
 	msg.header = ARC_MSG_TYPE_POWER_SETTING | (power_state->validity << 8) | (power_state->power_flags << 16);
 	BUILD_BUG_ON(sizeof(power_state->power_settings) != sizeof(msg.payload));
 	memcpy(msg.payload, power_state->power_settings, sizeof(msg.payload));
 
-	return send_arc_message(wh, &msg);
+	return arc_msg_send_sync(tt_dev, &msg, WH_POWER_MSG_TIMEOUT_MS);
 }
 
 static void wormhole_arc_msg_trigger(struct tenstorrent_device *tt_dev)

--- a/wormhole.c
+++ b/wormhole.c
@@ -1165,6 +1165,16 @@ static int wormhole_set_power_state(struct tenstorrent_device *tt_dev, struct te
 	return send_arc_message(wh, &msg);
 }
 
+static void wormhole_arc_msg_trigger(struct tenstorrent_device *tt_dev)
+{
+	struct wormhole_device *wh = tt_dev_to_wh_dev(tt_dev);
+	u8 __iomem *regs = wh->bar4_mapping + RESET_UNIT_START;
+	u32 arc_misc_cntl;
+
+	arc_misc_cntl = ioread32(regs + ARC_MISC_CNTL_REG);
+	iowrite32(arc_misc_cntl | ARC_MISC_CNTL_IRQ0_MASK, regs + ARC_MISC_CNTL_REG);
+}
+
 struct tenstorrent_device_class wormhole_class = {
 	.name = "Wormhole",
 	.instance_size = sizeof(struct wormhole_device),
@@ -1191,4 +1201,5 @@ struct tenstorrent_device_class wormhole_class = {
 	.csm_read32 = wormhole_csm_read32,
 	.csm_write32 = wormhole_csm_write32,
 	.set_power_state = wormhole_set_power_state,
+	.arc_msg_trigger = wormhole_arc_msg_trigger,
 };

--- a/wormhole.c
+++ b/wormhole.c
@@ -260,7 +260,10 @@ static int send_arc_message(struct wormhole_device *wh, struct arc_msg *msg)
 	u32 queue_info;
 	u32 num_entries;
 	u32 arc_misc_cntl;
+	int ret;
 	unsigned long timeout;
+
+	mutex_lock(&wh->tt.arc_msg_mutex);
 
 	// Wait for ARC L2 to be running.
 	timeout = jiffies + msecs_to_jiffies(ARC_MSG_READY_MS);
@@ -269,36 +272,51 @@ static int send_arc_message(struct wormhole_device *wh, struct arc_msg *msg)
 			break;
 	} while (time_before(jiffies, timeout));
 
-	if (!arc_l2_is_running(regs))
-		return -ETIMEDOUT;
+	if (!arc_l2_is_running(regs)) {
+		ret = -ETIMEDOUT;
+		goto out;
+	}
 
 	// Read QCB pointer from NOC_NODEID_X_1. Zero means FW doesn't support queues.
 	qcb_ptr = ioread32(wh->bar4_mapping + ARC_MSG_QCB_PTR);
 	if (qcb_ptr == 0) {
 		dev_warn_once(&wh->tt.pdev->dev, "ARC message queue not available (this is normal for old FW)\n");
-		return -EOPNOTSUPP;
+		ret = -EOPNOTSUPP;
+		goto out;
 	}
-	if (!is_range_within_csm(qcb_ptr, sizeof(u32)))
-		return -EIO;
+	if (!is_range_within_csm(qcb_ptr, sizeof(u32))) {
+		ret = -EIO;
+		goto out;
+	}
 
 	if (csm_read32(wh, qcb_ptr + 0, &queue_base) != 0 ||
-	    csm_read32(wh, qcb_ptr + 4, &queue_info) != 0)
-		return -EIO;
+	    csm_read32(wh, qcb_ptr + 4, &queue_info) != 0) {
+		ret = -EIO;
+		goto out;
+	}
 
 	queue_base += ARC_CSM_BASE;
 	num_entries = queue_info & 0xFF;
 
-	if (!arc_msg_push(&wh->tt, msg, queue_base, num_entries))
-		return -ETIMEDOUT;
+	if (!arc_msg_push(&wh->tt, msg, queue_base, num_entries)) {
+		ret = -ETIMEDOUT;
+		goto out;
+	}
 
 	// Trigger ARC interrupt via IRQ0.
 	arc_misc_cntl = ioread32(regs + ARC_MISC_CNTL_REG);
 	iowrite32(arc_misc_cntl | ARC_MISC_CNTL_IRQ0_MASK, regs + ARC_MISC_CNTL_REG);
 
-	if (!arc_msg_pop(&wh->tt, msg, queue_base, num_entries))
-		return -ETIMEDOUT;
+	if (!arc_msg_pop(&wh->tt, msg, queue_base, num_entries)) {
+		ret = -ETIMEDOUT;
+		goto out;
+	}
 
-	return (msg->header == 0) ? 0 : -EREMOTEIO;
+	ret = (msg->header == 0) ? 0 : -EREMOTEIO;
+
+out:
+	mutex_unlock(&wh->tt.arc_msg_mutex);
+	return ret;
 }
 
 static bool wormhole_shutdown_firmware(struct pci_dev *pdev, u8 __iomem *reset_unit_regs)

--- a/wormhole.c
+++ b/wormhole.c
@@ -836,6 +836,9 @@ fail_bar2:
 
 static bool wormhole_init_hardware(struct tenstorrent_device *tt_dev) {
 	struct wormhole_device *wh_dev = tt_dev_to_wh_dev(tt_dev);
+	u32 qcb_ptr;
+	u32 queue_base;
+	u32 queue_info;
 
 	map_bar4_to_system_registers(wh_dev);
 
@@ -845,6 +848,17 @@ static bool wormhole_init_hardware(struct tenstorrent_device *tt_dev) {
 		update_device_index(wh_dev);
 		wormhole_complete_pcie_init(&wh_dev->tt, reset_unit_regs(wh_dev));
 		wormhole_send_arc_fw_message_with_args(reset_unit_regs(wh_dev), WH_FW_MSG_UPDATE_M3_AUTO_RESET_TIMEOUT, auto_reset_timeout, 0, 10000, NULL);
+
+		// Cache the message queue parameters for the async pump.
+		qcb_ptr = ioread32(wh_dev->bar4_mapping + ARC_MSG_QCB_PTR);
+		if (qcb_ptr != 0 && is_range_within_csm(qcb_ptr, sizeof(u32)) &&
+		    csm_read32(wh_dev, qcb_ptr, &queue_base) == 0 &&
+		    csm_read32(wh_dev, qcb_ptr + 4, &queue_info) == 0) {
+			tt_dev->arc_msg_queue_base = queue_base + ARC_CSM_BASE;
+			tt_dev->arc_msg_num_entries = queue_info & 0xFF;
+		} else {
+			dev_warn_once(&tt_dev->pdev->dev, "ARC message queue not available (this is normal for old FW)\n");
+		}
 	}
 
 	return true;

--- a/wormhole.c
+++ b/wormhole.c
@@ -252,7 +252,7 @@ static bool wormhole_read_fw_telemetry_offset(u8 __iomem *reset_unit_regs, u32 *
 	return true;
 }
 
-static bool send_arc_message(struct wormhole_device *wh, struct arc_msg *msg)
+static int send_arc_message(struct wormhole_device *wh, struct arc_msg *msg)
 {
 	u8 __iomem *regs = wh->bar4_mapping + RESET_UNIT_START;
 	u32 qcb_ptr;
@@ -270,37 +270,35 @@ static bool send_arc_message(struct wormhole_device *wh, struct arc_msg *msg)
 	} while (time_before(jiffies, timeout));
 
 	if (!arc_l2_is_running(regs))
-		return false;
+		return -ETIMEDOUT;
 
 	// Read QCB pointer from NOC_NODEID_X_1. Zero means FW doesn't support queues.
 	qcb_ptr = ioread32(wh->bar4_mapping + ARC_MSG_QCB_PTR);
 	if (qcb_ptr == 0) {
 		dev_warn_once(&wh->tt.pdev->dev, "ARC message queue not available (this is normal for old FW)\n");
-		return false;
+		return -EOPNOTSUPP;
 	}
 	if (!is_range_within_csm(qcb_ptr, sizeof(u32)))
-		return false;
+		return -EIO;
 
-	if (csm_read32(wh, qcb_ptr + 0, &queue_base) != 0)
-		return false;
-
-	if (csm_read32(wh, qcb_ptr + 4, &queue_info) != 0)
-		return false;
+	if (csm_read32(wh, qcb_ptr + 0, &queue_base) != 0 ||
+	    csm_read32(wh, qcb_ptr + 4, &queue_info) != 0)
+		return -EIO;
 
 	queue_base += ARC_CSM_BASE;
 	num_entries = queue_info & 0xFF;
 
 	if (!arc_msg_push(&wh->tt, msg, queue_base, num_entries))
-		return false;
+		return -ETIMEDOUT;
 
 	// Trigger ARC interrupt via IRQ0.
 	arc_misc_cntl = ioread32(regs + ARC_MISC_CNTL_REG);
 	iowrite32(arc_misc_cntl | ARC_MISC_CNTL_IRQ0_MASK, regs + ARC_MISC_CNTL_REG);
 
 	if (!arc_msg_pop(&wh->tt, msg, queue_base, num_entries))
-		return false;
+		return -ETIMEDOUT;
 
-	return msg->header == 0;
+	return (msg->header == 0) ? 0 : -EREMOTEIO;
 }
 
 static bool wormhole_shutdown_firmware(struct pci_dev *pdev, u8 __iomem *reset_unit_regs)
@@ -1127,18 +1125,12 @@ static int wormhole_set_power_state(struct tenstorrent_device *tt_dev, struct te
 {
 	struct wormhole_device *wh = tt_dev_to_wh_dev(tt_dev);
 	struct arc_msg msg = {0};
-	bool ok;
 
 	msg.header = ARC_MSG_TYPE_POWER_SETTING | (power_state->validity << 8) | (power_state->power_flags << 16);
 	BUILD_BUG_ON(sizeof(power_state->power_settings) != sizeof(msg.payload));
 	memcpy(msg.payload, power_state->power_settings, sizeof(msg.payload));
 
-	ok = send_arc_message(wh, &msg);
-
-	if (!ok)
-		return -EINVAL;
-
-	return 0;
+	return send_arc_message(wh, &msg);
 }
 
 struct tenstorrent_device_class wormhole_class = {


### PR DESCRIPTION
## Summary
Add `TENSTORRENT_IOCTL_ARC_MSG`, an asynchronous ioctl for userspace to communicate with the ARC management processor via the firmware message queue. A single ioctl with flag-selected operations (POST, POLL, ABANDON) replaces the synchronous `SEND_ARC_MSG` from #216. POST|POLL provides a synchronous fast path for callers that don't need async. It polls in-kernel for up to 100ms, catching most FW responses in a single syscall.

## Changes
- **Add `ARC_MSG` ioctl** — follows the argsz extensibility pattern.
  POST queues a message, POLL checks for a response, ABANDON cancels.
  POST|POLL combines both for a synchronous fast path. Each fd may have at most one outstanding message.
- **Add pump function** — drives messages between a per-device software queue and the firmware queue. Single-inflight design simplifies response matching. Kernel callers preempt the user queue.
- **Refactor `send_arc_message()`** in blackhole.c and wormhole.c from `bool` to `int` with specific error codes (`-EIO`, `-ETIMEDOUT`, `-EOPNOTSUPP`, `-EREMOTEIO`).
- **Add `arc_msg_send_sync()`** — synchronous wrapper for internal driver callers (power state, reset, init). Holds the mutex for the entire push+pop cycle to prevent interleaving.
- **Cache queue parameters** at init time instead of re-reading the QCB on every message.
- **Add tests** covering ioctl contract validation (argsz, flags, reserved fields), state machine transitions (echo, POST then POLL, double POST, abandon in each state, fd close cleanup), and stress scenarios (throughput floor, abandon-before-submit via two fds, rapid POST/ABANDON storm).

## Deviation from proposed design
The [proposed design](https://tenstorrent.atlassian.net/wiki/spaces/syseng/pages/537723135/ARC+FW+Messages) specifies interrupt-driven `poll(2)` completion. This is deferred until MSI infrastructure is in place. The POST|POLL fast path provides synchronous convenience without it. The design doc specifies separate kernel and user queues. This implementation shares a single FW queue, serialized by `arc_msg_mutex`. The firmware processes all queues sequentially, so separate queues would not improve latency.