### PR TITLE
Zap userspace MMIO mmaps in tenstorrent_pci_remove

### DIFF
--- a/enumerate.c
+++ b/enumerate.c
@@ -440,6 +440,7 @@ static void tenstorrent_pci_remove(struct pci_dev *dev)
 	// Drain in-flight ioctls before BAR unmap.  detached was already
 	// set under chardev_mutex above.
 	down_write(&tt_dev->reset_rwsem);
+	tenstorrent_vma_zap(tt_dev);
 	tt_dev->dev_class->cleanup_device(tt_dev); // unmap BARs
 	up_write(&tt_dev->reset_rwsem);
 


### PR DESCRIPTION
During a tt-telemetry review, the device-disappearance test (writing `1` to the
PCI device's sysfs `remove` file) did not behave as expected. The expectation was
that once the device is removed, its userspace mappings would be invalidated and
any subsequent access from tt-telemetry would fault with `SIGBUS`.

Instead, mappings were only being invalidated on *reset*. On removal they stayed
live, so tt-telemetry would hang indefinitely on the dead mapping and eventually
get killed by its own watchdog.

### Change

`tenstorrent_pci_remove` now zaps all userspace BAR/TLB mappings (reusing the
existing `tenstorrent_vma_zap` path used by reset) before unmapping the BARs.
After this change, accessing a mapping belonging to a removed device faults with
`SIGBUS`, as expected.

### Notes

- Until a KMD version including this change ships, the sysfs-remove mechanism
  should not be relied upon to verify tt-telemetry's disappearance handling.
- https://gist.github.com/joelsmithTT/65c568dce3fe876fdd93a1ce90581faa has a standalone test for this change.
- 
https://github.com/tenstorrent/tt-kmd/issues/254