### PR TITLE
Add O_EXCL exclusive-open support to the chardev

### DIFF
--- a/chardev.c
+++ b/chardev.c
@@ -93,6 +93,7 @@ int tenstorrent_register_device(struct tenstorrent_device *tt_dev)
 	char name[16];
 
 	init_waitqueue_head(&tt_dev->resource_lock_waitqueue);
+	init_waitqueue_head(&tt_dev->chardev_excl_waitqueue);
 
 	device_initialize(&tt_dev->dev);
 	tt_dev->dev.devt = devt;
@@ -188,6 +189,14 @@ static long ioctl_get_driver_info(struct chardev_private *priv,
 	return 0;
 }
 
+// Bump the device's reset generation and bring this fd's open_reset_gen along
+// with it. Other fds become permanently invalid, but the resetter keeps a live
+// fd so it can complete the reset sequence without a close/reopen window.
+static void bump_reset_gen(struct chardev_private *priv)
+{
+	priv->open_reset_gen = atomic_long_inc_return(&priv->device->reset_gen);
+}
+
 static long ioctl_reset_device(struct chardev_private *priv,
 			       struct tenstorrent_reset_device __user *arg)
 {
@@ -220,21 +229,21 @@ static long ioctl_reset_device(struct chardev_private *priv,
 		tenstorrent_vma_zap(tt_dev);
 		ok = pcie_hot_reset_and_restore_state(pdev);
 	} else if (in.flags == TENSTORRENT_RESET_DEVICE_CONFIG_WRITE) {
-		atomic_long_inc(&priv->device->reset_gen);
+		bump_reset_gen(priv);
 		tenstorrent_vma_zap(tt_dev);
 		ok = pcie_timer_interrupt(pdev);
 	} else if (in.flags == TENSTORRENT_RESET_DEVICE_USER_RESET) {
-		atomic_long_inc(&priv->device->reset_gen);
+		bump_reset_gen(priv);
 		tenstorrent_vma_zap(tt_dev);
 		ok = set_reset_marker(pdev);
 		priv->device->needs_hw_init = true;
 	} else if (in.flags == TENSTORRENT_RESET_DEVICE_ASIC_RESET) {
-		atomic_long_inc(&priv->device->reset_gen);
+		bump_reset_gen(priv);
 		tenstorrent_vma_zap(tt_dev);
 		ok = priv->device->dev_class->reset(priv->device, in.flags);
 		priv->device->needs_hw_init = true;
 	} else if (in.flags == TENSTORRENT_RESET_DEVICE_ASIC_DMC_RESET) {
-		atomic_long_inc(&priv->device->reset_gen);
+		bump_reset_gen(priv);
 		tenstorrent_vma_zap(tt_dev);
 		ok = priv->device->dev_class->reset(priv->device, in.flags);
 		priv->device->needs_hw_init = true;
@@ -708,11 +717,60 @@ static struct tenstorrent_device *inode_to_tt_dev(struct inode *inode)
 	return container_of(inode->i_cdev, struct tenstorrent_device, chardev);
 }
 
+// Arbitrate open vs existing fds.  This is an open()-time reader/writer lock:
+// O_EXCL is the writer and plain opens are readers.  A writer waits for the
+// device to be idle; a reader waits for any O_EXCL holder to go away.  In both
+// cases O_NONBLOCK turns the wait into -EAGAIN.  While an O_EXCL fd is held it
+// is the only fd on the list, so the holder's release is exactly the
+// list_empty transition that wakes both kinds of waiter.
+static int admit_chardev_open(struct tenstorrent_device *tt_dev, struct chardev_private *priv, unsigned int f_flags)
+{
+	bool want_excl = f_flags & O_EXCL;
+	bool nonblock = f_flags & O_NONBLOCK;
+	int ret;
+
+	mutex_lock(&tt_dev->chardev_mutex);
+
+	if (want_excl) {
+		// Writer: wait until no other fd is open, then take exclusivity.
+		while (!list_empty(&tt_dev->open_fds_list)) {
+			mutex_unlock(&tt_dev->chardev_mutex);
+			if (nonblock)
+				return -EAGAIN;
+			ret = wait_event_interruptible_exclusive(tt_dev->chardev_excl_waitqueue,
+								 list_empty(&tt_dev->open_fds_list));
+			if (ret)
+				return ret;
+			mutex_lock(&tt_dev->chardev_mutex);
+		}
+		WRITE_ONCE(tt_dev->chardev_excl_held, true);
+	} else {
+		// Reader: wait until no O_EXCL fd is held.  Registered non-exclusively
+		// so all readers wake together when the holder releases.
+		while (tt_dev->chardev_excl_held) {
+			mutex_unlock(&tt_dev->chardev_mutex);
+			if (nonblock)
+				return -EAGAIN;
+			ret = wait_event_interruptible(tt_dev->chardev_excl_waitqueue,
+						       !READ_ONCE(tt_dev->chardev_excl_held));
+			if (ret)
+				return ret;
+			mutex_lock(&tt_dev->chardev_mutex);
+		}
+	}
+
+	list_add(&priv->open_fd, &tt_dev->open_fds_list);
+
+	mutex_unlock(&tt_dev->chardev_mutex);
+	return 0;
+}
+
 static int tt_cdev_open(struct inode *inode, struct file *file)
 {
 	struct tenstorrent_device *tt_dev = inode_to_tt_dev(inode);
 	struct chardev_private *private_data;
 	bool power_aware = file->f_flags & O_APPEND;
+	int ret;
 
 	private_data = kzalloc(sizeof(*private_data), GFP_KERNEL);
 	if (private_data == NULL)
@@ -729,48 +787,54 @@ static int tt_cdev_open(struct inode *inode, struct file *file)
 	kref_get(&tt_dev->kref);
 	private_data->device = tt_dev;
 	private_data->open_reset_gen = atomic_long_read(&tt_dev->reset_gen);
-	file->private_data = private_data;
 
 	private_data->pid = get_pid(task_pid(current->group_leader));
 	get_task_comm(private_data->comm, current);
 
 	// Legacy client: default to AICLK=Low, everything else enabled.
 	// Else, client is expected to explicitly request power states via ioctl.
+	// Initialize before admit_chardev_open() so this fd is fully initialized
+	// before it becomes visible on open_fds_list.
 	private_data->power_state.validity = TT_POWER_VALIDITY(15, 0);
 	if (!power_aware)
 		private_data->power_state.power_flags = TT_POWER_FLAG_ALL & ~TT_POWER_FLAG_MAX_AI_CLK;
 
-	// Hold reset_rwsem (shared) across the body so the reset ioctl
-	// (which holds it exclusive) cannot interleave with the deferred
-	// powerdown cancel, list_add, or the initial aggregation.  Without
-	// this, a reset that drained the work could find a fresh arm
-	// landed by this open after its cancel on the power_down_work.
+	ret = admit_chardev_open(tt_dev, private_data, file->f_flags);
+	if (ret) {
+		put_pid(private_data->pid);
+		kfree(private_data);
+		tenstorrent_device_put(tt_dev);
+		return ret;
+	}
+
+	// Hold reset_rwsem (shared) across the body so the reset ioctl (which holds
+	// it exclusive) cannot interleave with the deferred powerdown cancel or the
+	// initial aggregation.  Without this, a reset that drained the work could
+	// find a fresh arm landed by this open after its cancel on the
+	// power_down_work.
 	down_read(&tt_dev->reset_rwsem);
 
-	// Eagerly drain any deferred powerdown armed by a previous
-	// last-close so an open() arriving during the grace window
-	// doesn't ship a spurious powerdown->powerup pair.  Correctness
-	// doesn't depend on this: the handler re-aggregates current state
-	// and would ship the up-state once list_add lands below.  If the
-	// work is merely pending, the cancel is silent (no FW traffic,
-	// chip is still up); if mid-fire, we wait for the powerdown to
-	// complete and the aggregation below issues the balancing
-	// powerup.  Safe no-op when nothing is armed.
+	// Eagerly drain any deferred powerdown armed by a previous last-close so an
+	// open() arriving during the grace window doesn't ship a spurious
+	// powerdown->powerup pair.  Correctness doesn't depend on this: the handler
+	// re-aggregates current state and would ship the up-state since this fd is
+	// already on the list.  If the work is merely pending, the cancel is silent
+	// (no FW traffic, chip is still up); if mid-fire, we wait for the powerdown
+	// to complete and the aggregation below issues the balancing powerup.  Safe
+	// no-op when nothing is armed.
 	if (tt_dev->dev_class->defer_idle_powerdown
 	    && cancel_delayed_work_sync(&tt_dev->power_down_work))
 		dev_dbg(&tt_dev->pdev->dev, "cancelled pending idle powerdown\n");
 
-	mutex_lock(&tt_dev->chardev_mutex);
-	list_add(&private_data->open_fd, &tt_dev->open_fds_list);
-	mutex_unlock(&tt_dev->chardev_mutex);
-
 	if (!power_aware && !tt_dev->detached && !tt_dev->needs_hw_init) {
-		int ret = tenstorrent_set_aggregated_power_state(tt_dev);
+		ret = tenstorrent_set_aggregated_power_state(tt_dev);
 		if (ret < 0)
 			dev_warn(&tt_dev->pdev->dev, "Failed to set initial power state: %d\n", ret);
 	}
 
 	up_read(&tt_dev->reset_rwsem);
+
+	file->private_data = private_data;
 
 	return 0;
 }
@@ -852,6 +916,11 @@ static int tt_cdev_release(struct inode *inode, struct file *file)
 
 	// Must follow the list_del: release_power reads open_fds_list.
 	tt_cdev_release_power(priv);
+
+	if (list_empty(&tt_dev->open_fds_list)) {
+		WRITE_ONCE(tt_dev->chardev_excl_held, false);
+		wake_up_interruptible(&tt_dev->chardev_excl_waitqueue);
+	}
 
 	mutex_unlock(&tt_dev->chardev_mutex);
 

--- a/chardev.c
+++ b/chardev.c
@@ -708,22 +708,6 @@ static struct tenstorrent_device *inode_to_tt_dev(struct inode *inode)
 	return container_of(inode->i_cdev, struct tenstorrent_device, chardev);
 }
 
