### PR TITLE
Remove flaky Nix CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,17 +11,6 @@ on:
 
 jobs:
 
-  build-nix:
-    strategy:
-      matrix:
-        os: [ubuntu-24.04, ubuntu-22.04]
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: DeterminateSystems/nix-installer-action@v18
-    - run: nix flake check
-    - run: ./contrib/packaging/nix/ci.sh
-
   build-dkms:
     strategy:
       matrix:


### PR DESCRIPTION
Remove the build-nix job from CI. It fails intermittently on packages unrelated to tt-kmd, producing 16MB logs that GitHub can't display.