### PR TITLE
Fix LOCK_CTL ACQUIRE_BLOCKING vs RESET_DEVICE deadlock

### DIFF
--- a/chardev.c
+++ b/chardev.c
@@ -264,6 +264,12 @@ static long ioctl_reset_device(struct chardev_private *priv,
 	out.output_size_bytes = sizeof(out);
 	out.result = !ok;
 
+	// Wake any LOCK_CTL ACQUIRE_BLOCKING waiters. If reset_gen was bumped
+	// or the device is otherwise unusable for them, they will observe it
+	// and return -ENODEV instead of waiting forever for a lock that no
+	// pre-reset fd can ever release via ioctl.
+	wake_up_interruptible(&tt_dev->resource_lock_waitqueue);
+
 	if (clear_user(&arg->out, in.output_size_bytes) != 0)
 		return -EFAULT;
 
@@ -275,11 +281,69 @@ static long ioctl_reset_device(struct chardev_private *priv,
 	return 0;
 }
 
+// Resource locks survive reset.  A reset invalidates every pre-reset fd
+// (open_reset_gen no longer matches reset_gen), so the holder cannot release
+// via ioctl; only close(fd) clears the bits.  ACQUIRE_BLOCKING from a
+// pre-reset fd therefore returns -ENODEV after a reset because the fd is no
+// longer allowed to acquire anything.
+//
+// Holding reset_rwsem across wait_event_interruptible deadlocks RESET_DEVICE
+// (which needs the rwsem for write) and starves all other ioctls because the
+// rwsem is writer-fair.  Drop it for the duration of the wait and reacquire
+// before returning so the caller's matching up_read in tt_cdev_ioctl stays
+// balanced.
+static long acquire_resource_lock_blocking(struct chardev_private *priv, u8 idx)
+{
+	struct tenstorrent_device *tt_dev = priv->device;
+	bool got_bit = false;
+	long w = 0;
+
+	up_read(&tt_dev->reset_rwsem);
+
+	while (!got_bit) {
+		w = wait_event_interruptible(tt_dev->resource_lock_waitqueue,
+			!test_bit(idx, tt_dev->resource_lock) ||
+			tt_dev->detached ||
+			atomic_long_read(&tt_dev->reset_gen) != priv->open_reset_gen);
+		if (w)
+			break;
+		if (tt_dev->detached ||
+		    atomic_long_read(&tt_dev->reset_gen) != priv->open_reset_gen)
+			break;
+		got_bit = !test_and_set_bit(idx, tt_dev->resource_lock);
+	}
+
+	down_read(&tt_dev->reset_rwsem);
+
+	if (w)
+		return -ERESTARTSYS;
+
+	// If a reset/remove raced in after we set the device bit, give the
+	// bit back: the reset is treated as having won against the unlock
+	// that would have made the bit takeable.  The caller never observes
+	// a successful acquire on a fd that is now invalid.
+	if (tt_dev->detached ||
+	    atomic_long_read(&tt_dev->reset_gen) != priv->open_reset_gen) {
+		if (got_bit) {
+			clear_bit(idx, tt_dev->resource_lock);
+			wake_up_interruptible(&tt_dev->resource_lock_waitqueue);
+		}
+		return -ENODEV;
+	}
+
+	if (!got_bit)
+		return -ENODEV;
+
+	set_bit(idx, priv->resource_lock);
+	return 0;
+}
+
 // Ordering invariant: acquire sets global then local; release clears local then
 // global. This ensures the global bit is always set while the local bit is set.
 static long ioctl_lock_ctl(struct chardev_private *priv, struct tenstorrent_lock_ctl __user *arg)
 {
 	u32 bytes_to_copy;
+	long blocking_ret;
 
 	struct tenstorrent_lock_ctl_in in;
 	struct tenstorrent_lock_ctl_out out;
@@ -303,10 +367,9 @@ static long ioctl_lock_ctl(struct chardev_private *priv, struct tenstorrent_lock
 		}
 		break;
 	case TENSTORRENT_LOCK_CTL_ACQUIRE_BLOCKING:
-		if (wait_event_interruptible(priv->device->resource_lock_waitqueue,
-					     !test_and_set_bit(in.index, priv->device->resource_lock)))
-			return -ERESTARTSYS;
-		set_bit(in.index, priv->resource_lock);
+		blocking_ret = acquire_resource_lock_blocking(priv, in.index);
+		if (blocking_ret)
+			return blocking_ret;
 		out.value = 1;
 		break;
 	case TENSTORRENT_LOCK_CTL_RELEASE:

--- a/enumerate.c
+++ b/enumerate.c
@@ -443,6 +443,10 @@ static void tenstorrent_pci_remove(struct pci_dev *dev)
 	tt_dev->dev_class->cleanup_device(tt_dev); // unmap BARs
 	up_write(&tt_dev->reset_rwsem);
 
+	// Wake any LOCK_CTL ACQUIRE_BLOCKING waiters parked on this device so
+	// they observe detached and return -ENODEV instead of waiting forever.
+	wake_up_interruptible(&tt_dev->resource_lock_waitqueue);
+
 	list_for_each_entry_safe(priv, tmp, &tt_dev->open_fds_list, open_fd) {
 		tenstorrent_memory_cleanup(priv);
 	}


### PR DESCRIPTION
tt_cdev_ioctl() takes reset_rwsem for read on every non-reset ioctl and for write on RESET_DEVICE. ioctl_lock_ctl()'s ACQUIRE_BLOCKING path parked the caller in wait_event_interruptible() while still holding down_read(reset_rwsem), so a subsequent RESET_DEVICE blocked indefinitely in down_write(). The rwsem is writer-fair, so a pending writer also blocked any concurrent LOCK_CTL_RELEASE that would otherwise have woken the parked waiter, making it a hard deadlock until the waiter took a signal. The same shape would deadlock against tenstorrent_pci_remove, which also takes the rwsem for write.

Extract acquire_resource_lock_blocking(), which drops reset_rwsem for the duration of the wait and reacquires it before returning so the caller's matching up_read stays balanced. Broaden the wait condition to also unblock when the device is detached or reset_gen has advanced past the fd's open_reset_gen, and wake the waitqueue from ioctl_reset_device and tenstorrent_pci_remove so parked waiters exit promptly with -ENODEV.

Resource locks are intentionally preserved across reset: a reset invalidates every pre-reset fd (open_reset_gen mismatch), so a holder cannot release via ioctl after a reset and only close(fd) clears the bits. The one carve-out is the case where a waiter wins test_and_set_bit() and a reset/remove then races in before reacquire: give the bit back, since the caller never observed a successful acquire on a fd that is now invalid.

Fixes: #235
Assisted-by: Claude:claude-4.7-opus