-static void increment_cdev_open_count(struct tenstorrent_device *tt_dev) {
-	mutex_lock(&tt_dev->chardev_mutex);
-	if (!tt_dev->chardev_open_count && tt_dev->dev_class->first_open_cb)
-		tt_dev->dev_class->first_open_cb(tt_dev);
-	tt_dev->chardev_open_count++;
-	mutex_unlock(&tt_dev->chardev_mutex);
-}
-
-static void decrement_cdev_open_count(struct tenstorrent_device *tt_dev) {
-	mutex_lock(&tt_dev->chardev_mutex);
-	tt_dev->chardev_open_count--;
-	if (!tt_dev->chardev_open_count && tt_dev->dev_class->last_release_cb)
-		tt_dev->dev_class->last_release_cb(tt_dev);
-	mutex_unlock(&tt_dev->chardev_mutex);
-}
-
 static int tt_cdev_open(struct inode *inode, struct file *file)
 {
 	struct tenstorrent_device *tt_dev = inode_to_tt_dev(inode);
@@ -779,8 +763,6 @@ static int tt_cdev_open(struct inode *inode, struct file *file)
 	mutex_lock(&tt_dev->chardev_mutex);
 	list_add(&private_data->open_fd, &tt_dev->open_fds_list);
 	mutex_unlock(&tt_dev->chardev_mutex);
-
-	increment_cdev_open_count(tt_dev);
 
 	if (!power_aware && !tt_dev->detached && !tt_dev->needs_hw_init) {
 		int ret = tenstorrent_set_aggregated_power_state(tt_dev);
@@ -860,7 +842,6 @@ static int tt_cdev_release(struct inode *inode, struct file *file)
 	down_read(&tt_dev->reset_rwsem);
 
 	tt_cdev_release_noc_cleanup(priv);
-	decrement_cdev_open_count(tt_dev);
 	tenstorrent_memory_cleanup(priv);
 	tt_cdev_release_resource_locks(priv);
 	tt_cdev_release_tlbs(priv);

--- a/device.h
+++ b/device.h
@@ -41,7 +41,6 @@ struct tenstorrent_device {
 	bool interrupt_enabled;
 
 	struct mutex chardev_mutex;
-	unsigned int chardev_open_count;
 
 	struct notifier_block reboot_notifier;
 
@@ -94,8 +93,6 @@ struct tenstorrent_device_class {
 	void (*cleanup_telemetry)(struct tenstorrent_device *ttdev);
 	void (*cleanup_hardware)(struct tenstorrent_device *ttdev);
 	void (*cleanup_device)(struct tenstorrent_device *ttdev);
-	void (*first_open_cb)(struct tenstorrent_device *ttdev);
-	void (*last_release_cb)(struct tenstorrent_device *ttdev);
 	void (*reboot)(struct tenstorrent_device *ttdev);
 	int (*configure_tlb)(struct tenstorrent_device *ttdev, int tlb, struct tenstorrent_noc_tlb_config *config);
 	int (*describe_tlb)(struct tenstorrent_device *ttdev, int tlb, struct tlb_descriptor *tlb_desc);

--- a/device.h
+++ b/device.h
@@ -41,6 +41,8 @@ struct tenstorrent_device {
 	bool interrupt_enabled;
 
 	struct mutex chardev_mutex;
+	bool chardev_excl_held;	// An O_EXCL fd is currently open
+	wait_queue_head_t chardev_excl_waitqueue;
 
 	struct notifier_block reboot_notifier;
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,7 +8,7 @@ PROG := ttkmd_test
 TEST_SOURCES := get_driver_info.cpp get_device_info.cpp query_mappings.cpp \
 	dma_buf.cpp pin_pages.cpp config_space.cpp lock.cpp hwmon.cpp map_peer_bar.cpp \
 	ioctl_overrun.cpp ioctl_zeroing.cpp tlbs.cpp release.cpp mappings_debugfs.cpp \
-	procfs_pids.cpp
+	procfs_pids.cpp excl.cpp
 
 CORE_SOURCES := enumeration.cpp util.cpp devfd.cpp main.cpp test_failure.cpp
 SOURCES := $(CORE_SOURCES) $(TEST_SOURCES)

--- a/test/excl.cpp
+++ b/test/excl.cpp
@@ -1,0 +1,332 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Test O_EXCL exclusive-open semantics on the chardev.
+//
+// open() is an open-time reader/writer lock: O_EXCL is the writer, plain opens
+// are readers, and O_NONBLOCK selects trylock behavior.  While an O_EXCL fd is
+// open, every other open() (plain or O_EXCL) blocks until it is released, or
+// returns EAGAIN if O_NONBLOCK is set.  Blocking waiters wake when
+// open_fds_list becomes empty (i.e. on the last release).
+
+#include <atomic>
+#include <chrono>
+#include <cerrno>
+#include <string>
+#include <thread>
+
+#include <fcntl.h>
+#include <pthread.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "enumeration.h"
+#include "test_failure.h"
+
+namespace
+{
+
+// Raw open() wrapper that records errno on failure. We can't use DevFd because
+// it always opens O_RDWR | O_CLOEXEC and throws -- we need to inspect EAGAIN
+// and EINTR here.
+int open_with_flags(const std::string &path, int extra_flags)
+{
+    return open(path.c_str(), O_RDWR | O_CLOEXEC | extra_flags);
+}
+
+void expect_open_fails(const std::string &path, int extra_flags, int expected_errno, const char *what)
+{
+    int fd = open_with_flags(path, extra_flags);
+    if (fd >= 0) {
+        close(fd);
+        THROW_TEST_FAILURE(std::string(what) + ": open() unexpectedly succeeded");
+    }
+    if (errno != expected_errno)
+        THROW_TEST_FAILURE(std::string(what) + ": expected errno " + std::to_string(expected_errno)
+                           + ", got " + std::to_string(errno));
+}
+
+// Two plain opens of the same device coexist (baseline -- ensure the common
+// case still works).
+void VerifyPlainCoexists(const EnumeratedDevice &dev)
+{
+    int a = open_with_flags(dev.path, 0);
+    if (a < 0)
+        THROW_TEST_FAILURE("First plain open should succeed");
+
+    int b = open_with_flags(dev.path, 0);
+    if (b < 0) {
+        close(a);
+        THROW_TEST_FAILURE("Second plain open should succeed alongside the first");
+    }
+
+    close(a);
+    close(b);
+}
+
+// O_EXCL on an idle device succeeds.
+void VerifyExclOnIdleSucceeds(const EnumeratedDevice &dev)
+{
+    int fd = open_with_flags(dev.path, O_EXCL);
+    if (fd < 0)
+        THROW_TEST_FAILURE("O_EXCL open on an idle device should succeed");
+    close(fd);
+}
+
+// While an O_EXCL fd is held, non-blocking opens fail fast with EAGAIN --
+// both a plain reader and another O_EXCL writer.
+void VerifyHeldExclRejectsNonblock(const EnumeratedDevice &dev)
+{
+    int excl = open_with_flags(dev.path, O_EXCL);
+    if (excl < 0)
+        THROW_TEST_FAILURE("Initial O_EXCL open should succeed");
+
+    expect_open_fails(dev.path, O_NONBLOCK, EAGAIN,
+                      "plain O_NONBLOCK while O_EXCL is held");
+    expect_open_fails(dev.path, O_EXCL | O_NONBLOCK, EAGAIN,
+                      "O_EXCL|O_NONBLOCK while O_EXCL is held");
+
+    close(excl);
+}
+
+// While a plain fd is held: O_EXCL|O_NONBLOCK returns EAGAIN.
+void VerifyExclNonblockBlockedByPlain(const EnumeratedDevice &dev)
+{
+    int plain = open_with_flags(dev.path, 0);
+    if (plain < 0)
+        THROW_TEST_FAILURE("Plain open should succeed");
+
+    expect_open_fails(dev.path, O_EXCL | O_NONBLOCK, EAGAIN,
+                      "O_EXCL|O_NONBLOCK while plain fd is open");
+
+    close(plain);
+}
+
+// Releasing the O_EXCL fd reopens the device to ordinary opens.
+void VerifyExclReleaseRestoresAccess(const EnumeratedDevice &dev)
+{
+    int excl = open_with_flags(dev.path, O_EXCL);
+    if (excl < 0)
+        THROW_TEST_FAILURE("O_EXCL open should succeed");
+    close(excl);
+
+    int plain = open_with_flags(dev.path, 0);
+    if (plain < 0)
+        THROW_TEST_FAILURE("Plain open should succeed after O_EXCL holder closes");
+    close(plain);
+}
+
+// Blocking O_EXCL waits while another fd is open, then proceeds when that
+// fd closes. Mirrors VerifyBlockingLock in lock.cpp.
+void VerifyExclBlocksUntilIdle(const EnumeratedDevice &dev)
+{
+    int plain = open_with_flags(dev.path, 0);
+    if (plain < 0)
+        THROW_TEST_FAILURE("Plain open should succeed");
+
+    std::atomic<bool> thread_started{false};
+    std::atomic<int> blocked_fd{-2};
+    std::atomic<int> blocked_err{0};
+
+    std::thread blocker([&]() {
+        thread_started = true;
+        int fd = open_with_flags(dev.path, O_EXCL);
+        blocked_err = (fd < 0) ? errno : 0;
+        blocked_fd = fd;
+    });
+
+    while (!thread_started)
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    if (blocked_fd.load() != -2) {
+        close(plain);
+        if (blocked_fd.load() >= 0)
+            close(blocked_fd.load());
+        blocker.join();
+        THROW_TEST_FAILURE("O_EXCL open should block while a plain fd is open");
+    }
+
+    close(plain);
+    blocker.join();
+
+    int fd = blocked_fd.load();
+    if (fd < 0)
+        THROW_TEST_FAILURE("O_EXCL open should succeed after plain fd closes, errno="
+                           + std::to_string(blocked_err.load()));
+    close(fd);
+}
+
+// A plain (reader) open blocks while an O_EXCL fd is held, then proceeds once
+// the holder releases. This is the reader side of VerifyExclBlocksUntilIdle.
+void VerifyPlainBlocksUntilExclReleases(const EnumeratedDevice &dev)
+{
+    int excl = open_with_flags(dev.path, O_EXCL);
+    if (excl < 0)
+        THROW_TEST_FAILURE("O_EXCL open should succeed");
+
+    std::atomic<bool> thread_started{false};
+    std::atomic<int> blocked_fd{-2};
+    std::atomic<int> blocked_err{0};
+
+    std::thread blocker([&]() {
+        thread_started = true;
+        int fd = open_with_flags(dev.path, 0);
+        blocked_err = (fd < 0) ? errno : 0;
+        blocked_fd = fd;
+    });
+
+    while (!thread_started)
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    if (blocked_fd.load() != -2) {
+        close(excl);
+        if (blocked_fd.load() >= 0)
+            close(blocked_fd.load());
+        blocker.join();
+        THROW_TEST_FAILURE("Plain open should block while an O_EXCL fd is held");
+    }
+
+    close(excl);
+    blocker.join();
+
+    int fd = blocked_fd.load();
+    if (fd < 0)
+        THROW_TEST_FAILURE("Plain open should succeed after O_EXCL holder closes, errno="
+                           + std::to_string(blocked_err.load()));
+    close(fd);
+}
+
+// Blocking O_EXCL wakes when the holder dies and the kernel cleans up its fd,
+// mirroring VerifyBlockingWakesOnExit in lock.cpp.
+void VerifyExclWakesOnHolderExit(const EnumeratedDevice &dev)
+{
+    // Readiness pipe: the child reports that its plain open is on the list
+    // before the parent attempts O_EXCL.  Without this handshake the parent's
+    // O_EXCL could win the race, take exclusivity, and then deadlock in
+    // waitpid() while the child's plain open blocks forever on that exclusivity.
+    int ready_pipe[2];
+    if (pipe(ready_pipe) == -1)
+        THROW_TEST_FAILURE("pipe() failed");
+
+    pid_t pid = fork();
+    if (pid == -1) {
+        close(ready_pipe[0]);
+        close(ready_pipe[1]);
+        THROW_TEST_FAILURE("fork() failed");
+    }
+
+    if (pid == 0) {
+        // Child holds the device for a short while, then exits without
+        // explicitly closing -- exit() releases the fd.
+        close(ready_pipe[0]);
+        int fd = open_with_flags(dev.path, 0);
+        if (fd < 0)
+            _exit(2);
+        // Signal readiness only once the fd is held, then hold briefly.
+        char ready = 1;
+        if (write(ready_pipe[1], &ready, 1) != 1)
+            _exit(3);
+        usleep(100000);
+        _exit(0);
+    }
+
+    close(ready_pipe[1]);
+
+    // Wait for the child's plain open to land before we contend for it.
+    char ready = 0;
+    ssize_t n = read(ready_pipe[0], &ready, 1);
+    close(ready_pipe[0]);
+    if (n != 1) {
+        waitpid(pid, nullptr, 0);
+        THROW_TEST_FAILURE("Child failed to open the device before exit");
+    }
+
+    // Blocks until the child exits and the kernel releases its fd.
+    int fd = open_with_flags(dev.path, O_EXCL);
+    int err = errno;
+
+    int status;
+    if (waitpid(pid, &status, 0) == -1)
+        THROW_TEST_FAILURE("waitpid() failed");
+
+    if (fd < 0)
+        THROW_TEST_FAILURE("O_EXCL should succeed after holder exits, errno="
+                           + std::to_string(err));
+    close(fd);
+}
+
+// A signal without SA_RESTART interrupts a blocking O_EXCL open and the
+// syscall returns EINTR. Mirrors the signal pattern used in lock.cpp's
+// VerifySARestart, but with SA_RESTART explicitly cleared so the syscall is
+// not transparently restarted.
+void sigusr1_noop(int) {}
+
+void VerifyExclInterruptedBySignal(const EnumeratedDevice &dev)
+{
+    int plain = open_with_flags(dev.path, 0);
+    if (plain < 0)
+        THROW_TEST_FAILURE("Plain open should succeed");
+
+    struct sigaction sa{};
+    sa.sa_handler = sigusr1_noop;
+    sa.sa_flags = 0;          // No SA_RESTART: open() returns EINTR.
+    sigemptyset(&sa.sa_mask);
+
+    struct sigaction old_sa{};
+    if (sigaction(SIGUSR1, &sa, &old_sa) == -1) {
+        close(plain);
+        THROW_TEST_FAILURE("sigaction() failed");
+    }
+
+    std::atomic<bool> thread_started{false};
+    std::atomic<int> blocked_fd{-2};
+    std::atomic<int> blocked_err{0};
+
+    std::thread blocker([&]() {
+        thread_started = true;
+        int fd = open_with_flags(dev.path, O_EXCL);
+        blocked_err = (fd < 0) ? errno : 0;
+        blocked_fd = fd;
+    });
+
+    while (!thread_started)
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+    while (blocked_fd.load() == -2) {
+        pthread_kill(blocker.native_handle(), SIGUSR1);
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    blocker.join();
+
+    sigaction(SIGUSR1, &old_sa, nullptr);
+    close(plain);
+
+    int fd = blocked_fd.load();
+    if (fd >= 0) {
+        close(fd);
+        THROW_TEST_FAILURE("O_EXCL should have returned EINTR, not succeeded");
+    }
+    if (blocked_err.load() != EINTR)
+        THROW_TEST_FAILURE("O_EXCL should have returned EINTR, got errno="
+                           + std::to_string(blocked_err.load()));
+}
+
+} // namespace
+
+void TestExcl(const EnumeratedDevice &dev)
+{
+    VerifyPlainCoexists(dev);
+    VerifyExclOnIdleSucceeds(dev);
+    VerifyHeldExclRejectsNonblock(dev);
+    VerifyExclNonblockBlockedByPlain(dev);
+    VerifyExclReleaseRestoresAccess(dev);
+    VerifyExclBlocksUntilIdle(dev);
+    VerifyPlainBlocksUntilExclReleases(dev);
+    VerifyExclWakesOnHolderExit(dev);
+    VerifyExclInterruptedBySignal(dev);
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -24,6 +24,7 @@ void TestTlbs(const EnumeratedDevice &dev);
 void TestDeviceRelease(const EnumeratedDevice &dev);
 void TestMappingsDebugfs(const EnumeratedDevice &dev);
 void TestProcfsPids(const EnumeratedDevice &dev);
+void TestExcl(const EnumeratedDevice &dev);
 
 int main(int argc, char *argv[])
 {
@@ -53,6 +54,7 @@ int main(int argc, char *argv[])
         TestTlbs(d);
         TestMappingsDebugfs(d);
         TestProcfsPids(d);
+        TestExcl(d);
         TestDeviceRelease(d);
 
         at_least_one_device = true;


### PR DESCRIPTION
## Motivation
tt-flash wants to flash and reset the device without any other process being able to use it, and without new processes being able to open it mid-flash.

See also: https://tenstorrent.atlassian.net/browse/PT-377

## Semantics
open() acts as a reader/writer lock: `O_EXCL` is the writer, plain opens are readers, and `O_NONBLOCK` selects trylock behavior.

| open flags | behavior |
|---|---|
| `O_RDWR` | Blocks (interruptible) while an `O_EXCL` fd is held, then proceeds once it is released; otherwise unchanged. |
| `O_RDWR \| O_NONBLOCK` | `-EAGAIN` while an `O_EXCL` fd is held; otherwise unchanged. |
| `O_RDWR \| O_EXCL` | Blocks (interruptible) until the device is idle, then takes exclusive ownership. |
| `O_RDWR \| O_EXCL \| O_NONBLOCK` | `-EAGAIN` if not immediately acquirable. |

While an `O_EXCL` fd is open, every other open blocks until it is released (or gets `-EAGAIN` with `O_NONBLOCK`). Applications that don't pass `O_EXCL` are unaffected unless something like tt-flash is actively holding the device, in which case their `open()` blocks until it finishes.

Fairness: this is a reader-preferring lock with barge-in (no FIFO ordering). Plain opens (readers) never starve. A blocking `O_EXCL` writer can be starved by a steady stream of plain opens, since it only wakes on the last-close transition; callers that can't tolerate that should use `O_EXCL | O_NONBLOCK` and retry. In tt-flash's case the system is quiesced before flashing, so there is no reader churn to starve against.

## Commits
1. Remove unused chardev open count and lifecycle callbacks — drops chardev_open_count, first_open_cb, last_release_cb, and the increment/decrement helpers that were never observed by anyone. open_fds_list already tracks who has the device open.

2. Add O_EXCL exclusive-open semantics for the chardev — implements the table above using a new chardev_excl_held bool and a waitqueue on tenstorrent_device, all gated by the existing chardev_mutex. Readers wait non-exclusively and writers wait exclusively on that waitqueue, so a single wake on the last-close transition releases every blocked reader plus one writer. Also folds in a reset-path fix: ioctls that bump reset_gen (CONFIG_WRITE, USER_RESET, ASIC_RESET, ASIC_DMC_RESET) now carry the issuing fd's open_reset_gen along with the bump, so the resetter's own fd stays valid for the follow-up POST_RESET. Other fds still mismatch and continue to fail with -ENODEV. Without this, tt-flash would have to close and reopen between ASIC_RESET and POST_RESET, dropping exclusivity in a window where another opener could interpose.

3. Add tests for O_EXCL chardev semantics — test/excl.cpp exercises plain coexistence, idle-acquire, EAGAIN for non-blocking opens (both plain-vs-O_EXCL and O_EXCL-vs-O_EXCL) while held, the release-restores-access transition, the blocking variants in both directions (an O_EXCL open waiting on a plain holder, and a plain open waiting on an O_EXCL holder — covering both an explicit close in another thread and implicit fd cleanup when the holder process exits), and EINTR on signal without SA_RESTART. Threading and signal patterns mirror the equivalents in lock.cpp.