### PR TITLE
Fix DKMS cleanup during Debian upgrades

### DIFF
--- a/tools/build_debs.sh
+++ b/tools/build_debs.sh
@@ -79,6 +79,21 @@ cat > "${DEBIAN_DIR}/postinst" << 'EOF'
 #!/bin/sh
 set -e
 
+# Remove stale DKMS registrations left behind by older packages.  Once the
+# matching /usr/src tree is gone, dkms remove cannot recover the entry.
+for dkms_dir in /var/lib/dkms/tenstorrent/*; do
+    [ -d "$dkms_dir" ] || continue
+    [ -L "$dkms_dir/source" ] || [ -d "$dkms_dir/source" ] || continue
+    [ ! -e "$dkms_dir/source/dkms.conf" ] || continue
+
+    case "$dkms_dir" in
+        /var/lib/dkms/tenstorrent/*)
+            echo "Removing stale Tenstorrent DKMS state: $dkms_dir"
+            rm -rf "$dkms_dir"
+            ;;
+    esac
+done
+
 # Pass arguments to common postinst script
 /usr/lib/dkms/common.postinst tenstorrent __VERSION__ /usr/share/tenstorrent "" "$2"
 
@@ -101,8 +116,8 @@ cat > "${DEBIAN_DIR}/prerm" << 'EOF'
 set -e
 
 case "$1" in
-    remove)
-        dkms remove -m tenstorrent -v __VERSION__ --all
+    remove|upgrade)
+        dkms remove -m tenstorrent -v __VERSION__ --all || true
         ;;
 esac
 
@@ -137,4 +152,3 @@ echo "Package contents:"
 dpkg-deb --contents "${OUTPUT_DIR}/${DEB_FILE}"
 
 exit 0
-


### PR DESCRIPTION
## Summary

Fix Debian package maintainer scripts so stale Tenstorrent DKMS registrations do not survive package upgrades and break future kernel updates.

The generated `prerm` now removes the package's DKMS registration on both `remove` and `upgrade`. The generated `postinst` also cleans up stale Tenstorrent DKMS entries whose `source/dkms.conf` is already missing, repairing systems affected by older packages.

## Motivation

A system upgraded from `tenstorrent-dkms` 2.7.0 to 2.8.0 was left with stale DKMS state:

```
/var/lib/dkms/tenstorrent/2.7.0/source -> /usr/src/tenstorrent-2.7.0
```

but /usr/src/tenstorrent-2.7.0 no longer existed.

On a later kernel update, Ubuntu's DKMS hooks failed with:

Error! Could not locate dkms.conf file.
File: /var/lib/dkms/tenstorrent/2.7.0/source/dkms.conf does not exist.

This prevented DKMS from rebuilding the current tenstorrent/2.8.0 module for the new kernel.

## Testing

- Ran bash -n tools/build_debs.sh