### PR TITLE
Improve Tenstorrent driver logging context

### DIFF
--- a/blackhole.c
+++ b/blackhole.c
@@ -645,7 +645,7 @@ static bool blackhole_init_telemetry(struct tenstorrent_device *tt_dev)
 
 	r = device_add_group(&tt_dev->dev, &bh_pcie_perf_counters_group);
 	if (r)
-		dev_err(&tt_dev->dev, "PCIe perf counters unavailable: %d\n", r);
+		dev_err(&tt_dev->pdev->dev, "PCIe perf counters unavailable: %d\n", r);
 	else
 		bh->pcie_perf_group_registered = true;
 
@@ -704,7 +704,7 @@ static void blackhole_cleanup_hardware(struct tenstorrent_device *tt_dev)
 
 	msg.header = ARC_MSG_TYPE_ASIC_STATE3;
 	if (!send_arc_message(bh, &msg))
-		dev_err(&tt_dev->dev, "Failed to send ARC message for A3 state\n");
+		dev_err(&tt_dev->pdev->dev, "Failed to send ARC message for A3 state\n");
 }
 
 static void blackhole_cleanup(struct tenstorrent_device *tt_dev)

--- a/chardev.c
+++ b/chardev.c
@@ -460,6 +460,9 @@ static long ioctl_set_power_state(struct chardev_private *priv, struct tenstorre
 	if (data.validity > TT_POWER_VALIDITY(15, 14))
 		return -EINVAL;
 
+	dev_dbg(&tt_dev->pdev->dev, "Power state request: validity=0x%x flags=0x%x\n",
+		data.validity, data.power_flags);
+
 	mutex_lock(&priv->mutex);
 	priv->power_state = data;
 	mutex_unlock(&priv->mutex);
@@ -672,7 +675,7 @@ static int tt_cdev_open(struct inode *inode, struct file *file)
 	if (!power_aware && !tt_dev->detached && !tt_dev->needs_hw_init) {
 		int ret = tenstorrent_set_aggregated_power_state(tt_dev);
 		if (ret < 0)
-			dev_warn(&tt_dev->dev, "Failed to set initial power state: %d\n", ret);
+			dev_warn(&tt_dev->pdev->dev, "Failed to set initial power state: %d\n", ret);
 	}
 
 	return 0;

--- a/enumerate.c
+++ b/enumerate.c
@@ -265,8 +265,7 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 
 	device_class = (const struct tenstorrent_device_class *)id->driver_data;
 
-	printk(KERN_INFO "Found a Tenstorrent %s device at bus %04x:%02x.\n",
-	       device_class->name, (unsigned)pci_domain_nr(dev->bus), (unsigned)dev->bus->number);
+	dev_info(&dev->dev, "Found a Tenstorrent %s device\n", device_class->name);
 
 	// During pre-test, unflashed boards have no class code which trips up __dev_sort_resources.
 	// Assign the proper class code and rerun resource assignment to clear things up.

--- a/memory.c
+++ b/memory.c
@@ -588,20 +588,20 @@ long ioctl_pin_pages(struct chardev_private *priv,
 	nr_pages = PAGE_ALIGN(in.size) >> PAGE_SHIFT;
 	pages = vzalloc(nr_pages * sizeof(struct page *));
 	if (!pages) {
-		pr_err("vzalloc failed for %lu page pointers\n", nr_pages);
+		dev_err(&priv->device->pdev->dev, "vzalloc failed for %lu page pointers\n", nr_pages);
 		ret = -ENOMEM;
 		goto err_free_pinning;
 	}
 
 	pages_pinned = pin_user_pages_fast_longterm(in.virtual_address, nr_pages, FOLL_WRITE, pages);
 	if (pages_pinned < 0) {
-		pr_warn("pin_user_pages_longterm failed: %d\n", pages_pinned);
+		dev_warn(&priv->device->pdev->dev, "pin_user_pages_longterm failed: %d\n", pages_pinned);
 		ret = pages_pinned;
 		goto err_vfree_pages;
 	}
 
 	if (pages_pinned != nr_pages) {
-		pr_err("could only pin %d of %lu pages\n", pages_pinned, nr_pages);
+		dev_err(&priv->device->pdev->dev, "could only pin %d of %lu pages\n", pages_pinned, nr_pages);
 		ret = -EINVAL;
 		goto err_unpin_pages;
 	}
@@ -613,7 +613,8 @@ long ioctl_pin_pages(struct chardev_private *priv,
 		unsigned long total_dma_len = 0;
 
 		if (!alloc_chained_sgt_for_pages(&dma_mapping, pages, nr_pages)) {
-			pr_warn("alloc_chained_sgt_for_pages failed for %lu pages, probably out of memory.\n", nr_pages);
+			dev_warn(&priv->device->pdev->dev,
+				 "alloc_chained_sgt_for_pages failed for %lu pages, probably out of memory\n", nr_pages);
 			ret = -ENOMEM;
 			goto err_unpin_pages;
 		}
@@ -621,14 +622,14 @@ long ioctl_pin_pages(struct chardev_private *priv,
 		ret = dma_map_sgtable(&priv->device->pdev->dev, &dma_mapping, DMA_BIDIRECTIONAL, 0);
 
 		if (ret != 0) {
-			pr_err("dma_map_sg failed.\n");
+			dev_err(&priv->device->pdev->dev, "dma_map_sg failed\n");
 			goto err_unlock_priv;
 		}
 
 		// This can only happen due to a misconfiguration or a bug.
 		for_each_sgtable_dma_sg((&dma_mapping), sg, i) {
 			if (i > 0 && sg_dma_address(sg) != expected_next_address) {
-				pr_err("discontiguous mapping\n");
+				dev_err(&priv->device->pdev->dev, "discontiguous mapping\n");
 				ret = -EINVAL;
 			}
 
@@ -637,12 +638,13 @@ long ioctl_pin_pages(struct chardev_private *priv,
 		}
 
 		if (total_dma_len != nr_pages * PAGE_SIZE) {
-			pr_err("dma-mapped (%lX) != original length (%lX).\n", total_dma_len, nr_pages * PAGE_SIZE);
+			dev_err(&priv->device->pdev->dev, "dma-mapped (%lX) != original length (%lX)\n",
+				total_dma_len, nr_pages * PAGE_SIZE);
 			ret = -EINVAL;
 		}
 
 		if (ret != 0) {
-			debug_print_sgtable(&dma_mapping);
+			debug_print_sgtable(&priv->device->pdev->dev, &dma_mapping);
 			goto err_dma_unmap;
 		}
 
@@ -660,7 +662,7 @@ long ioctl_pin_pages(struct chardev_private *priv,
 
 		for (i = 1; i < pages_pinned; i++) {
 			if (page_to_pfn(pages[i]) != page_to_pfn(pages[i-1]) + 1) {
-				pr_err("pages discontiguous at %d\n", i);
+				dev_err(&priv->device->pdev->dev, "pages discontiguous at %d\n", i);
 				ret = -EINVAL;
 				goto err_unpin_pages;
 			}
@@ -1031,7 +1033,7 @@ static void tenstorrent_vma_open(struct vm_area_struct *vma)
 
 	new_mmap_vma = kzalloc(sizeof(*new_mmap_vma), GFP_KERNEL);
 	if (!new_mmap_vma) {
-		pr_err_ratelimited("Failed to allocate mmap_vma on fork()\n");
+		dev_err_ratelimited(&priv->device->pdev->dev, "Failed to allocate mmap_vma on fork()\n");
 		zap_vma_ptes(vma, vma->vm_start, vma->vm_end - vma->vm_start);
 		vma->vm_private_data = NULL;
 		return;

--- a/module.c
+++ b/module.c
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
 // SPDX-License-Identifier: GPL-2.0-only
 
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/init.h>
@@ -67,7 +69,7 @@ static int __init ttdriver_init(void)
 {
 	int err = 0;
 
-	printk(KERN_INFO "Loading Tenstorrent AI driver module v%s.\n", TENSTORRENT_DRIVER_VERSION_STRING);
+	pr_info("Loading Tenstorrent AI driver module v%s\n", TENSTORRENT_DRIVER_VERSION_STRING);
 
 	tt_debugfs_root = debugfs_create_dir("tenstorrent", NULL);
 
@@ -99,7 +101,7 @@ fail_procfs:
 
 static void __exit ttdriver_cleanup(void)
 {
-	printk(KERN_INFO "Unloading Tenstorrent AI driver module.\n");
+	pr_info("Unloading Tenstorrent AI driver module\n");
 
 	tenstorrent_pci_unregister_driver();
 	cleanup_char_driver();

--- a/pcie.c
+++ b/pcie.c
@@ -109,7 +109,7 @@ bool wormhole_complete_pcie_init(struct tenstorrent_device *tt_dev, u8 __iomem* 
 
 		pci_read_config_word(bridge_dev, PCI_SUBSYSTEM_VENDOR_ID, &subsys_vendor_id);
 
-		if (!wormhole_send_arc_fw_message_with_args(&pdev->dev, reset_unit_regs, FW_MSG_PCIE_RETRAIN,
+		if (!wormhole_send_arc_fw_message_with_args(pdev, reset_unit_regs, FW_MSG_PCIE_RETRAIN,
 			target_link_speed | (last_retry << 15), subsys_vendor_id, 200000, &exit_code))
 			return false;
 

--- a/pcie.c
+++ b/pcie.c
@@ -28,7 +28,7 @@ static bool poll_pcie_link_up(struct pci_dev *pdev, u32 timeout_ms) {
 	pci_read_config_word(pdev, PCI_VENDOR_ID, &tt_vendor_id);
 	while (tt_vendor_id != PCI_VENDOR_ID_TENSTORRENT) {
 		if (ktime_after(ktime_get(), end_time)) {
-			pr_debug("device timeout during link up.\n");
+			dev_dbg(&pdev->dev, "device timeout during link up\n");
 			return false;
 		}
 
@@ -36,7 +36,7 @@ static bool poll_pcie_link_up(struct pci_dev *pdev, u32 timeout_ms) {
 		msleep(100);
 	}
 
-	pr_debug("device link up successfully.\n");
+	dev_dbg(&pdev->dev, "device link up successfully\n");
 	return true;
 }
 
@@ -109,15 +109,15 @@ bool wormhole_complete_pcie_init(struct tenstorrent_device *tt_dev, u8 __iomem* 
 
 		pci_read_config_word(bridge_dev, PCI_SUBSYSTEM_VENDOR_ID, &subsys_vendor_id);
 
-		if (!wormhole_send_arc_fw_message_with_args(reset_unit_regs, FW_MSG_PCIE_RETRAIN,
+		if (!wormhole_send_arc_fw_message_with_args(&pdev->dev, reset_unit_regs, FW_MSG_PCIE_RETRAIN,
 			target_link_speed | (last_retry << 15), subsys_vendor_id, 200000, &exit_code))
 			return false;
 
 		if (exit_code == 0) {
-			pr_debug("pcie init passed after %u iterations.\n", i);
+			dev_dbg(&pdev->dev, "pcie init passed after %u iterations\n", i);
 			return true;
 		} else {
-			pr_debug("pcie init failed on iteration %u.\n", i);
+			dev_dbg(&pdev->dev, "pcie init failed on iteration %u\n", i);
 			if (last_retry)
 				return false;
 		}

--- a/sg_helpers.c
+++ b/sg_helpers.c
@@ -98,20 +98,20 @@ void free_chained_sgt(struct sg_table *table)
 	}
 }
 
-void debug_print_sgtable(struct sg_table *table)
+void debug_print_sgtable(struct device *dev, struct sg_table *table)
 {
 	struct scatterlist *sg;
 	unsigned int i;
 	dma_addr_t expected_next_address;
 
-	pr_debug("dma_map_sgtable returned %u entries from %u original\n", table->nents, table->orig_nents);
+	dev_dbg(dev, "dma_map_sgtable returned %u entries from %u original\n", table->nents, table->orig_nents);
 
 	for_each_sgtable_dma_sg(table, sg, i) {
 		if (i > 0 && sg_dma_address(sg) != expected_next_address) {
-			pr_debug("discontiguous\n");
+			dev_dbg(dev, "discontiguous\n");
 		}
 
-		pr_debug("[%4u] %llX + %X\n", i, sg_dma_address(sg), sg_dma_len(sg));
+		dev_dbg(dev, "[%4u] %llX + %X\n", i, sg_dma_address(sg), sg_dma_len(sg));
 
 		expected_next_address = sg_dma_address(sg) + sg_dma_len(sg);
 	}

--- a/sg_helpers.h
+++ b/sg_helpers.h
@@ -36,6 +36,6 @@ static inline void dma_unmap_sgtable(struct device *dev, struct sg_table *dma_ma
 bool alloc_chained_sgt_for_pages(struct sg_table *table, struct page **pages, unsigned int n_pages);
 void free_chained_sgt(struct sg_table *table); // Safe to pass zero-intialized sg_table.
 
-void debug_print_sgtable(struct sg_table *table);
+void debug_print_sgtable(struct device *dev, struct sg_table *table);
 
 #endif

--- a/wormhole.c
+++ b/wormhole.c
@@ -160,7 +160,7 @@ static int csm_write32(struct wormhole_device *wh, u32 addr, u32 value)
 	return 0;
 }
 
-static int arc_msg_poll_completion(struct device *dev, u8 __iomem *reset_unit_regs, u8 __iomem *msg_reg,
+static int arc_msg_poll_completion(struct pci_dev *pdev, u8 __iomem *reset_unit_regs, u8 __iomem *msg_reg,
 				   u32 msg_code, u32 timeout_us, u16 *exit_code)
 {
 	// Scale poll_period for around 100 polls, and at least 10 us
@@ -177,18 +177,18 @@ static int arc_msg_poll_completion(struct device *dev, u8 __iomem *reset_unit_re
 			return 0;
 		}
 
-		if (read_val == 0xFFFFFFFFu && is_hardware_hung(NULL, reset_unit_regs)) {
-			dev_dbg(dev, "Tenstorrent device is hung executing message: %08X\n", msg_code);
+		if (read_val == 0xFFFFFFFFu && is_hardware_hung(pdev, reset_unit_regs)) {
+			dev_dbg(&pdev->dev, "Tenstorrent device is hung executing message: %08X\n", msg_code);
 			return -3;
 		}
 
 		if (read_val == 0xFFFFFFFFu) {
-			dev_dbg(dev, "Tenstorrent FW message unrecognized: %08X\n", msg_code);
+			dev_dbg(&pdev->dev, "Tenstorrent FW message unrecognized: %08X\n", msg_code);
 			return -2;
 		}
 
 		if (ktime_after(ktime_get(), end_time)) {
-			dev_dbg(dev, "Tenstorrent FW message timeout: %08X\n", msg_code);
+			dev_dbg(&pdev->dev, "Tenstorrent FW message timeout: %08X\n", msg_code);
 			return -1;
 		}
 
@@ -202,7 +202,7 @@ static bool arc_l2_is_running(u8 __iomem *reset_unit_regs)
 	return ((post_code & POST_CODE_ARC_L2_MASK) == POST_CODE_ARC_L2);
 }
 
-bool wormhole_send_arc_fw_message_with_args(struct device *dev, u8 __iomem *reset_unit_regs, u8 message_id,
+bool wormhole_send_arc_fw_message_with_args(struct pci_dev *pdev, u8 __iomem *reset_unit_regs, u8 message_id,
 					    u16 arg0, u16 arg1, u32 timeout_us, u16 *exit_code)
 {
 	void __iomem *args_reg = reset_unit_regs + SCRATCH_REG(3);
@@ -212,7 +212,7 @@ bool wormhole_send_arc_fw_message_with_args(struct device *dev, u8 __iomem *rese
 	u32 arc_misc_cntl;
 
 	if (!arc_l2_is_running(reset_unit_regs)) {
-		dev_warn(dev, "Skipping message %08X due to FW not running\n", (unsigned int)message_id);
+		dev_warn(&pdev->dev, "Skipping message %08X due to FW not running\n", (unsigned int)message_id);
 		return false;
 	}
 
@@ -226,17 +226,17 @@ bool wormhole_send_arc_fw_message_with_args(struct device *dev, u8 __iomem *rese
 	if (timeout_us == 0)
 		return false;
 
-	if (arc_msg_poll_completion(dev, reset_unit_regs, message_reg, message_id, timeout_us, exit_code) < 0) {
+	if (arc_msg_poll_completion(pdev, reset_unit_regs, message_reg, message_id, timeout_us, exit_code) < 0) {
 		return false;
 	} else {
 		return true;
 	}
 }
 
-static bool wormhole_send_arc_fw_message(struct device *dev, u8 __iomem *reset_unit_regs, u8 message_id,
+static bool wormhole_send_arc_fw_message(struct pci_dev *pdev, u8 __iomem *reset_unit_regs, u8 message_id,
 					 u32 timeout_us, u16 *exit_code)
 {
-	return wormhole_send_arc_fw_message_with_args(dev, reset_unit_regs, message_id, 0, 0, timeout_us, exit_code);
+	return wormhole_send_arc_fw_message_with_args(pdev, reset_unit_regs, message_id, 0, 0, timeout_us, exit_code);
 }
 
 static bool __maybe_unused send_arc_message(struct wormhole_device *wh, struct arc_msg *msg)
@@ -295,7 +295,7 @@ static bool wormhole_shutdown_firmware(struct pci_dev *pdev, u8 __iomem *reset_u
 	if (is_hardware_hung(pdev, reset_unit_regs))
 		return false;
 
-	if (!wormhole_send_arc_fw_message(&pdev->dev, reset_unit_regs, WH_FW_MSG_ASTATE3, 10000, NULL))
+	if (!wormhole_send_arc_fw_message(pdev, reset_unit_regs, WH_FW_MSG_ASTATE3, 10000, NULL))
 		return false;
 	return true;
 }
@@ -318,7 +318,7 @@ static void month_lookup(u32 days_into_year, u32 *day, u32 *month)
 	*month = i;
 }
 
-static void wormhole_send_curr_date(struct device *dev, u8 __iomem *reset_unit_regs)
+static void wormhole_send_curr_date(struct pci_dev *pdev, u8 __iomem *reset_unit_regs)
 {
 	const u32 SECONDS_TO_2020 = 1577836800; // date -d "Jan 1, 2020 UTC" +%s
 	const u32 DAYS_PER_FOUR_YEARS = 4 * 365 + 1;
@@ -355,7 +355,7 @@ static void wormhole_send_curr_date(struct device *dev, u8 __iomem *reset_unit_r
 	packed_datetime_low = (HH << 8) | MM;
 	packed_datetime_high = (Y << 12) | (M << 8) | DD;
 
-	wormhole_send_arc_fw_message_with_args(dev, reset_unit_regs, WH_FW_MSG_CURR_DATE, packed_datetime_low,
+	wormhole_send_arc_fw_message_with_args(pdev, reset_unit_regs, WH_FW_MSG_CURR_DATE, packed_datetime_low,
 					       packed_datetime_high, 1000, NULL);
 }
 
@@ -464,7 +464,7 @@ static u8 __iomem *reset_unit_regs(struct wormhole_device *wh_dev) {
 static void update_device_index(struct wormhole_device *wh_dev) {
 	static const u8 INDEX_VALID = 0x80;
 
-	wormhole_send_arc_fw_message_with_args(&wh_dev->tt.pdev->dev, reset_unit_regs(wh_dev),
+	wormhole_send_arc_fw_message_with_args(wh_dev->tt.pdev, reset_unit_regs(wh_dev),
 						WH_FW_MSG_PCIE_INDEX,
 						wh_dev->tt.ordinal | INDEX_VALID, 0,
 						10*1000, NULL);
@@ -478,7 +478,7 @@ static bool wormhole_reset(struct tenstorrent_device *tt_dev, u32 reset_flag)
 	bool responsive;
 
 	// See if the device is responsive.
-	responsive = wormhole_send_arc_fw_message(&pdev->dev, reset_unit_regs(wh_dev), WH_FW_MSG_NOP, 1000, NULL);
+	responsive = wormhole_send_arc_fw_message(pdev, reset_unit_regs(wh_dev), WH_FW_MSG_NOP, 1000, NULL);
 
 	// If not responsive, wait for the watchdog.
 	if (!responsive) {
@@ -494,7 +494,7 @@ static bool wormhole_reset(struct tenstorrent_device *tt_dev, u32 reset_flag)
 		while (ktime_before(ktime_get(), end_time)) {
 			pcie_hot_reset_and_restore_state(pdev);
 
-			responsive = wormhole_send_arc_fw_message(&pdev->dev, reset_unit_regs(wh_dev), WH_FW_MSG_NOP,
+			responsive = wormhole_send_arc_fw_message(pdev, reset_unit_regs(wh_dev), WH_FW_MSG_NOP,
 								  1000, NULL);
 			if (responsive)
 				break;
@@ -507,7 +507,7 @@ static bool wormhole_reset(struct tenstorrent_device *tt_dev, u32 reset_flag)
 	// If the device is responsive, finalize the reset.
 	if (responsive) {
 		set_reset_marker(pdev);
-		wormhole_send_arc_fw_message_with_args(&pdev->dev, reset_unit_regs(wh_dev), WH_FW_MSG_TRIGGER_RESET,
+		wormhole_send_arc_fw_message_with_args(pdev, reset_unit_regs(wh_dev), WH_FW_MSG_TRIGGER_RESET,
 						       reset_arg, 0, 0, NULL);
 		return true; // Assumes the reset was successful.
 	}
@@ -721,12 +721,12 @@ static bool wormhole_init_hardware(struct tenstorrent_device *tt_dev) {
 	map_bar4_to_system_registers(wh_dev);
 
 	if (arc_l2_is_running(reset_unit_regs(wh_dev))) {
-		wormhole_send_curr_date(&tt_dev->pdev->dev, reset_unit_regs(wh_dev));
-		wormhole_send_arc_fw_message(&tt_dev->pdev->dev, reset_unit_regs(wh_dev), WH_FW_MSG_ASTATE0, 10000,
+		wormhole_send_curr_date(tt_dev->pdev, reset_unit_regs(wh_dev));
+		wormhole_send_arc_fw_message(tt_dev->pdev, reset_unit_regs(wh_dev), WH_FW_MSG_ASTATE0, 10000,
 					     NULL);
 		update_device_index(wh_dev);
 		wormhole_complete_pcie_init(&wh_dev->tt, reset_unit_regs(wh_dev));
-		wormhole_send_arc_fw_message_with_args(&tt_dev->pdev->dev, reset_unit_regs(wh_dev),
+		wormhole_send_arc_fw_message_with_args(tt_dev->pdev, reset_unit_regs(wh_dev),
 						       WH_FW_MSG_UPDATE_M3_AUTO_RESET_TIMEOUT, auto_reset_timeout, 0,
 						       10000, NULL);
 	}

--- a/wormhole.c
+++ b/wormhole.c
@@ -160,8 +160,8 @@ static int csm_write32(struct wormhole_device *wh, u32 addr, u32 value)
 	return 0;
 }
 
-static int arc_msg_poll_completion(u8 __iomem *reset_unit_regs, u8 __iomem *msg_reg, u32 msg_code, u32 timeout_us,
-				   u16 *exit_code)
+static int arc_msg_poll_completion(struct device *dev, u8 __iomem *reset_unit_regs, u8 __iomem *msg_reg,
+				   u32 msg_code, u32 timeout_us, u16 *exit_code)
 {
 	// Scale poll_period for around 100 polls, and at least 10 us
 	u32 poll_period_us = max((u32)10, timeout_us / 100);
@@ -178,17 +178,17 @@ static int arc_msg_poll_completion(u8 __iomem *reset_unit_regs, u8 __iomem *msg_
 		}
 
 		if (read_val == 0xFFFFFFFFu && is_hardware_hung(NULL, reset_unit_regs)) {
-			pr_debug("Tenstorrent Device is hung executing message: %08X.", msg_code);
+			dev_dbg(dev, "Tenstorrent device is hung executing message: %08X\n", msg_code);
 			return -3;
 		}
 
 		if (read_val == 0xFFFFFFFFu) {
-			pr_debug("Tenstorrent FW message unrecognized: %08X.", msg_code);
+			dev_dbg(dev, "Tenstorrent FW message unrecognized: %08X\n", msg_code);
 			return -2;
 		}
 
 		if (ktime_after(ktime_get(), end_time)) {
-			pr_debug("Tenstorrent FW message timeout: %08X.", msg_code);
+			dev_dbg(dev, "Tenstorrent FW message timeout: %08X\n", msg_code);
 			return -1;
 		}
 
@@ -202,8 +202,8 @@ static bool arc_l2_is_running(u8 __iomem *reset_unit_regs)
 	return ((post_code & POST_CODE_ARC_L2_MASK) == POST_CODE_ARC_L2);
 }
 
-bool wormhole_send_arc_fw_message_with_args(u8 __iomem *reset_unit_regs, u8 message_id, u16 arg0, u16 arg1,
-					    u32 timeout_us, u16 *exit_code)
+bool wormhole_send_arc_fw_message_with_args(struct device *dev, u8 __iomem *reset_unit_regs, u8 message_id,
+					    u16 arg0, u16 arg1, u32 timeout_us, u16 *exit_code)
 {
 	void __iomem *args_reg = reset_unit_regs + SCRATCH_REG(3);
 	void __iomem *message_reg = reset_unit_regs + SCRATCH_REG(5);
@@ -212,7 +212,7 @@ bool wormhole_send_arc_fw_message_with_args(u8 __iomem *reset_unit_regs, u8 mess
 	u32 arc_misc_cntl;
 
 	if (!arc_l2_is_running(reset_unit_regs)) {
-		pr_warn("Skipping message %08X due to FW not running.\n", (unsigned int)message_id);
+		dev_warn(dev, "Skipping message %08X due to FW not running\n", (unsigned int)message_id);
 		return false;
 	}
 
@@ -226,16 +226,17 @@ bool wormhole_send_arc_fw_message_with_args(u8 __iomem *reset_unit_regs, u8 mess
 	if (timeout_us == 0)
 		return false;
 
-	if (arc_msg_poll_completion(reset_unit_regs, message_reg, message_id, timeout_us, exit_code) < 0) {
+	if (arc_msg_poll_completion(dev, reset_unit_regs, message_reg, message_id, timeout_us, exit_code) < 0) {
 		return false;
 	} else {
 		return true;
 	}
 }
 
-static bool wormhole_send_arc_fw_message(u8 __iomem *reset_unit_regs, u8 message_id, u32 timeout_us, u16 *exit_code)
+static bool wormhole_send_arc_fw_message(struct device *dev, u8 __iomem *reset_unit_regs, u8 message_id,
+					 u32 timeout_us, u16 *exit_code)
 {
-	return wormhole_send_arc_fw_message_with_args(reset_unit_regs, message_id, 0, 0, timeout_us, exit_code);
+	return wormhole_send_arc_fw_message_with_args(dev, reset_unit_regs, message_id, 0, 0, timeout_us, exit_code);
 }
 
 static bool __maybe_unused send_arc_message(struct wormhole_device *wh, struct arc_msg *msg)
@@ -294,7 +295,7 @@ static bool wormhole_shutdown_firmware(struct pci_dev *pdev, u8 __iomem *reset_u
 	if (is_hardware_hung(pdev, reset_unit_regs))
 		return false;
 
-	if (!wormhole_send_arc_fw_message(reset_unit_regs, WH_FW_MSG_ASTATE3, 10000, NULL))
+	if (!wormhole_send_arc_fw_message(&pdev->dev, reset_unit_regs, WH_FW_MSG_ASTATE3, 10000, NULL))
 		return false;
 	return true;
 }
@@ -317,7 +318,7 @@ static void month_lookup(u32 days_into_year, u32 *day, u32 *month)
 	*month = i;
 }
 
-static void wormhole_send_curr_date(u8 __iomem *reset_unit_regs)
+static void wormhole_send_curr_date(struct device *dev, u8 __iomem *reset_unit_regs)
 {
 	const u32 SECONDS_TO_2020 = 1577836800; // date -d "Jan 1, 2020 UTC" +%s
 	const u32 DAYS_PER_FOUR_YEARS = 4 * 365 + 1;
@@ -354,7 +355,7 @@ static void wormhole_send_curr_date(u8 __iomem *reset_unit_regs)
 	packed_datetime_low = (HH << 8) | MM;
 	packed_datetime_high = (Y << 12) | (M << 8) | DD;
 
-	wormhole_send_arc_fw_message_with_args(reset_unit_regs, WH_FW_MSG_CURR_DATE, packed_datetime_low,
+	wormhole_send_arc_fw_message_with_args(dev, reset_unit_regs, WH_FW_MSG_CURR_DATE, packed_datetime_low,
 					       packed_datetime_high, 1000, NULL);
 }
 
@@ -463,7 +464,7 @@ static u8 __iomem *reset_unit_regs(struct wormhole_device *wh_dev) {
 static void update_device_index(struct wormhole_device *wh_dev) {
 	static const u8 INDEX_VALID = 0x80;
 
-	wormhole_send_arc_fw_message_with_args(reset_unit_regs(wh_dev),
+	wormhole_send_arc_fw_message_with_args(&wh_dev->tt.pdev->dev, reset_unit_regs(wh_dev),
 						WH_FW_MSG_PCIE_INDEX,
 						wh_dev->tt.ordinal | INDEX_VALID, 0,
 						10*1000, NULL);
@@ -477,7 +478,7 @@ static bool wormhole_reset(struct tenstorrent_device *tt_dev, u32 reset_flag)
 	bool responsive;
 
 	// See if the device is responsive.
-	responsive = wormhole_send_arc_fw_message(reset_unit_regs(wh_dev), WH_FW_MSG_NOP, 1000, NULL);
+	responsive = wormhole_send_arc_fw_message(&pdev->dev, reset_unit_regs(wh_dev), WH_FW_MSG_NOP, 1000, NULL);
 
 	// If not responsive, wait for the watchdog.
 	if (!responsive) {
@@ -493,7 +494,8 @@ static bool wormhole_reset(struct tenstorrent_device *tt_dev, u32 reset_flag)
 		while (ktime_before(ktime_get(), end_time)) {
 			pcie_hot_reset_and_restore_state(pdev);
 
-			responsive = wormhole_send_arc_fw_message(reset_unit_regs(wh_dev), WH_FW_MSG_NOP, 1000, NULL);
+			responsive = wormhole_send_arc_fw_message(&pdev->dev, reset_unit_regs(wh_dev), WH_FW_MSG_NOP,
+								  1000, NULL);
 			if (responsive)
 				break;
 
@@ -505,8 +507,8 @@ static bool wormhole_reset(struct tenstorrent_device *tt_dev, u32 reset_flag)
 	// If the device is responsive, finalize the reset.
 	if (responsive) {
 		set_reset_marker(pdev);
-		wormhole_send_arc_fw_message_with_args(reset_unit_regs(wh_dev), WH_FW_MSG_TRIGGER_RESET, reset_arg, 0,
-							0, NULL);
+		wormhole_send_arc_fw_message_with_args(&pdev->dev, reset_unit_regs(wh_dev), WH_FW_MSG_TRIGGER_RESET,
+						       reset_arg, 0, 0, NULL);
 		return true; // Assumes the reset was successful.
 	}
 
@@ -719,11 +721,14 @@ static bool wormhole_init_hardware(struct tenstorrent_device *tt_dev) {
 	map_bar4_to_system_registers(wh_dev);
 
 	if (arc_l2_is_running(reset_unit_regs(wh_dev))) {
-		wormhole_send_curr_date(reset_unit_regs(wh_dev));
-		wormhole_send_arc_fw_message(reset_unit_regs(wh_dev), WH_FW_MSG_ASTATE0, 10000, NULL);
+		wormhole_send_curr_date(&tt_dev->pdev->dev, reset_unit_regs(wh_dev));
+		wormhole_send_arc_fw_message(&tt_dev->pdev->dev, reset_unit_regs(wh_dev), WH_FW_MSG_ASTATE0, 10000,
+					     NULL);
 		update_device_index(wh_dev);
 		wormhole_complete_pcie_init(&wh_dev->tt, reset_unit_regs(wh_dev));
-		wormhole_send_arc_fw_message_with_args(reset_unit_regs(wh_dev), WH_FW_MSG_UPDATE_M3_AUTO_RESET_TIMEOUT, auto_reset_timeout, 0, 10000, NULL);
+		wormhole_send_arc_fw_message_with_args(&tt_dev->pdev->dev, reset_unit_regs(wh_dev),
+						       WH_FW_MSG_UPDATE_M3_AUTO_RESET_TIMEOUT, auto_reset_timeout, 0,
+						       10000, NULL);
 	}
 
 	return true;
@@ -747,7 +752,7 @@ static bool wormhole_init_telemetry(struct tenstorrent_device *tt_dev)
 
 	r = device_add_group(&tt_dev->dev, &wh_pcie_perf_counters_group);
 	if (r)
-		dev_err(&tt_dev->dev, "PCIe perf counters unavailable: %d\n", r);
+		dev_err(&tt_dev->pdev->dev, "PCIe perf counters unavailable: %d\n", r);
 	else
 		wh_dev->pcie_perf_group_registered = true;
 

--- a/wormhole.h
+++ b/wormhole.h
@@ -26,7 +26,7 @@ struct wormhole_device {
 #define tt_dev_to_wh_dev(ttdev) \
 	container_of((tt_dev), struct wormhole_device, tt)
 
-bool wormhole_send_arc_fw_message_with_args(u8 __iomem *reset_unit_regs, u8 message_id, u16 arg0, u16 arg1,
-					    u32 timeout_us, u16 *exit_code);
+bool wormhole_send_arc_fw_message_with_args(struct device *dev, u8 __iomem *reset_unit_regs, u8 message_id,
+					    u16 arg0, u16 arg1, u32 timeout_us, u16 *exit_code);
 
 #endif

--- a/wormhole.h
+++ b/wormhole.h
@@ -26,7 +26,7 @@ struct wormhole_device {
 #define tt_dev_to_wh_dev(ttdev) \
 	container_of((tt_dev), struct wormhole_device, tt)
 
-bool wormhole_send_arc_fw_message_with_args(struct device *dev, u8 __iomem *reset_unit_regs, u8 message_id,
+bool wormhole_send_arc_fw_message_with_args(struct pci_dev *pdev, u8 __iomem *reset_unit_regs, u8 message_id,
 					    u16 arg0, u16 arg1, u32 timeout_us, u16 *exit_code);
 
 #endif


### PR DESCRIPTION
## Summary

This improves logging consistency by using device scoped logging for messages tied to a PCI device, so logs include the PCI BDF where possible.

Changes include:
- Replace device-specific `printk` / `pr_debug` / `pr_warn` / `pr_err` call sites with `dev_*` logging.
- Prefer the PCI device (`&pdev->dev`) for driver messages that should identify the physical device by BDF.
- Add `dev_dbg` logging for power-state requests so developers can opt into extra detail via dynamic debug.
- Thread `struct device *` through Wormhole ARC message helpers so firmware message logs include device context.
- Convert scatterlist debug dump output to `dev_dbg`.

Fixes #238 