### PR TITLE
Add TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF

### DIFF
--- a/chardev.c
+++ b/chardev.c
@@ -213,6 +213,25 @@ static long ioctl_reset_device(struct chardev_private *priv,
 	if (copy_from_user(&in, &arg->in, sizeof(in)) != 0)
 		return -EFAULT;
 
+	// Refuse a destructive in-place reset while any TLB window is exported as
+	// a dma-buf: an importer may be doing peer-to-peer DMA into it, and a
+	// pin-only importer cannot be revoked to make the reset safe. See the
+	// EXPORT_TLB_DMABUF rationale in ioctl.h. RESTORE_STATE/POST_RESET are the
+	// re-init halves of a reset sequence, not destructive, so they are left
+	// alone.
+	switch (in.flags) {
+	case TENSTORRENT_RESET_DEVICE_RESET_PCIE_LINK:
+	case TENSTORRENT_RESET_DEVICE_CONFIG_WRITE:
+	case TENSTORRENT_RESET_DEVICE_USER_RESET:
+	case TENSTORRENT_RESET_DEVICE_ASIC_RESET:
+	case TENSTORRENT_RESET_DEVICE_ASIC_DMC_RESET:
+		if (tenstorrent_has_tlb_dmabuf_exports(tt_dev))
+			return -EBUSY;
+		break;
+	default:
+		break;
+	}
+
 	// Drain any deferred idle powerdown before disturbing the device.
 	// open()/release() take reset_rwsem shared and we hold it exclusive
 	// here, so no new arm can land between the cancel and the reset.

--- a/chardev.c
+++ b/chardev.c
@@ -668,6 +668,10 @@ static long tt_cdev_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
 			ret = ioctl_set_power_state(priv, (struct tenstorrent_power_state __user *)arg);
 			break;
 
+		case TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF:
+			ret = ioctl_export_tlb_dmabuf(priv, (struct tenstorrent_export_tlb_dmabuf __user *)arg);
+			break;
+
 		default:
 			ret = -EINVAL;
 			break;

--- a/device.h
+++ b/device.h
@@ -10,6 +10,7 @@
 #include <linux/cdev.h>
 #include <linux/reboot.h>
 #include <linux/kref.h>
+#include <linux/refcount.h>
 #include <linux/rwsem.h>
 #include <linux/wait.h>
 #include <linux/workqueue.h>
@@ -63,6 +64,7 @@ struct tenstorrent_device {
 
 	DECLARE_BITMAP(tlbs, TENSTORRENT_MAX_INBOUND_TLBS);
 	u32 tlb_counts[MAX_TLB_KINDS];	// Per-device TLB counts (may differ from dev_class defaults)
+	refcount_t tlb_refcount[TENSTORRENT_MAX_INBOUND_TLBS];
 
 	struct mutex iatu_mutex;
 	struct tenstorrent_outbound_iatu_region outbound_iatus[TENSTORRENT_MAX_OUTBOUND_IATU_REGIONS];

--- a/device.h
+++ b/device.h
@@ -77,6 +77,9 @@ struct tenstorrent_device {
 	// The stored value is arch-specific: WH stores a BAR4 sysreg offset,
 	// BH stores a raw CSM address for NOC reads.
 	u64 telemetry_tag_cache[TELEM_TAG_CACHE_SIZE];
+
+	struct list_head dmabuf_exports;
+	struct mutex dmabuf_export_lock;
 };
 
 struct tlb_descriptor;

--- a/enumerate.c
+++ b/enumerate.c
@@ -315,6 +315,8 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 
 	mutex_init(&tt_dev->chardev_mutex);
 	mutex_init(&tt_dev->iatu_mutex);
+	mutex_init(&tt_dev->dmabuf_export_lock);
+	INIT_LIST_HEAD(&tt_dev->dmabuf_exports);
 	INIT_DELAYED_WORK(&tt_dev->power_down_work, tenstorrent_power_down_work_func);
 
 	// Use dma_address_bits from module parameter or device class for coherent
@@ -444,6 +446,18 @@ static void tenstorrent_pci_remove(struct pci_dev *dev)
 	tt_dev->dev_class->cleanup_device(tt_dev); // unmap BARs
 	up_write(&tt_dev->reset_rwsem);
 
+	// Revoke all TLB dma-buf exports.  Correctness depends on reset_rwsem:
+	// every export is created by an ioctl holding it shared, and the
+	// detached check at ioctl entry runs under that same hold.  An export
+	// in flight at this point therefore completes its list_add before the
+	// write-side drain above finishes, and this walk sees it.  An export
+	// ioctl arriving after the drain takes the read lock after our
+	// up_write -- an acquire of our release -- so it is guaranteed to
+	// observe detached (written before down_write) and fail at entry
+	// before a dma-buf can be created.  Do not move this call above the
+	// drain, and do not move the detached check outside the rwsem.
+	tenstorrent_revoke_tlb_dmabufs(tt_dev);
+
 	// Wake any LOCK_CTL ACQUIRE_BLOCKING waiters parked on this device so
 	// they observe detached and return -ENODEV instead of waiting forever.
 	wake_up_interruptible(&tt_dev->resource_lock_waitqueue);
@@ -487,6 +501,7 @@ static int tenstorrent_suspend(struct device *dev) {
 	struct tenstorrent_device *tt_dev = pci_get_drvdata(pdev);
 
 	cancel_delayed_work_sync(&tt_dev->power_down_work);
+	tenstorrent_revoke_tlb_dmabufs(tt_dev);
 
 	tt_dev->dev_class->cleanup_hardware(tt_dev);
 

--- a/ioctl.h
+++ b/ioctl.h
@@ -27,6 +27,7 @@
 #define TENSTORRENT_IOCTL_CONFIGURE_TLB		_IO(TENSTORRENT_IOCTL_MAGIC, 13)
 #define TENSTORRENT_IOCTL_SET_NOC_CLEANUP		_IO(TENSTORRENT_IOCTL_MAGIC, 14)
 #define TENSTORRENT_IOCTL_SET_POWER_STATE		_IO(TENSTORRENT_IOCTL_MAGIC, 15)
+#define TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF		_IO(TENSTORRENT_IOCTL_MAGIC, 16)
 
 // For tenstorrent_mapping.mapping_id. These are not array indices.
 #define TENSTORRENT_MAPPING_UNUSED		0
@@ -407,6 +408,40 @@ struct tenstorrent_power_state {
 #define TT_POWER_FLAG_TENSIX_ENABLE     (1U << 2) /* 1=Enable Tensix, 0=Clock Gate Tensix */
 #define TT_POWER_FLAG_L2CPU_ENABLE      (1U << 3) /* 1=Enable L2CPU,  0=Clock Gate L2CPU */
 	__u16 power_settings[14];
+};
+
+/**
+ * TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF - export a TLB window as a dma-buf
+ *
+ * Wraps a previously-allocated TLB window (see TENSTORRENT_IOCTL_ALLOCATE_TLB)
+ * in a dma-buf and returns a file descriptor for it. The fd can be handed to
+ * another device's driver -- e.g. an RDMA NIC via ibv_reg_dmabuf_mr() -- so
+ * that device can perform peer-to-peer PCIe DMA into/out of the window, which
+ * routes onto the NOC according to the window's configuration (CONFIGURE_TLB).
+ *
+ * The exported region is [offset, offset + size) within the window. A size of
+ * 0 means the remainder of the window starting at offset.
+ *
+ * WARNING: behavior is undefined if the device is reset while an importer holds
+ * a mapping of the returned dma-buf. The importer's mapping cannot be revoked.
+ * Applications must release importer mappings before resetting the device.
+ *
+ * @argsz: Must be sizeof(struct tenstorrent_export_tlb_dmabuf).
+ * @flags: Reserved for future use, must be 0.
+ * @tlb_id: A TLB window id returned by TENSTORRENT_IOCTL_ALLOCATE_TLB.
+ * @fd: OUT: the dma-buf file descriptor.
+ * @offset: Byte offset within the window at which the export begins; must be
+ *          page-aligned.
+ * @size: Number of bytes to export; 0 means to the end of the window. A
+ *        non-zero size must be a multiple of the page size.
+ */
+struct tenstorrent_export_tlb_dmabuf {
+	__u32 argsz;
+	__u32 flags;
+	__u32 tlb_id;
+	__s32 fd;
+	__u64 offset;
+	__u64 size;
 };
 
 #endif

--- a/ioctl.h
+++ b/ioctl.h
@@ -419,12 +419,23 @@ struct tenstorrent_power_state {
  * that device can perform peer-to-peer PCIe DMA into/out of the window, which
  * routes onto the NOC according to the window's configuration (CONFIGURE_TLB).
  *
- * The exported region is [offset, offset + size) within the window. A size of
- * 0 means the remainder of the window starting at offset.
+ * The exported region is [offset, offset + size); a size of 0 means the
+ * remainder of the window starting at offset.
  *
- * WARNING: behavior is undefined if the device is reset while an importer holds
- * a mapping of the returned dma-buf. The importer's mapping cannot be revoked.
- * Applications must release importer mappings before resetting the device.
+ * The region is a PCI BAR aperture with no backing pages, so importers must
+ * support peer-to-peer DMA. Both importers that implement move_notify and
+ * importers that pin the mapping are accepted.
+ *
+ * Resetting the device under in-flight P2P DMA can wedge the host hard enough
+ * to require out-of-band recovery, and a pin-only importer cannot be revoked to
+ * prevent the in-flight DMA. RESET_DEVICE is therefore refused with -EBUSY
+ * while any export is live.
+ *
+ * An export pins its window: FREE_TLB or close() of the owning fd does not
+ * return the window to the allocation pool while the export is live, so the
+ * window cannot be reallocated and reconfigured to redirect a live importer's
+ * DMA elsewhere on the NOC. The window is freed only once the dma-buf is
+ * released.
  *
  * @argsz: Must be sizeof(struct tenstorrent_export_tlb_dmabuf).
  * @flags: Reserved for future use, must be 0.

--- a/memory.c
+++ b/memory.c
@@ -15,6 +15,8 @@
 #include <linux/file.h>
 #include <linux/vmalloc.h>
 #include <linux/sched/mm.h>
+#include <linux/dma-buf.h>
+#include <linux/module.h>
 
 #include "chardev_private.h"
 #include "device.h"
@@ -990,6 +992,253 @@ long ioctl_configure_tlb(struct chardev_private *priv,
 
 	return tenstorrent_device_configure_tlb(tt_dev, in.id, &in.config);
 }
+
+// On kernels older than 5.8.0, EXPORT_TLB_DMABUF is unsupported.
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
+
+// dma_buf_export() and friends live in the DMA_BUF symbol namespace.
+// Linux 6.13 changed MODULE_IMPORT_NS to take a string literal instead of a bare token.
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
+MODULE_IMPORT_NS("DMA_BUF");
+#else
+MODULE_IMPORT_NS(DMA_BUF);
+#endif
+
+// Private data for a dma-buf that exports a TLB window's BAR aperture.
+struct tt_tlb_dmabuf {
+	struct tenstorrent_device *tt_dev;
+	phys_addr_t phys;	// BAR physical address of the exported region
+	size_t size;
+};
+
+static int tt_tlb_dmabuf_attach(struct dma_buf *dmabuf, struct dma_buf_attachment *attach)
+{
+	// We hand out a PCI BAR region with no backing struct page, so the
+	// importer must be able to consume peer resources (peer-to-peer DMA).
+	if (!attach->peer2peer)
+		return -EOPNOTSUPP;
+
+	return 0;
+}
+
+// A scatterlist entry's length (sg_dma_len) is a 32-bit unsigned int, so a
+// single entry cannot describe a >=4 GiB segment (4 GiB truncates to 0).
+// Split the contiguous BAR mapping across entries kept well under 4 GiB.
+#define TT_TLB_DMABUF_SG_CHUNK SZ_1G
+
+static struct sg_table *tt_tlb_dmabuf_map(struct dma_buf_attachment *attach, enum dma_data_direction dir)
+{
+	struct tt_tlb_dmabuf *priv = attach->dmabuf->priv;
+	struct scatterlist *sg;
+	struct sg_table *sgt;
+	unsigned int nents;
+	dma_addr_t addr;
+	size_t off;
+	int ret;
+	int i;
+
+	nents = DIV_ROUND_UP(priv->size, TT_TLB_DMABUF_SG_CHUNK);
+
+	sgt = kzalloc(sizeof(*sgt), GFP_KERNEL);
+	if (!sgt)
+		return ERR_PTR(-ENOMEM);
+
+	ret = sg_alloc_table(sgt, nents, GFP_KERNEL);
+	if (ret) {
+		kfree(sgt);
+		return ERR_PTR(ret);
+	}
+
+	// Map the whole BAR region into the *importer's* DMA domain as one
+	// contiguous IOVA. attach->dev is the importing device (e.g. the NIC),
+	// supplied by the dma-buf core.
+	addr = dma_map_resource(attach->dev, priv->phys, priv->size, dir, 0);
+	if (dma_mapping_error(attach->dev, addr)) {
+		sg_free_table(sgt);
+		kfree(sgt);
+		return ERR_PTR(-ENOMEM);
+	}
+
+	// Describe the single contiguous IOVA with page-less entries, each
+	// below the 32-bit sg length limit. Only the DMA address and length are
+	// meaningful (there are no backing struct pages). Entry 0 holds the base
+	// address, which tt_tlb_dmabuf_unmap() uses to release the whole range.
+	off = 0;
+	for_each_sg(sgt->sgl, sg, sgt->orig_nents, i) {
+		size_t len = min_t(size_t, TT_TLB_DMABUF_SG_CHUNK, priv->size - off);
+
+		sg_dma_address(sg) = addr + off;
+		sg_dma_len(sg) = len;
+		off += len;
+	}
+
+	return sgt;
+}
+
+static void tt_tlb_dmabuf_unmap(struct dma_buf_attachment *attach, struct sg_table *sgt, enum dma_data_direction dir)
+{
+	struct tt_tlb_dmabuf *priv = attach->dmabuf->priv;
+
+	dma_unmap_resource(attach->dev, sg_dma_address(sgt->sgl), priv->size, dir, 0);
+	sg_free_table(sgt);
+	kfree(sgt);
+}
+
+static int tt_tlb_dmabuf_pin(struct dma_buf_attachment *attach)
+{
+	// The exported region is a fixed PCI BAR aperture; it never migrates.
+	return 0;
+}
+
+static void tt_tlb_dmabuf_unpin(struct dma_buf_attachment *attach)
+{
+}
+
+static void tt_tlb_dmabuf_release(struct dma_buf *dmabuf)
+{
+	// Frees only the export's private data. We hold no device reference:
+	// the dma-buf may outlive the device (reset/removal), but the ops never
+	// dereference tt_dev, so there is no use-after-free. Accessing the
+	// aperture across a reset/removal is undefined by design; we do not try
+	// try to revoke the importer's mapping.
+	//
+	// TODO: make FREE_TLB refuse (-EBUSY) while an export of the window exists.
+	kfree(dmabuf->priv);
+}
+
+static const struct dma_buf_ops tt_tlb_dmabuf_ops = {
+	.attach = tt_tlb_dmabuf_attach,
+	.map_dma_buf = tt_tlb_dmabuf_map,
+	.unmap_dma_buf = tt_tlb_dmabuf_unmap,
+	.pin = tt_tlb_dmabuf_pin,
+	.unpin = tt_tlb_dmabuf_unpin,
+	.release = tt_tlb_dmabuf_release,
+};
+
+long ioctl_export_tlb_dmabuf(struct chardev_private *priv, struct tenstorrent_export_tlb_dmabuf __user *arg)
+{
+	struct tenstorrent_device *tt_dev = priv->device;
+	struct tenstorrent_export_tlb_dmabuf in = {0};
+	DEFINE_DMA_BUF_EXPORT_INFO(exp_info);
+	struct tlb_descriptor tlb_desc = {0};
+	struct tt_tlb_dmabuf *dmabuf_priv;
+	struct dma_buf *dmabuf;
+	resource_size_t bar_len;
+	u64 region_size;
+	u64 region_end;
+	phys_addr_t phys;
+	long ret;
+	int fd;
+
+	if (copy_from_user(&in, arg, sizeof(in)))
+		return -EFAULT;
+
+	if (in.argsz != sizeof(in))
+		return -EINVAL;
+
+	if (in.flags != 0)
+		return -EINVAL;
+
+	if (in.tlb_id >= TENSTORRENT_MAX_INBOUND_TLBS)
+		return -EINVAL;
+
+	if (!PAGE_ALIGNED(in.offset) || !PAGE_ALIGNED(in.size))
+		return -EINVAL;
+
+	if (!tt_dev->dev_class->describe_tlb)
+		return -EINVAL;
+
+	// The caller must own the TLB window it wants to export.
+	mutex_lock(&priv->mutex);
+	if (!test_bit(in.tlb_id, priv->tlbs)) {
+		ret = -EPERM;
+		goto unlock;
+	}
+
+	if (tt_dev->dev_class->describe_tlb(tt_dev, in.tlb_id, &tlb_desc)) {
+		ret = -EINVAL;
+		goto unlock;
+	}
+
+	// Resolve the exported sub-range [offset, offset + size) within the
+	// window. size == 0 means "to the end of the window".
+	if (in.offset >= tlb_desc.size || in.size > tlb_desc.size) {
+		ret = -EINVAL;
+		goto unlock;
+	}
+
+	region_size = in.size ? in.size : tlb_desc.size - in.offset;
+	region_end = in.offset + region_size;	// no overflow: both <= tlb_desc.size
+
+	if (region_end > tlb_desc.size) {
+		ret = -EINVAL;
+		goto unlock;
+	}
+
+	// The exported region must lie within the BAR (matches map_tlb_window()).
+	bar_len = pci_resource_len(tt_dev->pdev, tlb_desc.bar);
+	if (tlb_desc.bar_offset + region_end > bar_len) {
+		ret = -EINVAL;
+		goto unlock;
+	}
+
+	phys = pci_resource_start(tt_dev->pdev, tlb_desc.bar) + tlb_desc.bar_offset + in.offset;
+
+	dmabuf_priv = kzalloc(sizeof(*dmabuf_priv), GFP_KERNEL);
+	if (!dmabuf_priv) {
+		ret = -ENOMEM;
+		goto unlock;
+	}
+
+	dmabuf_priv->tt_dev = tt_dev;
+	dmabuf_priv->phys = phys;
+	dmabuf_priv->size = region_size;
+
+	exp_info.ops = &tt_tlb_dmabuf_ops;
+	exp_info.size = region_size;
+	exp_info.flags = O_RDWR | O_CLOEXEC;
+	exp_info.priv = dmabuf_priv;
+
+	dmabuf = dma_buf_export(&exp_info);
+	if (IS_ERR(dmabuf)) {
+		kfree(dmabuf_priv);
+		ret = PTR_ERR(dmabuf);
+		goto unlock;
+	}
+
+	mutex_unlock(&priv->mutex);
+
+	fd = get_unused_fd_flags(O_CLOEXEC);
+	if (fd < 0) {
+		dma_buf_put(dmabuf);
+		return fd;
+	}
+
+	in.fd = fd;
+	if (copy_to_user(arg, &in, sizeof(in))) {
+		put_unused_fd(fd);
+		dma_buf_put(dmabuf);
+		return -EFAULT;
+	}
+
+	// Transfer the dma_buf's file reference to the new fd.
+	fd_install(fd, dmabuf->file);
+
+	return 0;
+
+unlock:
+	mutex_unlock(&priv->mutex);
+	return ret;
+}
+
+#else /* LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0) */
+
+long ioctl_export_tlb_dmabuf(struct chardev_private *priv, struct tenstorrent_export_tlb_dmabuf __user *arg)
+{
+	return -EOPNOTSUPP;
+}
+
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0) */
 
 // Is the mapping target range contained entirely with start - start+len?
 // start and len must be page-aligned.

--- a/memory.c
+++ b/memory.c
@@ -1007,6 +1007,7 @@ MODULE_IMPORT_NS(DMA_BUF);
 // Private data for a dma-buf that exports a TLB window's BAR aperture.
 struct tt_tlb_dmabuf {
 	struct tenstorrent_device *tt_dev;
+	u32 tlb_id;		// window this export holds a refcount on
 	phys_addr_t phys;	// BAR physical address of the exported region
 	size_t size;
 };
@@ -1096,14 +1097,19 @@ static void tt_tlb_dmabuf_unpin(struct dma_buf_attachment *attach)
 
 static void tt_tlb_dmabuf_release(struct dma_buf *dmabuf)
 {
-	// Frees only the export's private data. We hold no device reference:
-	// the dma-buf may outlive the device (reset/removal), but the ops never
-	// dereference tt_dev, so there is no use-after-free. Accessing the
-	// aperture across a reset/removal is undefined by design; we do not try
-	// try to revoke the importer's mapping.
+	struct tt_tlb_dmabuf *priv = dmabuf->priv;
+
+	// Drop this export's hold on the TLB window. If the owning fd is already
+	// gone (FREE_TLB or close()), this returns the window to the pool. The
+	// device reference taken at export time is what makes touching tt_dev
+	// safe here even if the device was removed while the dma-buf was open.
 	//
-	// TODO: make FREE_TLB refuse (-EBUSY) while an export of the window exists.
-	kfree(dmabuf->priv);
+	// NOTE: a reset still leaves an importer's mapping pointing at a window
+	// whose NOC routing has been torn down. Revoking that mapping
+	// (dma_buf_move_notify) is handled separately, not here.
+	tenstorrent_tlb_export_put(priv->tt_dev, priv->tlb_id);
+	tenstorrent_device_put(priv->tt_dev);
+	kfree(priv);
 }
 
 static const struct dma_buf_ops tt_tlb_dmabuf_ops = {
@@ -1191,8 +1197,18 @@ long ioctl_export_tlb_dmabuf(struct chardev_private *priv, struct tenstorrent_ex
 	}
 
 	dmabuf_priv->tt_dev = tt_dev;
+	dmabuf_priv->tlb_id = in.tlb_id;
 	dmabuf_priv->phys = phys;
 	dmabuf_priv->size = region_size;
+
+	// Pin the window and the device for the lifetime of the dma-buf, so the
+	// export survives FREE_TLB and close() of this fd. Both references are
+	// dropped in tt_tlb_dmabuf_release(). Taken before dma_buf_export() so
+	// the release callback -- reachable via dma_buf_put() on the error paths
+	// below -- balances them. The window is still owned here (priv->mutex is
+	// held and ownership was verified above), so its refcount is >= 1.
+	kref_get(&tt_dev->kref);
+	tenstorrent_tlb_export_get(tt_dev, in.tlb_id);
 
 	exp_info.ops = &tt_tlb_dmabuf_ops;
 	exp_info.size = region_size;
@@ -1201,6 +1217,8 @@ long ioctl_export_tlb_dmabuf(struct chardev_private *priv, struct tenstorrent_ex
 
 	dmabuf = dma_buf_export(&exp_info);
 	if (IS_ERR(dmabuf)) {
+		tenstorrent_tlb_export_put(tt_dev, in.tlb_id);
+		tenstorrent_device_put(tt_dev);
 		kfree(dmabuf_priv);
 		ret = PTR_ERR(dmabuf);
 		goto unlock;

--- a/memory.c
+++ b/memory.c
@@ -17,6 +17,7 @@
 #include <linux/sched/mm.h>
 #include <linux/dma-buf.h>
 #include <linux/module.h>
+#include <linux/dma-resv.h>
 
 #include "chardev_private.h"
 #include "device.h"
@@ -27,8 +28,12 @@
 
 #define BAR0_SIZE (1UL << 29)
 
+// In 7.1:
+// 52a9e9cd181f renamed zap_vma_ptes() to zap_special_vma_range()
+// 95308225e5ba renamed dma_buf_move_notify() to dma_buf_invalidate_mappings()
 #if LINUX_VERSION_CODE < KERNEL_VERSION(7, 1, 0)
-# define zap_special_vma_range(vma, addr, size) zap_vma_ptes(vma, addr, size)
+#define zap_special_vma_range(vma, addr, size) zap_vma_ptes(vma, addr, size)
+#define dma_buf_invalidate_mappings(dmabuf) dma_buf_move_notify(dmabuf)
 #endif
 
 static int get_sorted_iatu_region_indices(const struct tenstorrent_outbound_iatu_region *regions, int *sorted_indices)
@@ -1007,9 +1012,12 @@ MODULE_IMPORT_NS(DMA_BUF);
 // Private data for a dma-buf that exports a TLB window's BAR aperture.
 struct tt_tlb_dmabuf {
 	struct tenstorrent_device *tt_dev;
+	struct dma_buf *dmabuf;		// back-pointer for the revoke walk
+	struct list_head list;		// node in tt_dev->dmabuf_exports
 	u32 tlb_id;		// window this export holds a refcount on
 	phys_addr_t phys;	// BAR physical address of the exported region
 	size_t size;
+	bool revoked;		// guarded by dmabuf->resv
 };
 
 static int tt_tlb_dmabuf_attach(struct dma_buf *dmabuf, struct dma_buf_attachment *attach)
@@ -1037,6 +1045,11 @@ static struct sg_table *tt_tlb_dmabuf_map(struct dma_buf_attachment *attach, enu
 	size_t off;
 	int ret;
 	int i;
+
+	dma_resv_assert_held(attach->dmabuf->resv);
+
+	if (priv->revoked)
+		return ERR_PTR(-ENODEV);
 
 	nents = DIV_ROUND_UP(priv->size, TT_TLB_DMABUF_SG_CHUNK);
 
@@ -1087,7 +1100,14 @@ static void tt_tlb_dmabuf_unmap(struct dma_buf_attachment *attach, struct sg_tab
 
 static int tt_tlb_dmabuf_pin(struct dma_buf_attachment *attach)
 {
-	// The exported region is a fixed PCI BAR aperture; it never migrates.
+	struct tt_tlb_dmabuf *priv = attach->dmabuf->priv;
+
+	dma_resv_assert_held(attach->dmabuf->resv);
+
+	// Refuse only an already-revoked export.
+	if (priv->revoked)
+		return -ENODEV;
+
 	return 0;
 }
 
@@ -1098,17 +1118,19 @@ static void tt_tlb_dmabuf_unpin(struct dma_buf_attachment *attach)
 static void tt_tlb_dmabuf_release(struct dma_buf *dmabuf)
 {
 	struct tt_tlb_dmabuf *priv = dmabuf->priv;
+	struct tenstorrent_device *tt_dev = priv->tt_dev;
+
+	mutex_lock(&tt_dev->dmabuf_export_lock);
+	list_del(&priv->list);
+	mutex_unlock(&tt_dev->dmabuf_export_lock);
 
 	// Drop this export's hold on the TLB window. If the owning fd is already
 	// gone (FREE_TLB or close()), this returns the window to the pool. The
 	// device reference taken at export time is what makes touching tt_dev
 	// safe here even if the device was removed while the dma-buf was open.
-	//
-	// NOTE: a reset still leaves an importer's mapping pointing at a window
-	// whose NOC routing has been torn down. Revoking that mapping
-	// (dma_buf_move_notify) is handled separately, not here.
 	tenstorrent_tlb_export_put(priv->tt_dev, priv->tlb_id);
 	tenstorrent_device_put(priv->tt_dev);
+
 	kfree(priv);
 }
 
@@ -1200,8 +1222,9 @@ long ioctl_export_tlb_dmabuf(struct chardev_private *priv, struct tenstorrent_ex
 	dmabuf_priv->tlb_id = in.tlb_id;
 	dmabuf_priv->phys = phys;
 	dmabuf_priv->size = region_size;
+	// dmabuf back-pointer can only be set after the export succeeds (below).
 
-	// Pin the window and the device for the lifetime of the dma-buf, so the
+	// Pin the device and the window for the lifetime of the dma-buf, so the
 	// export survives FREE_TLB and close() of this fd. Both references are
 	// dropped in tt_tlb_dmabuf_release(). Taken before dma_buf_export() so
 	// the release callback -- reachable via dma_buf_put() on the error paths
@@ -1223,6 +1246,12 @@ long ioctl_export_tlb_dmabuf(struct chardev_private *priv, struct tenstorrent_ex
 		ret = PTR_ERR(dmabuf);
 		goto unlock;
 	}
+
+	dmabuf_priv->dmabuf = dmabuf;	// back-pointer for the revoke walk
+
+	mutex_lock(&tt_dev->dmabuf_export_lock);
+	list_add(&dmabuf_priv->list, &tt_dev->dmabuf_exports);
+	mutex_unlock(&tt_dev->dmabuf_export_lock);
 
 	mutex_unlock(&priv->mutex);
 
@@ -1249,11 +1278,49 @@ unlock:
 	return ret;
 }
 
+void tenstorrent_revoke_tlb_dmabufs(struct tenstorrent_device *tt_dev)
+{
+	struct tt_tlb_dmabuf *exp;
+
+	mutex_lock(&tt_dev->dmabuf_export_lock);
+	list_for_each_entry(exp, &tt_dev->dmabuf_exports, list) {
+		dma_resv_lock(exp->dmabuf->resv, NULL);
+
+		if (!exp->revoked) {
+			exp->revoked = true;
+			dma_buf_invalidate_mappings(exp->dmabuf);
+		}
+
+		dma_resv_unlock(exp->dmabuf->resv);
+	}
+	mutex_unlock(&tt_dev->dmabuf_export_lock);
+}
+
+bool tenstorrent_has_tlb_dmabuf_exports(struct tenstorrent_device *tt_dev)
+{
+	bool any;
+
+	mutex_lock(&tt_dev->dmabuf_export_lock);
+	any = !list_empty(&tt_dev->dmabuf_exports);
+	mutex_unlock(&tt_dev->dmabuf_export_lock);
+
+	return any;
+}
+
 #else /* LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0) */
 
 long ioctl_export_tlb_dmabuf(struct chardev_private *priv, struct tenstorrent_export_tlb_dmabuf __user *arg)
 {
 	return -EOPNOTSUPP;
+}
+
+void tenstorrent_revoke_tlb_dmabufs(struct tenstorrent_device *tt_dev)
+{
+}
+
+bool tenstorrent_has_tlb_dmabuf_exports(struct tenstorrent_device *tt_dev)
+{
+	return false;
 }
 
 #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0) */

--- a/memory.h
+++ b/memory.h
@@ -58,6 +58,8 @@ long ioctl_export_tlb_dmabuf(struct chardev_private *priv,
 int tenstorrent_mmap(struct chardev_private *priv, struct vm_area_struct *vma);
 void tenstorrent_memory_cleanup(struct chardev_private *priv);
 void tenstorrent_vma_zap(struct tenstorrent_device *tt_dev);
+void tenstorrent_revoke_tlb_dmabufs(struct tenstorrent_device *tt_dev);
+bool tenstorrent_has_tlb_dmabuf_exports(struct tenstorrent_device *tt_dev);
 bool is_iommu_translated(struct device *dev);
 
 #define TENSTORRENT_MAX_OUTBOUND_IATU_REGIONS 16

--- a/memory.h
+++ b/memory.h
@@ -16,6 +16,7 @@ struct tenstorrent_allocate_dma_buf;
 struct tenstorrent_free_dma_buf;
 struct tenstorrent_pin_pages;
 struct tenstorrent_map_peer_bar;
+struct tenstorrent_export_tlb_dmabuf;
 struct vm_area_struct;
 
 struct pinned_page_range {
@@ -51,6 +52,8 @@ long ioctl_free_tlb(struct chardev_private *priv,
 			struct tenstorrent_free_tlb __user *arg);
 long ioctl_configure_tlb(struct chardev_private *priv,
 			struct tenstorrent_configure_tlb __user *arg);
+long ioctl_export_tlb_dmabuf(struct chardev_private *priv,
+			struct tenstorrent_export_tlb_dmabuf __user *arg);
 
 int tenstorrent_mmap(struct chardev_private *priv, struct vm_area_struct *vma);
 void tenstorrent_memory_cleanup(struct chardev_private *priv);

--- a/test/Makefile
+++ b/test/Makefile
@@ -7,8 +7,8 @@ PROG := ttkmd_test
 
 TEST_SOURCES := get_driver_info.cpp get_device_info.cpp query_mappings.cpp \
 	dma_buf.cpp pin_pages.cpp config_space.cpp lock.cpp hwmon.cpp map_peer_bar.cpp \
-	ioctl_overrun.cpp ioctl_zeroing.cpp tlbs.cpp release.cpp mappings_debugfs.cpp \
-	procfs_pids.cpp excl.cpp
+	ioctl_overrun.cpp ioctl_zeroing.cpp tlbs.cpp dmabuf_export.cpp release.cpp \
+	mappings_debugfs.cpp procfs_pids.cpp excl.cpp
 
 CORE_SOURCES := enumeration.cpp util.cpp devfd.cpp main.cpp test_failure.cpp
 SOURCES := $(CORE_SOURCES) $(TEST_SOURCES)

--- a/test/dmabuf_export.cpp
+++ b/test/dmabuf_export.cpp
@@ -1,0 +1,350 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+#include "ioctl.h"
+
+#include "enumeration.h"
+#include "devfd.h"
+#include "tlbs.h"
+#include "test_failure.h"
+
+namespace
+{
+
+uint32_t allocate_window(int fd, size_t size = TWO_MEG)
+{
+    tenstorrent_allocate_tlb alloc{};
+    alloc.in.size = size;
+    if (ioctl(fd, TENSTORRENT_IOCTL_ALLOCATE_TLB, &alloc) != 0)
+        THROW_TEST_FAILURE("Failed to allocate TLB window");
+    return alloc.out.id;
+}
+
+void free_window(int fd, uint32_t id)
+{
+    tenstorrent_free_tlb free_tlb{};
+    free_tlb.in.id = id;
+    if (ioctl(fd, TENSTORRENT_IOCTL_FREE_TLB, &free_tlb) != 0)
+        THROW_TEST_FAILURE("Failed to free TLB window");
+}
+
+// Export [offset, offset+size) of a window. Returns the ioctl result (0 on
+// success); on success the dma-buf fd is stored in *out_fd.
+int try_export(int fd, uint32_t tlb_id, uint64_t offset, uint64_t size, int *out_fd)
+{
+    tenstorrent_export_tlb_dmabuf exp{};
+    exp.argsz = sizeof(exp);
+    exp.tlb_id = tlb_id;
+    exp.offset = offset;
+    exp.size = size;
+
+    errno = 0;
+    int ret = ioctl(fd, TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF, &exp);
+    if (ret == 0)
+        *out_fd = exp.fd;
+    return ret;
+}
+
+// The dma-buf export path requires Linux >= 5.8; on older kernels the driver
+// still builds but the ioctl returns -EOPNOTSUPP. Probe so the suite can skip
+// gracefully there rather than report spurious failures.
+bool export_supported(int fd)
+{
+    uint32_t id = allocate_window(fd);
+    int dmabuf_fd = -1;
+    int ret = try_export(fd, id, 0, 0, &dmabuf_fd);
+    bool supported = true;
+
+    if (ret == 0)
+        close(dmabuf_fd);
+    else if (errno == EOPNOTSUPP)
+        supported = false;
+
+    free_window(fd, id);
+    return supported;
+}
+
+// A basic export of a whole window should succeed and yield a usable fd.
+void VerifyExportBasic(const EnumeratedDevice &dev)
+{
+    DevFd dev_fd(dev.path);
+    int fd = dev_fd.get();
+
+    uint32_t id = allocate_window(fd);
+
+    int dmabuf_fd = -1;
+    if (try_export(fd, id, 0, 0, &dmabuf_fd) != 0)
+        THROW_TEST_FAILURE("Failed to export TLB window as dma-buf");
+    if (dmabuf_fd < 0)
+        THROW_TEST_FAILURE("Export returned an invalid fd");
+
+    close(dmabuf_fd);
+    free_window(fd, id);
+}
+
+// Malformed export requests must be rejected with EINVAL.
+void VerifyExportBadArgs(const EnumeratedDevice &dev)
+{
+    DevFd dev_fd(dev.path);
+    int fd = dev_fd.get();
+
+    uint32_t id = allocate_window(fd);
+
+    auto expect_einval = [&](tenstorrent_export_tlb_dmabuf exp, const char *what) {
+        errno = 0;
+        int ret = ioctl(fd, TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF, &exp);
+        if (ret == 0) {
+            close(exp.fd);
+            THROW_TEST_FAILURE(what);
+        }
+        if (errno != EINVAL)
+            THROW_TEST_FAILURE(what);
+    };
+
+    {
+        tenstorrent_export_tlb_dmabuf exp{};
+        exp.argsz = sizeof(exp) + 1;
+        exp.tlb_id = id;
+        expect_einval(exp, "Export accepted a bad argsz");
+    }
+    {
+        tenstorrent_export_tlb_dmabuf exp{};
+        exp.argsz = sizeof(exp);
+        exp.flags = 1;
+        exp.tlb_id = id;
+        expect_einval(exp, "Export accepted nonzero flags");
+    }
+    {
+        tenstorrent_export_tlb_dmabuf exp{};
+        exp.argsz = sizeof(exp);
+        exp.tlb_id = 0xFFFFFFFFu;
+        expect_einval(exp, "Export accepted an out-of-range tlb_id");
+    }
+    {
+        tenstorrent_export_tlb_dmabuf exp{};
+        exp.argsz = sizeof(exp);
+        exp.tlb_id = id;
+        exp.offset = 0x1; // not page-aligned
+        expect_einval(exp, "Export accepted a misaligned offset");
+    }
+    {
+        tenstorrent_export_tlb_dmabuf exp{};
+        exp.argsz = sizeof(exp);
+        exp.tlb_id = id;
+        exp.size = 0x1; // not page-aligned
+        expect_einval(exp, "Export accepted a misaligned size");
+    }
+    {
+        tenstorrent_export_tlb_dmabuf exp{};
+        exp.argsz = sizeof(exp);
+        exp.tlb_id = id;
+        exp.offset = TWO_MEG; // at/after end of window
+        expect_einval(exp, "Export accepted an out-of-range offset");
+    }
+
+    free_window(fd, id);
+}
+
+// A window may only be exported by the fd that owns it.
+void VerifyExportRequiresOwnership(const EnumeratedDevice &dev)
+{
+    DevFd owner(dev.path);
+    DevFd other(dev.path);
+
+    uint32_t id = allocate_window(owner.get());
+
+    int dmabuf_fd = -1;
+    errno = 0;
+    int ret = try_export(other.get(), id, 0, 0, &dmabuf_fd);
+    if (ret == 0) {
+        close(dmabuf_fd);
+        free_window(owner.get(), id);
+        THROW_TEST_FAILURE("Exported a window not owned by the fd");
+    }
+    if (errno != EPERM) {
+        free_window(owner.get(), id);
+        THROW_TEST_FAILURE("Expected EPERM exporting an unowned window");
+    }
+
+    free_window(owner.get(), id);
+}
+
+// The headline case: a live dma-buf export keeps its TLB window allocated
+// across FREE_TLB (and would across fd close); the window only returns to the
+// pool when the dma-buf is closed. Observed by exhausting the window pool: a
+// freed-but-exported window must not become re-allocatable until the dma-buf
+// is released.
+void VerifyExportKeepsTlbAliveAcrossFree(const EnumeratedDevice &dev)
+{
+    DevFd dev_fd(dev.path);
+    int fd = dev_fd.get();
+
+    // Exhaust every 2M window so the pool is full.
+    std::vector<uint32_t> ids;
+    for (;;) {
+        tenstorrent_allocate_tlb alloc{};
+        alloc.in.size = TWO_MEG;
+        if (ioctl(fd, TENSTORRENT_IOCTL_ALLOCATE_TLB, &alloc) != 0)
+            break;
+        ids.push_back(alloc.out.id);
+    }
+    if (ids.empty())
+        THROW_TEST_FAILURE("Could not allocate any 2M TLB window");
+
+    auto free_all = [&]() {
+        for (uint32_t id : ids) {
+            tenstorrent_free_tlb free_tlb{};
+            free_tlb.in.id = id;
+            ioctl(fd, TENSTORRENT_IOCTL_FREE_TLB, &free_tlb);
+        }
+    };
+
+    // Export one window, then drop the owner's reference with FREE_TLB. With
+    // the refcount model FREE_TLB succeeds, but the export keeps the window
+    // out of the pool.
+    uint32_t exported_id = ids.back();
+    ids.pop_back();
+
+    int dmabuf_fd = -1;
+    if (try_export(fd, exported_id, 0, 0, &dmabuf_fd) != 0) {
+        free_all();
+        THROW_TEST_FAILURE("Failed to export TLB window as dma-buf");
+    }
+
+    {
+        tenstorrent_free_tlb free_tlb{};
+        free_tlb.in.id = exported_id;
+        if (ioctl(fd, TENSTORRENT_IOCTL_FREE_TLB, &free_tlb) != 0) {
+            close(dmabuf_fd);
+            free_all();
+            THROW_TEST_FAILURE("FREE_TLB failed on an exported window");
+        }
+    }
+
+    // The window is still held by the export, so the pool remains full.
+    {
+        tenstorrent_allocate_tlb alloc{};
+        alloc.in.size = TWO_MEG;
+        if (ioctl(fd, TENSTORRENT_IOCTL_ALLOCATE_TLB, &alloc) == 0) {
+            ids.push_back(alloc.out.id);
+            close(dmabuf_fd);
+            free_all();
+            THROW_TEST_FAILURE("Exported window returned to the pool after FREE_TLB");
+        }
+    }
+
+    // Releasing the dma-buf drops the last reference; the window returns to the
+    // pool and becomes allocatable again.
+    close(dmabuf_fd);
+
+    {
+        tenstorrent_allocate_tlb alloc{};
+        alloc.in.size = TWO_MEG;
+        if (ioctl(fd, TENSTORRENT_IOCTL_ALLOCATE_TLB, &alloc) != 0) {
+            free_all();
+            THROW_TEST_FAILURE("Window not reusable after closing the dma-buf");
+        }
+        ids.push_back(alloc.out.id);
+    }
+
+    free_all();
+}
+
+// Closing the chardev fd that allocated and exported a window (without ever
+// calling FREE_TLB) must not tear the window down while the export is live: fd
+// release drops the owning reference, but the dma-buf keeps the window
+// allocated until it too is closed. Observed from a second fd via pool
+// exhaustion, as above.
+void VerifyExportSurvivesFdClose(const EnumeratedDevice &dev)
+{
+    DevFd observer(dev.path);
+    int obs = observer.get();
+
+    std::vector<uint32_t> ids;
+    auto free_all = [&]() {
+        for (uint32_t id : ids) {
+            tenstorrent_free_tlb free_tlb{};
+            free_tlb.in.id = id;
+            ioctl(obs, TENSTORRENT_IOCTL_FREE_TLB, &free_tlb);
+        }
+    };
+
+    int dmabuf_fd = -1;
+    {
+        DevFd owner(dev.path);
+        int own = owner.get();
+
+        uint32_t id = allocate_window(own);
+        if (try_export(own, id, 0, 0, &dmabuf_fd) != 0) {
+            free_window(own, id);
+            THROW_TEST_FAILURE("Failed to export TLB window as dma-buf");
+        }
+
+        // Exhaust the remaining pool from the observer fd, so that after the
+        // owner fd closes the only thing keeping the pool full is the export.
+        for (;;) {
+            tenstorrent_allocate_tlb alloc{};
+            alloc.in.size = TWO_MEG;
+            if (ioctl(obs, TENSTORRENT_IOCTL_ALLOCATE_TLB, &alloc) != 0)
+                break;
+            ids.push_back(alloc.out.id);
+        }
+
+        // The owner fd is closed here WITHOUT FREE_TLB. Its release drops the
+        // owning reference; the live export must keep the window allocated.
+    }
+
+    // The window is still held by the export, so the pool remains full.
+    {
+        tenstorrent_allocate_tlb alloc{};
+        alloc.in.size = TWO_MEG;
+        if (ioctl(obs, TENSTORRENT_IOCTL_ALLOCATE_TLB, &alloc) == 0) {
+            ids.push_back(alloc.out.id);
+            close(dmabuf_fd);
+            free_all();
+            THROW_TEST_FAILURE("Exported window returned to the pool after owner fd close");
+        }
+    }
+
+    // Releasing the dma-buf returns the window to the pool.
+    close(dmabuf_fd);
+
+    {
+        tenstorrent_allocate_tlb alloc{};
+        alloc.in.size = TWO_MEG;
+        if (ioctl(obs, TENSTORRENT_IOCTL_ALLOCATE_TLB, &alloc) != 0) {
+            free_all();
+            THROW_TEST_FAILURE("Window not reusable after closing the dma-buf");
+        }
+        ids.push_back(alloc.out.id);
+    }
+
+    free_all();
+}
+
+} // namespace
+
+void TestTlbExport(const EnumeratedDevice &dev)
+{
+    {
+        DevFd probe(dev.path);
+        if (!export_supported(probe.get())) {
+            std::cout << "  EXPORT_TLB_DMABUF unsupported on this kernel; skipping\n";
+            return;
+        }
+    }
+
+    VerifyExportBasic(dev);
+    VerifyExportBadArgs(dev);
+    VerifyExportRequiresOwnership(dev);
+    VerifyExportKeepsTlbAliveAcrossFree(dev);
+    VerifyExportSurvivesFdClose(dev);
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -21,6 +21,7 @@ void TestIoctlOverrun(const EnumeratedDevice &dev);
 void TestIoctlZeroing(const EnumeratedDevice &dev);
 void TestMapPeerBar(const EnumeratedDevice &dev1, const EnumeratedDevice &dev2);
 void TestTlbs(const EnumeratedDevice &dev);
+void TestTlbExport(const EnumeratedDevice &dev);
 void TestDeviceRelease(const EnumeratedDevice &dev);
 void TestMappingsDebugfs(const EnumeratedDevice &dev);
 void TestProcfsPids(const EnumeratedDevice &dev);
@@ -52,6 +53,7 @@ int main(int argc, char *argv[])
         TestIoctlOverrun(d);
         TestIoctlZeroing(d);
         TestTlbs(d);
+        TestTlbExport(d);
         TestMappingsDebugfs(d);
         TestProcfsPids(d);
         TestExcl(d);

--- a/tlb.c
+++ b/tlb.c
@@ -6,8 +6,7 @@
 #include "tlb.h"
 #include "device.h"
 
-int tenstorrent_device_allocate_tlb(struct tenstorrent_device *tt_dev,
-				    size_t size)
+int tenstorrent_device_allocate_tlb(struct tenstorrent_device *tt_dev, size_t size)
 {
 	const struct tenstorrent_device_class *dev_class = tt_dev->dev_class;
 	unsigned long id = 0;
@@ -40,8 +39,10 @@ int tenstorrent_device_allocate_tlb(struct tenstorrent_device *tt_dev,
 		if (id == offset + n)
 			return -ENOMEM;
 
-		if (!test_and_set_bit(id, tt_dev->tlbs))
+		if (!test_and_set_bit(id, tt_dev->tlbs)) {
+			refcount_set(&tt_dev->tlb_refcount[id], 1);
 			return id; // Claimed this TLB.
+		}
 
 		cond_resched();
 		if (signal_pending(current))
@@ -52,8 +53,7 @@ int tenstorrent_device_allocate_tlb(struct tenstorrent_device *tt_dev,
 	return -EINVAL;
 }
 
-int tenstorrent_device_free_tlb(struct tenstorrent_device *tt_dev,
-				unsigned int id)
+int tenstorrent_device_free_tlb(struct tenstorrent_device *tt_dev, unsigned int id)
 {
 	const struct tenstorrent_device_class *dev_class = tt_dev->dev_class;
 	u64 total_tlbs = 0;
@@ -68,10 +68,34 @@ int tenstorrent_device_free_tlb(struct tenstorrent_device *tt_dev,
 	if (id >= total_tlbs)
 		return -EINVAL;
 
-	if (!test_and_clear_bit(id, tt_dev->tlbs))
+	if (!test_bit(id, tt_dev->tlbs))
 		return -EPERM;
 
+	// Drop the owning fd's reference. If a dma-buf export of this window is
+	// still live, the window's bit stays set and the window is returned to
+	// the pool only when the last export is released.
+	if (refcount_dec_and_test(&tt_dev->tlb_refcount[id]))
+		clear_bit(id, tt_dev->tlbs);
+
 	return 0;
+}
+
+// Take an export reference on an allocated TLB window, keeping it allocated
+// (and out of the free pool) for the lifetime of a dma-buf export, even across
+// FREE_TLB or close() of the owning fd. The caller must currently own the
+// window. Pairs with tenstorrent_tlb_export_put().
+void tenstorrent_tlb_export_get(struct tenstorrent_device *tt_dev, unsigned int id)
+{
+	refcount_inc(&tt_dev->tlb_refcount[id]);
+}
+
+// Release an export reference taken by tenstorrent_tlb_export_get(). When the
+// last reference (owning fd or final export) goes away, the window returns to
+// the pool.
+void tenstorrent_tlb_export_put(struct tenstorrent_device *tt_dev, unsigned int id)
+{
+	if (refcount_dec_and_test(&tt_dev->tlb_refcount[id]))
+		clear_bit(id, tt_dev->tlbs);
 }
 
 int tenstorrent_device_configure_tlb(struct tenstorrent_device *tt_dev, int tlb,

--- a/tlb.h
+++ b/tlb.h
@@ -15,10 +15,10 @@ struct tlb_descriptor {
 	unsigned long bar_offset;
 };
 
-int tenstorrent_device_allocate_tlb(struct tenstorrent_device *tt_dev,
-				    size_t size);
-int tenstorrent_device_free_tlb(struct tenstorrent_device *tt_dev,
-				unsigned int id);
+int tenstorrent_device_allocate_tlb(struct tenstorrent_device *tt_dev, size_t size);
+int tenstorrent_device_free_tlb(struct tenstorrent_device *tt_dev, unsigned int id);
+void tenstorrent_tlb_export_get(struct tenstorrent_device *tt_dev, unsigned int id);
+void tenstorrent_tlb_export_put(struct tenstorrent_device *tt_dev, unsigned int id);
 int tenstorrent_device_configure_tlb(struct tenstorrent_device *tt_dev, int tlb,
 				     struct tenstorrent_noc_tlb_config *config);
 

--- a/tools/rdma/Makefile
+++ b/tools/rdma/Makefile
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+# SPDX-License-Identifier: GPL-2.0-only
+
+CFLAGS ?= -O2 -Wall -Wextra
+
+PROGS := nic_bh_p2p_dma
+
+all: $(PROGS)
+
+nic_bh_p2p_dma: LDLIBS := -libverbs
+
+clean:
+	rm -f $(PROGS)
+
+.PHONY: all clean

--- a/tools/rdma/nic_bh_p2p_dma.c
+++ b/tools/rdma/nic_bh_p2p_dma.c
@@ -1,0 +1,657 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// nic_bh_p2p_dma - minimal NIC <-> Blackhole peer-to-peer DMA demo.
+//
+// Demonstrates that an RDMA NIC can DMA directly into and out of Blackhole GDDR
+// over the fabric, with both transfers initiated by the NIC and no Blackhole
+// CPU involvement on the data path.
+//
+// The mechanism: the Blackhole node aims a TLB window at a GDDR tile, exports
+// that window as a dma-buf (TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF), and registers
+// it as an RDMA memory region. The peer node then drives the DMA.
+//
+// Single binary, two roles (traffic flows over the wire between the two NICs):
+//   server (no peer arg): the Blackhole node. Exports a GDDR tile as an MR and
+//     is otherwise passive - it never touches the data.
+//   client (peer arg = server IP): the NIC that drives the DMA:
+//     1. RDMA WRITE a pattern into BH   (NIC -> BH)
+//     2. RDMA READ  it back out of BH   (BH -> NIC)
+//     3. verify the read-back matches what was written.
+//
+// The GDDR tile coordinates and transfer size are compile-time constants; the
+// device path and RDMA device name are command-line arguments.
+//
+// To compile:  make
+// To run (RoCE example, gid index 3 = RoCEv2 IPv4):
+//   # on the Blackhole node:
+//   ./nic_bh_p2p_dma -b /dev/tenstorrent/5 -r rocep201s0f0 -g 3
+//   # on the peer node:
+//   ./nic_bh_p2p_dma -r rocep201s0f0 -g 3 10.32.34.129
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <sys/random.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <linux/types.h>
+
+#include <infiniband/verbs.h>
+
+/* ===== tt-kmd ioctl definitions (subset of ioctl.h) ===== */
+
+#define TENSTORRENT_IOCTL_MAGIC 0xFA
+#define TENSTORRENT_IOCTL_GET_DEVICE_INFO	_IO(TENSTORRENT_IOCTL_MAGIC, 0)
+#define TENSTORRENT_IOCTL_ALLOCATE_TLB		_IO(TENSTORRENT_IOCTL_MAGIC, 11)
+#define TENSTORRENT_IOCTL_FREE_TLB		_IO(TENSTORRENT_IOCTL_MAGIC, 12)
+#define TENSTORRENT_IOCTL_CONFIGURE_TLB		_IO(TENSTORRENT_IOCTL_MAGIC, 13)
+#define TENSTORRENT_IOCTL_SET_POWER_STATE	_IO(TENSTORRENT_IOCTL_MAGIC, 15)
+#define TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF	_IO(TENSTORRENT_IOCTL_MAGIC, 16)
+
+#define BLACKHOLE_PCI_DEVICE_ID 0xb140
+
+struct tenstorrent_get_device_info {
+	struct { __u32 output_size_bytes; } in;
+	struct {
+		__u32 output_size_bytes;
+		__u16 vendor_id, device_id, subsystem_vendor_id, subsystem_id;
+		__u16 bus_dev_fn, max_dma_buf_size_log2, pci_domain;
+		__u16 reserved;
+	} out;
+};
+
+struct tenstorrent_allocate_tlb {
+	struct { __u64 size; __u64 reserved; } in;
+	struct {
+		__u32 id; __u32 reserved0;
+		__u64 mmap_offset_uc; __u64 mmap_offset_wc; __u64 reserved1;
+	} out;
+};
+
+struct tenstorrent_free_tlb {
+	struct { __u32 id; } in;
+	struct { } out;
+};
+
+struct tenstorrent_noc_tlb_config {
+	__u64 addr;
+	__u16 x_end, y_end, x_start, y_start;
+	__u8 noc, mcast, ordering, linked, static_vc;
+	__u8 reserved0[3];
+	__u32 reserved1[2];
+};
+
+struct tenstorrent_configure_tlb {
+	struct {
+		__u32 id;
+		__u32 reserved;
+		struct tenstorrent_noc_tlb_config config;
+	} in;
+	struct { __u64 reserved; } out;
+};
+
+struct tenstorrent_export_tlb_dmabuf {
+	__u32 argsz; __u32 flags; __u32 tlb_id; __s32 fd;
+	__u64 offset; __u64 size;
+};
+
+struct tenstorrent_power_state {
+	__u32 argsz;
+	__u32 flags;
+	__u8 reserved0;
+	__u8 validity;
+#define TT_POWER_VALIDITY_FLAGS(n)	(((n) & 0xF) << 0)
+#define TT_POWER_VALIDITY_SETTINGS(n)	(((n) & 0xF) << 4)
+#define TT_POWER_VALIDITY(flags_count, settings_count) \
+	(TT_POWER_VALIDITY_FLAGS(flags_count) | TT_POWER_VALIDITY_SETTINGS(settings_count))
+	__u16 power_flags;
+#define TT_POWER_FLAG_MAX_AI_CLK	(1U << 0) /* 1=Max AI Clock,  0=Min AI Clock */
+#define TT_POWER_FLAG_MRISC_PHY_WAKEUP	(1U << 1) /* 1=PHY Wakeup,    0=PHY Powerdown */
+#define TT_POWER_FLAG_TENSIX_ENABLE	(1U << 2) /* 1=Enable Tensix, 0=Clock Gate Tensix */
+#define TT_POWER_FLAG_L2CPU_ENABLE	(1U << 3) /* 1=Enable L2CPU,  0=Clock Gate L2CPU */
+	__u16 power_settings[14];
+};
+
+/* ===== hard-coded test parameters ===== */
+
+#define NOC_X		17		// GDDR tile NOC coordinates
+#define NOC_Y		12
+#define NOC_ADDR	0ULL		// tile base address
+#define XFER_SIZE	(256ULL << 20)	// bytes written/read/verified (256 MiB)
+#define TLB_WINDOW_SIZE	(4ULL << 30)	// 4 GiB BAR4 window covers the tile
+#define TLB_ORDERING	0	// Relaxed
+
+#define RDMA_MTU_MAX	IBV_MTU_4096
+
+#define RDMA_CHUNK	(64ULL << 20)	// 64 MiB per work request
+#define OUTSTANDING	4		// in-flight work requests
+#define SQ_DEPTH	(OUTSTANDING + 8)
+#define MAX_RD_ATOMIC	16		// outstanding RDMA reads the QP allows
+
+#define TCP_PORT	18515
+
+#define DIE(fmt, ...) \
+	do { fprintf(stderr, "error: " fmt "\n", ##__VA_ARGS__); exit(1); } while (0)
+
+/* ===== helpers ===== */
+
+static double now_sec(void)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (double)ts.tv_sec + (double)ts.tv_nsec / 1e9;
+}
+
+static void report(const char *label, size_t bytes, double dt)
+{
+	printf("%-16s %5zu MiB in %8.3f ms  (%6.2f GiB/s)\n",
+	       label, bytes >> 20, dt * 1e3,
+	       (double)bytes / dt / (double)(1ULL << 30));
+}
+
+static void fill_random(void *buf, size_t n)
+{
+	uint8_t *p = buf;
+
+	while (n) {
+		ssize_t r = getrandom(p, n, 0);
+
+		if (r < 0) {
+			if (errno == EINTR)
+				continue;
+			DIE("getrandom failed: %s", strerror(errno));
+		}
+		p += r;
+		n -= (size_t)r;
+	}
+}
+
+/* ===== RDMA plumbing ===== */
+
+struct conn {
+	struct ibv_context *ctx;
+	struct ibv_pd *pd;
+	struct ibv_cq *cq;
+	struct ibv_qp *qp;
+	uint8_t port;
+	int gid_index;
+};
+
+// Wire format for the out-of-band TCP handshake. Both nodes are assumed to share
+// host byte order (x86-64 / aarch64 little-endian) for simplicity.
+struct exch {
+	uint32_t rkey;	// server: bh_mr rkey
+	uint32_t qpn;
+	uint32_t psn;
+	uint64_t addr;	// server: bh_mr iova (0)
+	uint8_t gid[16];
+};
+
+// Read the GID type string for a given index, e.g. "RoCE v2" or "IB/RoCE v1",
+// from sysfs. ibv_query_gid() does not expose the RoCE version, so a port that
+// has both v1 and v2 GIDs for the same IPv4 address looks identical without it.
+static int gid_is_rocev2(const char *rdma_name, uint8_t port, int index)
+{
+	char path[256], buf[64];
+	ssize_t n;
+	int fd;
+
+	snprintf(path, sizeof(path),
+		 "/sys/class/infiniband/%s/ports/%u/gid_attrs/types/%d",
+		 rdma_name, port, index);
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		return 0;
+	n = read(fd, buf, sizeof(buf) - 1);
+	close(fd);
+	if (n <= 0)
+		return 0;
+	buf[n] = '\0';
+	return strstr(buf, "RoCE v2") != NULL;
+}
+
+// Auto-select a RoCEv2 (IPv4-mapped) GID. We must check both the GID value
+// (IPv4-mapped prefix) and the GID type, since many ports expose a RoCE v1 and
+// a RoCE v2 GID for the same address - picking the v1 one fails to connect.
+static int pick_rocev2_gid(struct ibv_context *ctx, const char *rdma_name,
+			   uint8_t port)
+{
+	static const uint8_t v4_mapped_prefix[12] = { 0,0,0,0,0,0,0,0,0,0,0xff,0xff };
+	union ibv_gid g;
+	int i;
+
+	for (i = 0; i < 16; i++) {
+		if (ibv_query_gid(ctx, port, i, &g))
+			break;
+		if (memcmp(g.raw, v4_mapped_prefix, sizeof(v4_mapped_prefix)) != 0)
+			continue;
+		if (gid_is_rocev2(rdma_name, port, i))
+			return i;
+	}
+	return -1;
+}
+
+static struct ibv_context *open_rdma_device(const char *name)
+{
+	struct ibv_device **list;
+	struct ibv_context *ctx = NULL;
+	int n, i;
+
+	list = ibv_get_device_list(&n);
+	if (!list || n == 0)
+		DIE("no RDMA devices found");
+	for (i = 0; i < n; i++) {
+		if (!name || strcmp(ibv_get_device_name(list[i]), name) == 0) {
+			ctx = ibv_open_device(list[i]);
+			break;
+		}
+	}
+	ibv_free_device_list(list);
+	if (!ctx)
+		DIE("RDMA device %s not found/openable", name ? name : "(first)");
+	return ctx;
+}
+
+static void setup_verbs(struct conn *c, const char *rdma_name, int gid_index,
+			struct exch *local)
+{
+	struct ibv_qp_init_attr ia = {
+		.cap = { .max_send_wr = SQ_DEPTH, .max_recv_wr = 4,
+			 .max_send_sge = 1, .max_recv_sge = 1 },
+		.qp_type = IBV_QPT_RC,
+	};
+	union ibv_gid gid;
+
+	c->port = 1;
+	c->ctx = open_rdma_device(rdma_name);
+	c->pd = ibv_alloc_pd(c->ctx);
+	if (!c->pd)
+		DIE("ibv_alloc_pd failed");
+
+	c->cq = ibv_create_cq(c->ctx, OUTSTANDING + 16, NULL, NULL, 0);
+	if (!c->cq)
+		DIE("ibv_create_cq failed");
+
+	if (gid_index < 0) {
+		gid_index = pick_rocev2_gid(c->ctx, rdma_name, c->port);
+		if (gid_index < 0)
+			DIE("no RoCEv2 (IPv4-mapped) GID found; pass -g");
+	}
+	c->gid_index = gid_index;
+
+	if (ibv_query_gid(c->ctx, c->port, c->gid_index, &gid))
+		DIE("ibv_query_gid failed");
+
+	ia.send_cq = c->cq;
+	ia.recv_cq = c->cq;
+	c->qp = ibv_create_qp(c->pd, &ia);
+	if (!c->qp)
+		DIE("ibv_create_qp failed: %s", strerror(errno));
+
+	memcpy(local->gid, gid.raw, 16);
+	local->qpn = c->qp->qp_num;
+	local->psn = lrand48() & 0xffffff;
+	printf("local:  qpn=0x%x gid_index=%d\n", local->qpn, c->gid_index);
+}
+
+static void connect_qp(struct conn *c, const struct exch *local, const struct exch *remote)
+{
+	enum ibv_mtu mtu = RDMA_MTU_MAX;
+	struct ibv_port_attr pa;
+	struct ibv_qp_attr init = {
+		.qp_state = IBV_QPS_INIT,
+		.pkey_index = 0,
+		.port_num = c->port,
+		.qp_access_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
+				   IBV_ACCESS_REMOTE_READ,
+	};
+	struct ibv_qp_attr rtr = {
+		.qp_state = IBV_QPS_RTR,
+		.dest_qp_num = remote->qpn,
+		.rq_psn = remote->psn,
+		.max_dest_rd_atomic = MAX_RD_ATOMIC,
+		.min_rnr_timer = 12,
+		.ah_attr = {
+			.is_global = 1,
+			.port_num = c->port,
+			.grh = { .sgid_index = c->gid_index, .hop_limit = 64 },
+		},
+	};
+	struct ibv_qp_attr rts = {
+		.qp_state = IBV_QPS_RTS,
+		.timeout = 14,
+		.retry_cnt = 7,
+		.rnr_retry = 7,
+		.sq_psn = local->psn,
+		.max_rd_atomic = MAX_RD_ATOMIC,
+	};
+
+	// Clamp the RoCE MTU to what the port negotiated, so we never emit packets
+	// larger than the Ethernet link can carry (which would just be dropped ->
+	// "transport retry counter exceeded").
+	if (!ibv_query_port(c->ctx, c->port, &pa) && pa.active_mtu < mtu)
+		mtu = pa.active_mtu;
+	rtr.path_mtu = mtu;
+	printf("path MTU = %d bytes\n", 128 << mtu);
+
+	memcpy(rtr.ah_attr.grh.dgid.raw, remote->gid, 16);
+
+	if (ibv_modify_qp(c->qp, &init, IBV_QP_STATE | IBV_QP_PKEY_INDEX |
+					IBV_QP_PORT | IBV_QP_ACCESS_FLAGS))
+		DIE("modify INIT failed: %s", strerror(errno));
+	if (ibv_modify_qp(c->qp, &rtr, IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU |
+				       IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
+				       IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER))
+		DIE("modify RTR failed: %s (gid/route issue?)", strerror(errno));
+	if (ibv_modify_qp(c->qp, &rts, IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT |
+				       IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN | IBV_QP_MAX_QP_RD_ATOMIC))
+		DIE("modify RTS failed: %s", strerror(errno));
+}
+
+// Chunked, pipelined RDMA over [0, total). The remote iova base is 0, so
+// remote_addr == byte offset. Up to OUTSTANDING work requests are kept in flight.
+static void rdma_xfer(struct conn *c, enum ibv_wr_opcode op, struct ibv_mr *mr,
+		      uint8_t *host, size_t total, uint64_t remote_base, uint32_t rkey)
+{
+	size_t off = 0;
+	int inflight = 0;
+
+	while (off < total || inflight) {
+		while (off < total && inflight < OUTSTANDING) {
+			size_t len = (total - off < RDMA_CHUNK) ? total - off : RDMA_CHUNK;
+			struct ibv_sge sge = {
+				.addr = (uintptr_t)(host + off),
+				.length = (uint32_t)len,
+				.lkey = mr->lkey,
+			};
+			struct ibv_send_wr wr = {
+				.wr_id = off, .sg_list = &sge, .num_sge = 1,
+				.opcode = op, .send_flags = IBV_SEND_SIGNALED,
+				.wr.rdma.remote_addr = remote_base + off,
+				.wr.rdma.rkey = rkey,
+			};
+			struct ibv_send_wr *bad = NULL;
+
+			if (ibv_post_send(c->qp, &wr, &bad))
+				DIE("ibv_post_send failed at off=%zu: %s", off, strerror(errno));
+			off += len;
+			inflight++;
+		}
+
+		struct ibv_wc wc;
+		int n = ibv_poll_cq(c->cq, 1, &wc);
+
+		if (n < 0)
+			DIE("ibv_poll_cq failed");
+		if (n > 0) {
+			if (wc.status != IBV_WC_SUCCESS)
+				DIE("completion error: %s (wr off=%llu)",
+				    ibv_wc_status_str(wc.status),
+				    (unsigned long long)wc.wr_id);
+			inflight--;
+		}
+	}
+}
+
+/* ===== TCP out-of-band exchange ===== */
+
+static void rw_all(int fd, void *buf, size_t n, int writing)
+{
+	uint8_t *p = buf;
+	while (n) {
+		ssize_t r = writing ? write(fd, p, n) : read(fd, p, n);
+		if (r <= 0)
+			DIE("tcp %s failed: %s", writing ? "write" : "read", strerror(errno));
+		p += r;
+		n -= (size_t)r;
+	}
+}
+
+static int tcp_listen_accept(void)
+{
+	struct sockaddr_in addr = { .sin_family = AF_INET, .sin_port = htons(TCP_PORT),
+				    .sin_addr.s_addr = htonl(INADDR_ANY) };
+	int lfd, fd, yes = 1;
+
+	lfd = socket(AF_INET, SOCK_STREAM, 0);
+	if (lfd < 0)
+		DIE("socket: %s", strerror(errno));
+	setsockopt(lfd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+	if (bind(lfd, (struct sockaddr *)&addr, sizeof(addr)))
+		DIE("bind: %s", strerror(errno));
+	if (listen(lfd, 1))
+		DIE("listen: %s", strerror(errno));
+	printf("waiting for client on tcp/%d ...\n", TCP_PORT);
+	fd = accept(lfd, NULL, NULL);
+	if (fd < 0)
+		DIE("accept: %s", strerror(errno));
+	close(lfd);
+	return fd;
+}
+
+static int tcp_connect(const char *host)
+{
+	struct sockaddr_in addr = { .sin_family = AF_INET, .sin_port = htons(TCP_PORT) };
+	int fd;
+
+	if (inet_pton(AF_INET, host, &addr.sin_addr) != 1)
+		DIE("bad server IP %s (use a dotted-quad)", host);
+	fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (fd < 0)
+		DIE("socket: %s", strerror(errno));
+	if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)))
+		DIE("connect %s:%d: %s", host, TCP_PORT, strerror(errno));
+	return fd;
+}
+
+/* ===== Blackhole side (server only) ===== */
+
+static void raise_power(int fd)
+{
+	struct tenstorrent_power_state ps = { 0 };
+
+	ps.argsz = sizeof(ps);
+	ps.validity = TT_POWER_VALIDITY(4, 0);
+	ps.power_flags = TT_POWER_FLAG_MAX_AI_CLK | TT_POWER_FLAG_MRISC_PHY_WAKEUP |
+			 TT_POWER_FLAG_TENSIX_ENABLE | TT_POWER_FLAG_L2CPU_ENABLE;
+	if (ioctl(fd, TENSTORRENT_IOCTL_SET_POWER_STATE, &ps) != 0)
+		DIE("SET_POWER_STATE: %s", strerror(errno));
+}
+
+static int open_blackhole(const char *path)
+{
+	struct tenstorrent_get_device_info info;
+	int fd = open(path, O_RDWR | O_CLOEXEC);
+
+	if (fd < 0)
+		DIE("open %s: %s", path, strerror(errno));
+	memset(&info, 0, sizeof(info));
+	info.in.output_size_bytes = sizeof(info.out);
+	if (ioctl(fd, TENSTORRENT_IOCTL_GET_DEVICE_INFO, &info) != 0)
+		DIE("GET_DEVICE_INFO: %s", strerror(errno));
+	if (info.out.device_id != BLACKHOLE_PCI_DEVICE_ID)
+		DIE("%s is not Blackhole (device_id=0x%04x)", path, info.out.device_id);
+
+	raise_power(fd);
+	return fd;
+}
+
+static int run_server(const char *bh_path, const char *rdma_name, int gid_index)
+{
+	struct tenstorrent_allocate_tlb alloc = { 0 };
+	struct tenstorrent_configure_tlb cfg = { 0 };
+	struct tenstorrent_free_tlb ft = { 0 };
+	struct tenstorrent_export_tlb_dmabuf exp = { 0 };
+	struct conn c = { 0 };
+	struct exch local = { 0 }, remote = { 0 };
+	struct ibv_mr *bh_mr;
+	int bh_fd, dmabuf_fd, sock;
+	uint8_t sync;
+
+	bh_fd = open_blackhole(bh_path);
+
+	// Aim a TLB window at the GDDR tile, then export the window as a dma-buf.
+	alloc.in.size = TLB_WINDOW_SIZE;
+	if (ioctl(bh_fd, TENSTORRENT_IOCTL_ALLOCATE_TLB, &alloc) != 0)
+		DIE("ALLOCATE_TLB(4G): %s", strerror(errno));
+	cfg.in.id = alloc.out.id;
+	cfg.in.config.addr = NOC_ADDR;
+	cfg.in.config.x_end = NOC_X;
+	cfg.in.config.y_end = NOC_Y;
+	cfg.in.config.ordering = TLB_ORDERING;
+	if (ioctl(bh_fd, TENSTORRENT_IOCTL_CONFIGURE_TLB, &cfg) != 0)
+		DIE("CONFIGURE_TLB: %s", strerror(errno));
+
+	exp.argsz = sizeof(exp);
+	exp.tlb_id = alloc.out.id;
+	exp.size = XFER_SIZE;
+	if (ioctl(bh_fd, TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF, &exp) != 0)
+		DIE("EXPORT_TLB_DMABUF: %s", strerror(errno));
+	dmabuf_fd = exp.fd;
+
+	printf("server: BH %s window->(x=%u,y=%u,addr=0x%llx) %zu MiB exported\n",
+	       bh_path, NOC_X, NOC_Y, (unsigned long long)NOC_ADDR, (size_t)(XFER_SIZE >> 20));
+
+	setup_verbs(&c, rdma_name, gid_index, &local);
+
+	// Register the exported BH window as an RDMA MR. This is the only place the
+	// dma-buf fd is used; the server never maps or touches the data itself.
+	bh_mr = ibv_reg_dmabuf_mr(c.pd, 0, XFER_SIZE, 0, dmabuf_fd,
+				  IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
+				  IBV_ACCESS_REMOTE_READ);
+	if (!bh_mr)
+		DIE("ibv_reg_dmabuf_mr failed: %s", strerror(errno));
+	local.rkey = bh_mr->rkey;
+	local.addr = 0;	// iova
+	printf("server: bh_mr rkey=0x%x\n", bh_mr->rkey);
+
+	sock = tcp_listen_accept();
+	rw_all(sock, &remote, sizeof(remote), 0);	// recv client's QP info
+	rw_all(sock, &local, sizeof(local), 1);		// send ours (incl rkey/addr)
+	connect_qp(&c, &local, &remote);
+	printf("server: connected to client (qpn=0x%x)\n", remote.qpn);
+
+	// The client drives all DMA; we just wait for it to report completion.
+	rw_all(sock, &sync, 1, 0);
+	printf("server: client reported DMA round-trip verified\n");
+	printf("\nNIC <-> Blackhole DMA round-trip verified over the fabric.\n");
+
+	close(sock);
+	ibv_dereg_mr(bh_mr);
+	close(dmabuf_fd);
+	ft.in.id = alloc.out.id;
+	ioctl(bh_fd, TENSTORRENT_IOCTL_FREE_TLB, &ft);
+	close(bh_fd);
+	return 0;
+}
+
+/* ===== peer side (client only) - drives all DMA ===== */
+
+static int run_client(const char *server_ip, const char *rdma_name, int gid_index)
+{
+	struct conn c = { 0 };
+	struct exch local = { 0 }, remote = { 0 };
+	struct ibv_mr *src_mr, *dst_mr;
+	uint64_t *src, *dst;
+	size_t nwords = XFER_SIZE / sizeof(uint64_t);
+	size_t j;
+	int sock;
+	uint8_t sync = 1;
+	double t0, t1;
+
+	setup_verbs(&c, rdma_name, gid_index, &local);
+
+	// Two registered DMA buffers: src is written into Blackhole, dst is filled
+	// back from Blackhole. After a correct round-trip they are identical.
+	src = aligned_alloc(4096, XFER_SIZE);
+	dst = aligned_alloc(4096, XFER_SIZE);
+	if (!src || !dst)
+		DIE("alloc(%zu) failed", (size_t)XFER_SIZE);
+	src_mr = ibv_reg_mr(c.pd, src, XFER_SIZE, IBV_ACCESS_LOCAL_WRITE);
+	dst_mr = ibv_reg_mr(c.pd, dst, XFER_SIZE, IBV_ACCESS_LOCAL_WRITE);
+	if (!src_mr || !dst_mr)
+		DIE("ibv_reg_mr failed: %s", strerror(errno));
+
+	sock = tcp_connect(server_ip);
+	rw_all(sock, &local, sizeof(local), 1);		// send our QP info
+	rw_all(sock, &remote, sizeof(remote), 0);	// recv server's (incl rkey/addr)
+	connect_qp(&c, &local, &remote);
+	printf("client: connected to server (qpn=0x%x, bh rkey=0x%x)\n",
+	       remote.qpn, remote.rkey);
+
+	// NIC -> BH: DMA a fresh random pattern from src into Blackhole GDDR.
+	fill_random(src, XFER_SIZE);
+	t0 = now_sec();
+	rdma_xfer(&c, IBV_WR_RDMA_WRITE, src_mr, (uint8_t *)src, XFER_SIZE, remote.addr, remote.rkey);
+	t1 = now_sec();
+	report("DMA write (NIC->BH)", XFER_SIZE, t1 - t0);
+
+	// BH -> NIC: DMA it back out into dst and verify src and dst now match.
+	// Zero dst first so a short/silent read can't leave stale data that matches.
+	memset(dst, 0, XFER_SIZE);
+	t0 = now_sec();
+	rdma_xfer(&c, IBV_WR_RDMA_READ, dst_mr, (uint8_t *)dst, XFER_SIZE, remote.addr, remote.rkey);
+	t1 = now_sec();
+	report("DMA read  (BH->NIC)", XFER_SIZE, t1 - t0);
+
+	for (j = 0; j < nwords; j++)
+		if (dst[j] != src[j])
+			DIE("verify FAILED at word %zu: got=0x%016llx want=0x%016llx",
+			    j, (unsigned long long)dst[j], (unsigned long long)src[j]);
+	printf("client: round-trip verified (src and dst identical)\n");
+
+	rw_all(sock, &sync, 1, 1);	// tell server "all verified"
+
+	close(sock);
+	ibv_dereg_mr(src_mr);
+	ibv_dereg_mr(dst_mr);
+	free(src);
+	free(dst);
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	const char *bh_path = NULL;
+	const char *rdma_name = NULL;
+	int gid_index = -1;
+	const char *peer;
+	int opt;
+
+	while ((opt = getopt(argc, argv, "b:r:g:h")) != -1) {
+		switch (opt) {
+		case 'b': bh_path = optarg; break;
+		case 'r': rdma_name = optarg; break;
+		case 'g': gid_index = atoi(optarg); break;
+		default:
+			printf("usage:\n"
+			       "  server: %s -b /dev/tenstorrent/N -r rdma_dev [-g gid]\n"
+			       "  client: %s -r rdma_dev [-g gid] <server_ip>\n",
+			       argv[0], argv[0]);
+			return opt == 'h' ? 0 : 2;
+		}
+	}
+
+	srand48(getpid());
+	peer = (optind < argc) ? argv[optind] : NULL;
+
+	if (!rdma_name)
+		DIE("missing -r rdma_dev (e.g. -r rocep201s0f0)");
+
+	if (peer)
+		return run_client(peer, rdma_name, gid_index);
+
+	if (!bh_path)
+		DIE("missing -b /dev/tenstorrent/N on the Blackhole (server) node");
+	return run_server(bh_path, rdma_name, gid_index);
+}


### PR DESCRIPTION
Add `TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF`, which exports an allocated TLB window's BAR aperture as a dma-buf fd. Handed to a peer device's driver, it lets that device do peer-to-peer PCIe DMA straight into/out of the window, which routes onto the NOC per the window's `CONFIGURE_TLB` setup.

- **ABI**: new ioctl + `struct tenstorrent_export_tlb_dmabuf`.
- **Exporter**: maps the aperture into the importer's DMA domain via `dma_map_resource()`.
- **Build**: gated on the dynamic dma-buf interface (Linux 5.8+); older kernels return `-EOPNOTSUPP` but still build.
- **Test tool**: `tools/rdma/nic_bh_p2p_dma` demonstrates and verifies a NIC <-> Blackhole DMA round trip over RoCE.

### Known limitations / follow-ups

1. ~**Importer mapping is not revocable.** If the device is reset or removed while an importer holds a mapping of the exported dma-buf, behavior is undefined.  There is no revoke today. Planned follow-up: `dma_buf_move_notify()`.~ Fixed

2. ~**`FREE_TLB` ignores outstanding exports.** `FREE_TLB` only refuses a window with an active VMA mapping; it does not track dma-buf exports, so a window can be freed (then reallocated/reconfigured) while a dma-buf still references its aperture.  Planned follow-up: a per-TLB export refcount so `FREE_TLB` returns `-EBUSY` while an export is live, released in the dma-buf `.release` callback.~ Fixed

3. **`dma_map_resource()` instead of `pci_p2pdma`.** This implementation uses the former.  It does not go through the PCI P2PDMA framework.  Planned follow-up: alternate implementation based on P2PDMA.

https://github.com/tenstorrent/tt-kmd/issues/248