### PR TITLE
Fix stale cdev routing for container opens after PCI re-probe

### DIFF
--- a/chardev.c
+++ b/chardev.c
@@ -730,6 +730,19 @@ static int tt_cdev_open(struct inode *inode, struct file *file)
 	struct chardev_private *private_data;
 	bool power_aware = file->f_flags & O_APPEND;
 
+	// Container devtmpfs inodes cache i_cdev from the first open and never
+	// update it.  After a PCI remove/re-probe cycle the cached i_cdev still
+	// points to the old (detached) cdev.  Redirect to the current device.
+	if (tt_dev->detached) {
+		unsigned int ordinal = iminor(inode) - MINOR(tt_device_id);
+		struct tenstorrent_device *new_dev = tenstorrent_lookup_device(ordinal);
+
+		if (new_dev && !new_dev->detached)
+			tt_dev = new_dev;
+		else
+			return -ENODEV;
+	}
+
 	private_data = kzalloc(sizeof(*private_data), GFP_KERNEL);
 	if (private_data == NULL)
 		return -ENOMEM;

--- a/enumerate.c
+++ b/enumerate.c
@@ -465,6 +465,11 @@ static void tenstorrent_pci_remove(struct pci_dev *dev)
 	tenstorrent_device_put(tt_dev);
 }
 
+struct tenstorrent_device *tenstorrent_lookup_device(unsigned int ordinal)
+{
+	return xa_load(&tenstorrent_dev_xa, ordinal);
+}
+
 static void tt_dev_release(struct kref *tt_dev_kref) {
 	struct tenstorrent_device *tt_dev = container_of(tt_dev_kref, struct tenstorrent_device, kref);
 	struct pci_dev *pdev = tt_dev->pdev;

--- a/enumerate.h
+++ b/enumerate.h
@@ -20,8 +20,11 @@
 struct pci_dev;
 struct cdev;
 
+struct tenstorrent_device;
+
 int tenstorrent_pci_register_driver(void);
 void tenstorrent_pci_unregister_driver(void);
+struct tenstorrent_device *tenstorrent_lookup_device(unsigned int ordinal);
 
 // Procfs show function for pids
 int pids_proc_show(struct seq_file *s, void *v);


### PR DESCRIPTION
Container devtmpfs inodes cache i_cdev on first open and never refresh it. After a PCI remove/re-probe cycle (e.g. galaxy warm reset), the cached i_cdev still points to the old detached cdev. New opens bind to the zombie device and all ioctls return -ENODEV.

When tt_cdev_open detects a detached device, it now recovers the ordinal from the minor number and redirects to the current live device via xarray lookup. Bare metal should be unaffected — udev creates fresh inodes that never hit the old cdev.