### PR TITLE
ci: fix deb artifact name to use Debian version

### DIFF
--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -34,17 +34,21 @@ jobs:
         id: version
         run: |
           VERSION=$(./tools/current-version)
+          # Debian uses ~ for prerelease sorting (2.7.0~rc1 sorts before 2.7.0).
+          DEB_VERSION="${VERSION//-/\~}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "deb_version=${DEB_VERSION}" >> $GITHUB_OUTPUT
           echo "Version: ${VERSION}"
+          echo "Deb version: ${DEB_VERSION}"
 
       - name: Upload Debian package
         uses: actions/upload-artifact@v4
         with:
-          name: tenstorrent-dkms_${{ steps.version.outputs.version }}_all.deb
-          path: tenstorrent-dkms_${{ steps.version.outputs.version }}_all.deb
+          name: tenstorrent-dkms_${{ steps.version.outputs.deb_version }}_all.deb
+          path: tenstorrent-dkms_${{ steps.version.outputs.deb_version }}_all.deb
 
       - name: Display package info
         run: |
           echo "=== Package Information ==="
-          dpkg-deb --info tenstorrent-dkms_${{ steps.version.outputs.version }}_all.deb
+          dpkg-deb --info tenstorrent-dkms_${{ steps.version.outputs.deb_version }}_all.deb
 


### PR DESCRIPTION
tools/build_debs.sh converts `-` to `~` in the version string so that prerelease packages sort correctly (e.g. 2.9.0-rc1 -> 2.9.0~rc1), but build-debian.yml was looking up the resulting .deb using the raw output of tools/current-version.  This caused upload-artifact to find nothing and `dpkg-deb --info` to fail with "No such file or directory" on any release-candidate build.

Apply the same `${VERSION//-/\~}` transform in the workflow and use it for the artifact name, upload path, and info lookup.  The RPM workflow already does this; only the deb workflow was wrong.

Assisted-by: Claude:claude-4.7-opus