### PR TITLE
Enable Wormhole power management with deferred idle powerdown

### DIFF
--- a/chardev.c
+++ b/chardev.c
@@ -441,6 +441,13 @@ int tenstorrent_set_aggregated_power_state(struct tenstorrent_device *tt_dev)
 	return ret;
 }
 
+// Delayed work: send the aggregated idle power-down message after the
+// grace period elapsed with no open fds.  Body added in a later change;
+// this stub is present so teardown can cancel the work unconditionally.
+void tenstorrent_power_down_work_func(struct work_struct *work)
+{
+}
+
 static long ioctl_set_power_state(struct chardev_private *priv, struct tenstorrent_power_state __user *arg)
 {
 	struct tenstorrent_device *tt_dev = priv->device;

--- a/chardev.c
+++ b/chardev.c
@@ -442,10 +442,16 @@ int tenstorrent_set_aggregated_power_state(struct tenstorrent_device *tt_dev)
 }
 
 // Delayed work: send the aggregated idle power-down message after the
-// grace period elapsed with no open fds.  Body added in a later change;
-// this stub is present so teardown can cancel the work unconditionally.
+// grace period elapses with no open fds.  Nothing arms this work yet;
+// a subsequent change adds arming in the release path and the teardown
+// ordering in pci_remove that makes this handler safe to call unguarded.
 void tenstorrent_power_down_work_func(struct work_struct *work)
 {
+	struct tenstorrent_device *tt_dev = container_of(to_delayed_work(work),
+							 struct tenstorrent_device,
+							 power_down_work);
+
+	tenstorrent_set_aggregated_power_state(tt_dev);
 }
 
 static long ioctl_set_power_state(struct chardev_private *priv, struct tenstorrent_power_state __user *arg)

--- a/chardev.c
+++ b/chardev.c
@@ -204,6 +204,11 @@ static long ioctl_reset_device(struct chardev_private *priv,
 	if (copy_from_user(&in, &arg->in, sizeof(in)) != 0)
 		return -EFAULT;
 
+	// Drain any deferred idle powerdown before disturbing the device.
+	// open()/release() take reset_rwsem shared and we hold it exclusive
+	// here, so no new arm can land between the cancel and the reset.
+	cancel_delayed_work_sync(&tt_dev->power_down_work);
+
 	if (in.flags == TENSTORRENT_RESET_DEVICE_RESTORE_STATE) {
 		if (safe_pci_restore_state(pdev)) {
 			priv->device->dev_class->restore_reset_state(priv->device);
@@ -681,6 +686,13 @@ static int tt_cdev_open(struct inode *inode, struct file *file)
 	if (!power_aware)
 		private_data->power_state.power_flags = TT_POWER_FLAG_ALL & ~TT_POWER_FLAG_MAX_AI_CLK;
 
+	// Hold reset_rwsem (shared) across the body so the reset ioctl
+	// (which holds it exclusive) cannot interleave with the deferred
+	// powerdown cancel, list_add, or the initial aggregation.  Without
+	// this, a reset that drained the work could find a fresh arm
+	// landed by this open after its cancel on the power_down_work.
+	down_read(&tt_dev->reset_rwsem);
+
 	// Eagerly drain any deferred powerdown armed by a previous
 	// last-close so an open() arriving during the grace window
 	// doesn't ship a spurious powerdown->powerup pair.  Correctness
@@ -706,6 +718,8 @@ static int tt_cdev_open(struct inode *inode, struct file *file)
 			dev_warn(&tt_dev->pdev->dev, "Failed to set initial power state: %d\n", ret);
 	}
 
+	up_read(&tt_dev->reset_rwsem);
+
 	return 0;
 }
 
@@ -719,9 +733,17 @@ static int tt_cdev_release(struct inode *inode, struct file *file)
 	bool is_minimum_power = priv->power_state.validity == TT_POWER_VALIDITY(15, 0)
 				&& priv->power_state.power_flags == 0;
 	bool has_power_contribution = !power_aware || !is_minimum_power;
-	bool cleanup_noc = !tt_dev->detached && priv->noc_cleanup.enabled;
+	bool cleanup_noc;
 	bool last_close = false;
 	bool armed = false;
+
+	// Hold reset_rwsem (shared) across the body so the reset ioctl
+	// (which holds it exclusive) cannot interleave with the device-
+	// touching cleanup, the list_del/arm site, or the synchronous
+	// aggregation fallback.
+	down_read(&tt_dev->reset_rwsem);
+
+	cleanup_noc = !tt_dev->detached && priv->noc_cleanup.enabled;
 
 	if (cleanup_noc)
 		tt_dev->dev_class->noc_write32(
@@ -774,6 +796,8 @@ static int tt_cdev_release(struct inode *inode, struct file *file)
 		   && !tt_dev->needs_hw_init) {
 		tenstorrent_set_aggregated_power_state(tt_dev);
 	}
+
+	up_read(&tt_dev->reset_rwsem);
 
 	tenstorrent_device_put(tt_dev);
 	put_pid(priv->pid);

--- a/chardev.c
+++ b/chardev.c
@@ -442,9 +442,11 @@ int tenstorrent_set_aggregated_power_state(struct tenstorrent_device *tt_dev)
 }
 
 // Delayed work: send the aggregated idle power-down message after the
