### PR TITLE
Add RHEL 9.4+ kernel compatibility

### DIFF
--- a/chardev.c
+++ b/chardev.c
@@ -56,8 +56,7 @@ int init_char_driver(unsigned int max_devices)
 	if (res < 0)
 		goto alloc_chrdev_region_failed;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0) || \
-    (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0) || TT_RHEL_RELEASE_GE(9, 4)
 	tt_dev_class = class_create(TENSTORRENT);
 #else
 	tt_dev_class = class_create(THIS_MODULE, TENSTORRENT);

--- a/chardev.c
+++ b/chardev.c
@@ -56,7 +56,8 @@ int init_char_driver(unsigned int max_devices)
 	if (res < 0)
 		goto alloc_chrdev_region_failed;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0) || \
+    (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4))
 	tt_dev_class = class_create(TENSTORRENT);
 #else
 	tt_dev_class = class_create(THIS_MODULE, TENSTORRENT);

--- a/enumerate.c
+++ b/enumerate.c
@@ -23,8 +23,7 @@
 #include "wormhole.h"
 #include "tlb.h"
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0) || \
-    (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0) || TT_RHEL_RELEASE_GE(9, 4)
 #define pci_enable_pcie_error_reporting(dev) do { } while (0)
 #define pci_disable_pcie_error_reporting(dev) do { } while (0)
 #else

--- a/enumerate.c
+++ b/enumerate.c
@@ -23,7 +23,8 @@
 #include "wormhole.h"
 #include "tlb.h"
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0) || \
+    (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4))
 #define pci_enable_pcie_error_reporting(dev) do { } while (0)
 #define pci_disable_pcie_error_reporting(dev) do { } while (0)
 #else

--- a/module.h
+++ b/module.h
@@ -6,6 +6,15 @@
 
 #include <linux/types.h>
 #include <linux/pci.h>
+#include <linux/version.h>
+
+// RHEL 9.4 backports API changes that normally key off newer upstream kernels.
+// Keep RHEL_RELEASE_VERSION() guarded because non-RHEL kernels do not define it.
+#if defined(RHEL_RELEASE_CODE) && defined(RHEL_RELEASE_VERSION)
+#define TT_RHEL_RELEASE_GE(a, b) (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(a, b))
+#else
+#define TT_RHEL_RELEASE_GE(a, b) 0
+#endif
 
 #define TENSTORRENT_DRIVER_VERSION_MAJOR 2
 #define TENSTORRENT_DRIVER_VERSION_MINOR 9


### PR DESCRIPTION
RHEL 9.4 backports two upstream API changes into its 5.14 kernel (class_create signature change, pci_*_pcie_error_reporting removal) that break the build on RHEL/RHCOS 9.4+.

This PR adds a `RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4)` gate to chardev.c and enumerate.c to support these backports without affecting mainline builds.

Tested: Builds and loads successfully on RHCOS running 5.14.0-570 via KMM.