### PR TITLE
Linux 7.1.0 compilation fix: zap_vma_ptes was renamed zap_special_vma_range

### DIFF
--- a/memory.c
+++ b/memory.c
@@ -9,6 +9,8 @@
 #include <linux/uaccess.h>
 #include <linux/dma-mapping.h>
 #include <linux/version.h>
+#include <linux/mm.h>
+
 #include <linux/iommu.h>
 #include <linux/file.h>
 #include <linux/vmalloc.h>
@@ -22,6 +24,10 @@
 #include "tlb.h"
 
 #define BAR0_SIZE (1UL << 29)
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7, 1, 0)
+# define zap_special_vma_range(vma, addr, size) zap_vma_ptes(vma, addr, size)
+#endif
 
 static int get_sorted_iatu_region_indices(const struct tenstorrent_outbound_iatu_region *regions, int *sorted_indices)
 {
@@ -1047,7 +1053,7 @@ static void tenstorrent_vma_open(struct vm_area_struct *vma)
 	new_mmap_vma = kzalloc(sizeof(*new_mmap_vma), GFP_KERNEL);
 	if (!new_mmap_vma) {
 		dev_err_ratelimited(&priv->device->pdev->dev, "Failed to allocate mmap_vma on fork()\n");
-		zap_vma_ptes(vma, vma->vm_start, vma->vm_end - vma->vm_start);
+		zap_special_vma_range(vma, vma->vm_start, vma->vm_end - vma->vm_start);
 		vma->vm_private_data = NULL;
 		return;
 	}
@@ -1389,7 +1395,8 @@ void tenstorrent_vma_zap(struct tenstorrent_device *tt_dev)
 				// Detach from list but keep structure alive for vma_close.
 				list_del_init(&mmap_vma->list);
 
-				zap_vma_ptes(vma, vma->vm_start, vma->vm_end - vma->vm_start);
+				zap_special_vma_range(vma, vma->vm_start,
+						      vma->vm_end - vma->vm_start);
 			}
 
 			mutex_unlock(&priv->vma_lock);


### PR DESCRIPTION
zap_vma_ptes was renamed zap_special_vma_range in Linux 7.1.0.

So, update memory.c to use zap_special_vma_range, adding a backward compatibility macro for it for earlier kernels.

I have confirmed that, with this change, tensortorrent.ko compiled without complaint, and apparently successfully auto-loaded the one time when the Tensortorrent card that I received yesterday worked.

At all other times, I have been having what I think may be electrical or mechanical problems, so I may not be able to verify much more for now.

Note that linux-7.1/mm/memory.c's zap_speical_vma_range was also edited so that it now allows use on VM_MIXEDMAP
(previously it would be a no-op).  I guess that the VM_MIXEDMAP support does not effect the calls that this diff changes, based on gemini.google.com explaining that flag to me and telling me that that change was a separate commit from the renaming of the function.

Trade-offs considered, which one could revisit:

1. Made the call sites use the new function name instead of having a forward compatibility macro.  As time goes by this, should keep the code more understandable by people following the then current coding conventions.

2. Used a macro instead of an inline function, on the theory that I'd rather not have to deal with the parameter types changes between kernel versions if it's not enough for the call sites to upset the compiler, although this is pretty unlikely.

3. Although both call sites operate on the entire address space, I declined to make a separate function which might have made the call sites more visible and could have contained this version compatibility accommodation, because
   (3a)  I'm not sure that it would be, overall, a readability and maintainability improvement and,
   (3b) if one wanted to do that, I'd rather see it done as a separate diff for easier separate reversibility.
   
Disclaimers, as a Tensortorrent newbie:

1. This is my first pull request to Tenstorrent.  So, please let me know if there are documents I should have read some other documentation about conventions for this source tree.

2. I vibe coded this diff, but did look over the changes between these functions with "diff -u linux-7.{0.14,1}/mm/memory.c".

3. I ran checkpatch.pl on this diff.  I ignored complaints about use the KERNEL_VERSION macro because this is an out of tree driver that needs to support many versions.  I ignored the complaint about the lack of a signed-off line, as that does not seem to be the convention in this tree.  I did accommodate a complaint that one line had become too long,
indenting according to what seems to be the convention in this tree: making each parameter align with the "(" that
opened the parameter list.