-// grace period elapses with no open fds.  Nothing arms this work yet;
-// a subsequent change adds arming in the release path and the teardown
-// ordering in pci_remove that makes this handler safe to call unguarded.
+// grace period elapses with no open fds.  Safe to run unguarded:
+// tt_cdev_release only arms this under chardev_mutex when !detached,
+// and tenstorrent_pci_remove writes detached=true under the same mutex
+// before cancel_delayed_work_sync, so the handler cannot fire after
+// teardown begins.
 void tenstorrent_power_down_work_func(struct work_struct *work)
 {
 	struct tenstorrent_device *tt_dev = container_of(to_delayed_work(work),
@@ -679,6 +681,19 @@ static int tt_cdev_open(struct inode *inode, struct file *file)
 	if (!power_aware)
 		private_data->power_state.power_flags = TT_POWER_FLAG_ALL & ~TT_POWER_FLAG_MAX_AI_CLK;
 
+	// Eagerly drain any deferred powerdown armed by a previous
+	// last-close so an open() arriving during the grace window
+	// doesn't ship a spurious powerdown->powerup pair.  Correctness
+	// doesn't depend on this: the handler re-aggregates current state
+	// and would ship the up-state once list_add lands below.  If the
+	// work is merely pending, the cancel is silent (no FW traffic,
+	// chip is still up); if mid-fire, we wait for the powerdown to
+	// complete and the aggregation below issues the balancing
+	// powerup.  Safe no-op when nothing is armed.
+	if (tt_dev->dev_class->defer_idle_powerdown
+	    && cancel_delayed_work_sync(&tt_dev->power_down_work))
+		dev_dbg(&tt_dev->pdev->dev, "cancelled pending idle powerdown\n");
+
 	mutex_lock(&tt_dev->chardev_mutex);
 	list_add(&private_data->open_fd, &tt_dev->open_fds_list);
 	mutex_unlock(&tt_dev->chardev_mutex);
@@ -699,13 +714,14 @@ static int tt_cdev_release(struct inode *inode, struct file *file)
 	struct chardev_private *priv = file->private_data;
 	struct tenstorrent_device *tt_dev = priv->device;
 	unsigned int bitpos;
+	bool defer = tt_dev->dev_class->defer_idle_powerdown;
 	bool power_aware = file->f_flags & O_APPEND;
 	bool is_minimum_power = priv->power_state.validity == TT_POWER_VALIDITY(15, 0)
 				&& priv->power_state.power_flags == 0;
 	bool has_power_contribution = !power_aware || !is_minimum_power;
-	bool power_down = !tt_dev->detached && power_policy && !tt_dev->needs_hw_init
-			  && has_power_contribution;
 	bool cleanup_noc = !tt_dev->detached && priv->noc_cleanup.enabled;
+	bool last_close = false;
+	bool armed = false;
 
 	if (cleanup_noc)
 		tt_dev->dev_class->noc_write32(
@@ -733,10 +749,31 @@ static int tt_cdev_release(struct inode *inode, struct file *file)
 
 	mutex_lock(&tt_dev->chardev_mutex);
 	list_del(&priv->open_fd);
+	last_close = list_empty(&tt_dev->open_fds_list);
+
+	// Armed under chardev_mutex; see the teardown comment in
+	// tenstorrent_pci_remove() for the invariant this supports.
+	// has_power_contribution gates the arm for the same reason it
+	// gates the synchronous fallback below: a zero-contribution
+	// power-aware fd closing after RESET_PCIE_LINK must not generate
+	// FW traffic (commit 40e6405).
+	if (defer && last_close && has_power_contribution && power_policy
+	    && !tt_dev->detached && !tt_dev->needs_hw_init
+	    && idle_power_down_grace_ms > 0) {
+		mod_delayed_work(system_wq, &tt_dev->power_down_work,
+				      msecs_to_jiffies(idle_power_down_grace_ms));
+		armed = true;
+	}
 	mutex_unlock(&tt_dev->chardev_mutex);
 
-	if (power_down)
+	if (armed) {
+		dev_dbg(&tt_dev->pdev->dev,
+			"deferred idle powerdown armed: grace=%u ms\n",
+			idle_power_down_grace_ms);
+	} else if (has_power_contribution && power_policy && !tt_dev->detached
+		   && !tt_dev->needs_hw_init) {
 		tenstorrent_set_aggregated_power_state(tt_dev);
+	}
 
 	tenstorrent_device_put(tt_dev);
 	put_pid(priv->pid);

--- a/chardev.h
+++ b/chardev.h
@@ -5,6 +5,7 @@
 #define TTDRIVER_CHARDEV_H_INCLUDED
 
 struct tenstorrent_device;
+struct work_struct;
 
 extern int init_char_driver(unsigned int max_devices);
 extern void cleanup_char_driver(void);
@@ -12,5 +13,6 @@ extern void cleanup_char_driver(void);
 int tenstorrent_register_device(struct tenstorrent_device *gs_dev);
 void tenstorrent_unregister_device(struct tenstorrent_device *gs_dev);
 int tenstorrent_set_aggregated_power_state(struct tenstorrent_device *tt_dev);
+void tenstorrent_power_down_work_func(struct work_struct *work);
 
 #endif

--- a/device.h
+++ b/device.h
@@ -54,9 +54,10 @@ struct tenstorrent_device {
 
 	struct list_head open_fds_list;	// List of struct chardev_private, linked through open_fds field
 
-	// Deferred idle power-down work.  Cancelled in suspend and remove
-	// so an in-flight FW message cannot race cleanup_hardware.  No
-	// code arms this work yet.
+	// Deferred idle power-down work.  Armed by tt_cdev_release on last
+	// close when dev_class->defer_idle_powerdown is set and
+	// idle_power_down_grace_ms > 0.  Cancelled in suspend and remove so
+	// an in-flight FW message cannot race cleanup_hardware.
 	struct delayed_work power_down_work;
 
 	DECLARE_BITMAP(tlbs, TENSTORRENT_MAX_INBOUND_TLBS);

--- a/device.h
+++ b/device.h
@@ -101,6 +101,14 @@ struct tenstorrent_device_class {
 	int (*set_power_state)(struct tenstorrent_device *ttdev, struct tenstorrent_power_state *power_state);
 	int (*read_telemetry_tag)(struct tenstorrent_device *ttdev, u16 tag_id, u32 *value);
 	int (*probe_telemetry)(struct tenstorrent_device *ttdev);
+
+	// If true, the idle power-down message is sent from a delayed work
+	// item armed when the last fd closes, rather than synchronously from
+	// release().  Honors idle_power_down_grace_ms: a value of 0 falls
+	// back to the synchronous path even when this is true.  If false,
+	// release() unconditionally sends synchronously (historical
+	// behavior).
+	bool defer_idle_powerdown;
 };
 
 void tenstorrent_device_put(struct tenstorrent_device *);

--- a/device.h
+++ b/device.h
@@ -12,6 +12,7 @@
 #include <linux/kref.h>
 #include <linux/rwsem.h>
 #include <linux/wait.h>
+#include <linux/workqueue.h>
 
 #include "ioctl.h"
 #include "memory.h"
@@ -52,6 +53,11 @@ struct tenstorrent_device {
 	const struct tt_hwmon_label *hwmon_labels;
 
 	struct list_head open_fds_list;	// List of struct chardev_private, linked through open_fds field
+
+	// Deferred idle power-down work.  Cancelled in suspend and remove
+	// so an in-flight FW message cannot race cleanup_hardware.  No
+	// code arms this work yet.
+	struct delayed_work power_down_work;
 
 	DECLARE_BITMAP(tlbs, TENSTORRENT_MAX_INBOUND_TLBS);
 	u32 tlb_counts[MAX_TLB_KINDS];	// Per-device TLB counts (may differ from dev_class defaults)

--- a/enumerate.c
+++ b/enumerate.c
@@ -315,6 +315,7 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 
 	mutex_init(&tt_dev->chardev_mutex);
 	mutex_init(&tt_dev->iatu_mutex);
+	INIT_DELAYED_WORK(&tt_dev->power_down_work, tenstorrent_power_down_work_func);
 
 	// Use dma_address_bits from module parameter or device class for coherent
 	// DMA mask, but use a 64-bit mask for streaming mappings. The problem this
@@ -409,6 +410,8 @@ static void tenstorrent_pci_remove(struct pci_dev *dev)
 		cancel_delayed_work_sync(&wh->fw_ready_work);
 	}
 
+	cancel_delayed_work_sync(&tt_dev->power_down_work);
+
 	// In a hotplug scenario, the device may not be accessible anymore. Check
 	// if it is still accessible by reading the vendor ID. If it is not, skip
 	// cleanup_hardware (which requires device access).
@@ -466,6 +469,8 @@ void tenstorrent_device_put(struct tenstorrent_device *tt_dev) {
 static int tenstorrent_suspend(struct device *dev) {
 	struct pci_dev *pdev = to_pci_dev(dev);
 	struct tenstorrent_device *tt_dev = pci_get_drvdata(pdev);
+
+	cancel_delayed_work_sync(&tt_dev->power_down_work);
 
 	tt_dev->dev_class->cleanup_hardware(tt_dev);
 

--- a/enumerate.c
+++ b/enumerate.c
@@ -410,6 +410,18 @@ static void tenstorrent_pci_remove(struct pci_dev *dev)
 		cancel_delayed_work_sync(&wh->fw_ready_work);
 	}
 
+	// Fence deferred-powerdown arming before draining.  tt_cdev_release
+	// arms power_down_work under chardev_mutex only when it observes
+	// !detached, so writing detached=true here under the same mutex
+	// partitions concurrent releases cleanly: any that armed did so
+	// strictly before this write and are drained by the cancel below;
+	// any that run after observe detached and skip the arm.  Without
+	// this ordering a release could slip an arm past the cancel and
+	// fire its FW message into a torn-down device.
+	mutex_lock(&tt_dev->chardev_mutex);
+	tt_dev->detached = true;
+	mutex_unlock(&tt_dev->chardev_mutex);
+
 	cancel_delayed_work_sync(&tt_dev->power_down_work);
 
 	// In a hotplug scenario, the device may not be accessible anymore. Check
@@ -425,10 +437,9 @@ static void tenstorrent_pci_remove(struct pci_dev *dev)
 	if (tt_dev->dev_class->cleanup_telemetry)
 		tt_dev->dev_class->cleanup_telemetry(tt_dev);
 
-	// Acquire reset_rwsem for write to ensure all in-flight ioctls complete
-	// before we set detached and unmap the BARs.
+	// Drain in-flight ioctls before BAR unmap.  detached was already
+	// set under chardev_mutex above.
 	down_write(&tt_dev->reset_rwsem);
-	tt_dev->detached = true;
 	tt_dev->dev_class->cleanup_device(tt_dev); // unmap BARs
 	up_write(&tt_dev->reset_rwsem);
 

--- a/module.c
+++ b/module.c
@@ -53,6 +53,14 @@ bool power_policy = true;
 module_param(power_policy, bool, 0444);
 MODULE_PARM_DESC(power_policy, "Enable power policy: low power at probe, re-aggregate on close (default=on).");
 
+uint idle_power_down_grace_ms = 0;
+module_param(idle_power_down_grace_ms, uint, 0644);
+MODULE_PARM_DESC(idle_power_down_grace_ms,
+		 "Delay in ms between the last fd closing a device and the "
+		 "idle power-down message being sent.  0 sends the message "
+		 "synchronously at close (default).  Only honored by device "
+		 "classes that opt in via defer_idle_powerdown.");
+
 const struct pci_device_id tenstorrent_ids[] = {
 	{ PCI_DEVICE(PCI_VENDOR_ID_TENSTORRENT, PCI_DEVICE_ID_GRAYSKULL),
 	  .driver_data=(kernel_ulong_t)NULL}, // Deprecated

--- a/module.c
+++ b/module.c
@@ -53,13 +53,13 @@ bool power_policy = true;
 module_param(power_policy, bool, 0444);
 MODULE_PARM_DESC(power_policy, "Enable power policy: low power at probe, re-aggregate on close (default=on).");
 
-uint idle_power_down_grace_ms = 0;
+uint idle_power_down_grace_ms = 5000;
 module_param(idle_power_down_grace_ms, uint, 0644);
 MODULE_PARM_DESC(idle_power_down_grace_ms,
 		 "Delay in ms between the last fd closing a device and the "
 		 "idle power-down message being sent.  0 sends the message "
-		 "synchronously at close (default).  Only honored by device "
-		 "classes that opt in via defer_idle_powerdown.");
+		 "synchronously at close.  Only honored by device classes "
+		 "that opt in via defer_idle_powerdown.");
 
 const struct pci_device_id tenstorrent_ids[] = {
 	{ PCI_DEVICE(PCI_VENDOR_ID_TENSTORRENT, PCI_DEVICE_ID_GRAYSKULL),

--- a/module.h
+++ b/module.h
@@ -17,6 +17,7 @@ extern uint dma_address_bits;
 extern uint reset_limit;
 extern unsigned char auto_reset_timeout;
 extern bool power_policy;
+extern uint idle_power_down_grace_ms;
 
 extern struct tenstorrent_device_class wormhole_class;
 extern struct tenstorrent_device_class blackhole_class;

--- a/msgqueue.c
+++ b/msgqueue.c
@@ -22,6 +22,11 @@ bool arc_msg_push(struct tenstorrent_device *tt_dev, const struct arc_msg *msg, 
 	if (cls->csm_read32(tt_dev, ARC_MSG_QUEUE_REQ_WPTR(queue_base), &wptr) != 0)
 		return false;
 
+	if (wptr == U32_MAX) {
+		dev_err(&tt_dev->pdev->dev, "ARC queue WPTR read returned all-1s; device gone?\n");
+		return false;
+	}
+
 	timeout = jiffies + msecs_to_jiffies(ARC_MSG_TIMEOUT_MS);
 	for (;;) {
 		u32 rptr;
@@ -29,6 +34,11 @@ bool arc_msg_push(struct tenstorrent_device *tt_dev, const struct arc_msg *msg, 
 
 		if (cls->csm_read32(tt_dev, ARC_MSG_QUEUE_REQ_RPTR(queue_base), &rptr) != 0)
 			return false;
+
+		if (rptr == U32_MAX) {
+			dev_err(&tt_dev->pdev->dev, "ARC queue RPTR read returned all-1s; device gone?\n");
+			return false;
+		}
 
 		num_occupied = (wptr - rptr) % (2 * num_entries);
 		if (num_occupied < num_entries)
@@ -72,6 +82,11 @@ bool arc_msg_pop(struct tenstorrent_device *tt_dev, struct arc_msg *msg, u32 que
 	if (cls->csm_read32(tt_dev, ARC_MSG_QUEUE_RES_RPTR(queue_base), &rptr) != 0)
 		return false;
 
+	if (rptr == U32_MAX) {
+		dev_err(&tt_dev->pdev->dev, "ARC queue RPTR read returned all-1s; device gone?\n");
+		return false;
+	}
+
 	timeout = jiffies + msecs_to_jiffies(ARC_MSG_TIMEOUT_MS);
 	for (;;) {
 		u32 wptr;
@@ -79,6 +94,11 @@ bool arc_msg_pop(struct tenstorrent_device *tt_dev, struct arc_msg *msg, u32 que
 
 		if (cls->csm_read32(tt_dev, ARC_MSG_QUEUE_RES_WPTR(queue_base), &wptr) != 0)
 			return false;
+
+		if (wptr == U32_MAX) {
+			dev_err(&tt_dev->pdev->dev, "ARC queue WPTR read returned all-1s; device gone?\n");
+			return false;
+		}
 
 		num_occupied = (wptr - rptr) % (2 * num_entries);
 		if (num_occupied > 0)

--- a/msgqueue.h
+++ b/msgqueue.h
@@ -14,7 +14,7 @@ struct arc_msg {
 };
 
 #define ARC_MSG_QUEUE_HEADER_SIZE 32
-#define ARC_MSG_TIMEOUT_MS        100
+#define ARC_MSG_TIMEOUT_MS        1000
 
 #define ARC_MSG_QUEUE_REQ_WPTR(base) ((base) + 0x00)
 #define ARC_MSG_QUEUE_RES_RPTR(base) ((base) + 0x04)

--- a/wormhole.c
+++ b/wormhole.c
@@ -1080,4 +1080,5 @@ struct tenstorrent_device_class wormhole_class = {
 	.csm_read32 = wormhole_csm_read32,
 	.csm_write32 = wormhole_csm_write32,
 	.set_power_state = wormhole_set_power_state,
+	.defer_idle_powerdown = true,
 };

--- a/wormhole.c
+++ b/wormhole.c
@@ -1033,10 +1033,6 @@ static int wormhole_csm_write32(struct tenstorrent_device *tt_dev, u64 addr, u32
 
 static int wormhole_set_power_state(struct tenstorrent_device *tt_dev, struct tenstorrent_power_state *power_state)
 {
-	// WH firmware can take over a second to process power state changes,
-	// blocking open() and close().
-	// TODO: fix FW latency or move the message off the calling thread.
-#if 0
 	struct wormhole_device *wh = tt_dev_to_wh_dev(tt_dev);
 	struct arc_msg msg = {0};
 	bool ok;
@@ -1045,11 +1041,13 @@ static int wormhole_set_power_state(struct tenstorrent_device *tt_dev, struct te
 	BUILD_BUG_ON(sizeof(power_state->power_settings) != sizeof(msg.payload));
 	memcpy(msg.payload, power_state->power_settings, sizeof(msg.payload));
 
+	dev_dbg(&wh->tt.pdev->dev, "Power state request: validity=%#x flags=%#x\n",
+		power_state->validity, power_state->power_flags);
+
 	ok = send_arc_message(wh, &msg);
 
 	if (!ok)
 		return -EINVAL;
-#endif
 
 	return 0;
 }

--- a/wormhole.c
+++ b/wormhole.c
@@ -118,7 +118,7 @@
 // ARC message queue. FW publishes the QCB pointer in NOC_NODEID_X_1.
 #define ARC_MSG_QCB_PTR (RESET_UNIT_START + 0x01D8)
 #define ARC_MSG_READY_MS 500
-#define ARC_MSG_TYPE_POWER_SETTING 0xBF
+#define ARC_MSG_TYPE_POWER_SETTING 0xC0
 
 #define WRITE_IATU_REG(wh_dev, direction, region, reg, value) \
 	write_iatu_reg(wh_dev, IATU_##direction, region, \


### PR DESCRIPTION
## Summary

GDDR is the dominant component of WH idle power; gating it saves~630 W per Galaxy (SYS-2973).  This series turns on the KMD plumbing that lets firmware drive that gating from fd ownership.

- Re-enable the FW path in `wormhole_set_power_state` (was `#if 0` pending FW work) and bump `ARC_MSG_TIMEOUT_MS` to 1000.
- Defer the synchronous idle-powerdown from last-close to a delayed work item with a configurable grace period.  An `open()` arriving inside the window cancels the pending powerdown, so a fast-following open doesn't pay the GDDR-on cost (17 ms - 800 ms per chip on current FW, dominated by stress-trained channels).

Default-off for the deferral: `idle_power_down_grace_ms=0` falls back to synchronous-at-close.  Operators opt in via the module param or `/sys/module/tenstorrent/parameters/idle_power_down_grace_ms`.

## Firmware
The handler in FW 19.8.x is unsafe to drive (PCIe speed-change side effects; Tensix/GDDR ordering); subsequent FW fixes both.  This PR runs against any WH firmware with the corrected handler.  In-flight performance mitigations (skip-slow channel; Samsung GDDR exclusion) improve the experience but aren't required for correctness.

~Forward-compat with old FW is handled by a separate V2-opcode change in both FW and KMD landing before customer release; out of scope here.~