### PR TITLE
Reclaim chip-backed resources upon reset

### DIFF
--- a/chardev.c
+++ b/chardev.c
@@ -276,23 +276,27 @@ static long ioctl_reset_device(struct chardev_private *priv,
 		bump_reset_gen(priv);
 		tenstorrent_vma_zap(tt_dev);
 		tenstorrent_reset_reclaim_tlbs(tt_dev);
+		tenstorrent_reset_reclaim_iatus(tt_dev);
 		ok = pcie_timer_interrupt(pdev);
 	} else if (in.flags == TENSTORRENT_RESET_DEVICE_USER_RESET) {
 		bump_reset_gen(priv);
 		tenstorrent_vma_zap(tt_dev);
 		tenstorrent_reset_reclaim_tlbs(tt_dev);
+		tenstorrent_reset_reclaim_iatus(tt_dev);
 		ok = set_reset_marker(pdev);
 		priv->device->needs_hw_init = true;
 	} else if (in.flags == TENSTORRENT_RESET_DEVICE_ASIC_RESET) {
 		bump_reset_gen(priv);
 		tenstorrent_vma_zap(tt_dev);
 		tenstorrent_reset_reclaim_tlbs(tt_dev);
+		tenstorrent_reset_reclaim_iatus(tt_dev);
 		ok = priv->device->dev_class->reset(priv->device, in.flags);
 		priv->device->needs_hw_init = true;
 	} else if (in.flags == TENSTORRENT_RESET_DEVICE_ASIC_DMC_RESET) {
 		bump_reset_gen(priv);
 		tenstorrent_vma_zap(tt_dev);
 		tenstorrent_reset_reclaim_tlbs(tt_dev);
+		tenstorrent_reset_reclaim_iatus(tt_dev);
 		ok = priv->device->dev_class->reset(priv->device, in.flags);
 		priv->device->needs_hw_init = true;
 	} else if (in.flags == TENSTORRENT_RESET_DEVICE_POST_RESET) {

--- a/chardev.c
+++ b/chardev.c
@@ -197,6 +197,31 @@ static void bump_reset_gen(struct chardev_private *priv)
 	priv->open_reset_gen = atomic_long_inc_return(&priv->device->reset_gen);
 }
 
+// Reclaim TLB windows from fds this reset invalidated.
+// An invalidated fd can only free its windows at close(), which a wedged
+// process may never reach, leaking windows until the pool is exhausted.
+// Caller holds reset_rwsem exclusive and has already called bump_reset_gen()
+// and tenstorrent_vma_zap().
+static void tenstorrent_reset_reclaim_tlbs(struct tenstorrent_device *tt_dev)
+{
+	struct chardev_private *priv;
+	long gen = atomic_long_read(&tt_dev->reset_gen);
+	unsigned int bitpos;
+
+	mutex_lock(&tt_dev->chardev_mutex);
+	list_for_each_entry(priv, &tt_dev->open_fds_list, open_fd) {
+		// Skip the resetting fd, since it survives the reset.
+		if (priv->open_reset_gen == gen)
+			continue;
+
+		for_each_set_bit(bitpos, priv->tlbs, TENSTORRENT_MAX_INBOUND_TLBS) {
+			tenstorrent_device_free_tlb(tt_dev, bitpos);
+			clear_bit(bitpos, priv->tlbs);
+		}
+	}
+	mutex_unlock(&tt_dev->chardev_mutex);
+}
+
 static long ioctl_reset_device(struct chardev_private *priv,
 			       struct tenstorrent_reset_device __user *arg)
 {
@@ -250,20 +275,24 @@ static long ioctl_reset_device(struct chardev_private *priv,
 	} else if (in.flags == TENSTORRENT_RESET_DEVICE_CONFIG_WRITE) {
 		bump_reset_gen(priv);
 		tenstorrent_vma_zap(tt_dev);
+		tenstorrent_reset_reclaim_tlbs(tt_dev);
 		ok = pcie_timer_interrupt(pdev);
 	} else if (in.flags == TENSTORRENT_RESET_DEVICE_USER_RESET) {
 		bump_reset_gen(priv);
 		tenstorrent_vma_zap(tt_dev);
+		tenstorrent_reset_reclaim_tlbs(tt_dev);
 		ok = set_reset_marker(pdev);
 		priv->device->needs_hw_init = true;
 	} else if (in.flags == TENSTORRENT_RESET_DEVICE_ASIC_RESET) {
 		bump_reset_gen(priv);
 		tenstorrent_vma_zap(tt_dev);
+		tenstorrent_reset_reclaim_tlbs(tt_dev);
 		ok = priv->device->dev_class->reset(priv->device, in.flags);
 		priv->device->needs_hw_init = true;
 	} else if (in.flags == TENSTORRENT_RESET_DEVICE_ASIC_DMC_RESET) {
 		bump_reset_gen(priv);
 		tenstorrent_vma_zap(tt_dev);
+		tenstorrent_reset_reclaim_tlbs(tt_dev);
 		ok = priv->device->dev_class->reset(priv->device, in.flags);
 		priv->device->needs_hw_init = true;
 	} else if (in.flags == TENSTORRENT_RESET_DEVICE_POST_RESET) {

--- a/memory.c
+++ b/memory.c
@@ -273,27 +273,77 @@ static void unpin_user_pages_dirty_lock(struct page **pages, unsigned long npage
 
 #define MMAP_SIZE_DMA_BUF (U64_C(1) << 32)
 
+// Clear an outbound iATU slot's bookkeeping without touching the hardware.
+static void release_outbound_iatu_slot(struct tenstorrent_device *tt_dev, int iatu_region)
+{
+	struct tenstorrent_outbound_iatu_region *region = &tt_dev->outbound_iatus[iatu_region];
+
+	lockdep_assert_held(&tt_dev->iatu_mutex);
+
+	region->priv = NULL;
+	region->base = 0;
+	region->limit = 0;
+	region->target = 0;
+}
+
 static void teardown_outbound_iatu(struct chardev_private *priv, int iatu_region)
 {
 	struct tenstorrent_device *tt_dev = priv->device;
-	struct tenstorrent_outbound_iatu_region *region;
 
 	if (iatu_region < 0)
 		return;
 
 	mutex_lock(&tt_dev->iatu_mutex);
 
-	region = &priv->device->outbound_iatus[iatu_region];
-
 	if (!tt_dev->detached)
 		tt_dev->dev_class->configure_outbound_atu(tt_dev, iatu_region, 0, 0, 0);
 
-	region->priv = NULL;
-	region->base = 0;
-	region->limit = 0;
-	region->target = 0;
+	release_outbound_iatu_slot(tt_dev, iatu_region);
 
 	mutex_unlock(&tt_dev->iatu_mutex);
+}
+
+// Reclaim outbound iATU slots from fds this reset invalidated (stale
+// open_reset_gen); a wedged process would otherwise hold them until a
+// close() that never comes.  Only the bookkeeping is released: reset leaves
+// the ATU default-clear, which is what a free slot means.  Nulling each
+// back-reference makes the stale fd's close() a no-op, so it cannot disable
+// a slot a post-reset fd has since claimed.  Caller holds reset_rwsem
+// exclusive and has already called bump_reset_gen().
+void tenstorrent_reset_reclaim_iatus(struct tenstorrent_device *tt_dev)
+{
+	long gen = atomic_long_read(&tt_dev->reset_gen);
+	struct chardev_private *priv;
+	struct pinned_page_range *pinning;
+	struct dmabuf *dmabuf;
+	unsigned int i;
+
+	mutex_lock(&tt_dev->chardev_mutex);
+	list_for_each_entry(priv, &tt_dev->open_fds_list, open_fd) {
+		if (priv->open_reset_gen == gen)
+			continue;
+
+		mutex_lock(&priv->mutex);
+		mutex_lock(&tt_dev->iatu_mutex);
+
+		hash_for_each(priv->dmabufs, i, dmabuf, hash_chain) {
+			if (dmabuf->outbound_iatu_region >= 0) {
+				release_outbound_iatu_slot(tt_dev, dmabuf->outbound_iatu_region);
+				dmabuf->outbound_iatu_region = -1;
+			}
+		}
+
+		list_for_each_entry(pinning, &priv->pinnings, list) {
+			if (pinning->outbound_iatu_region >= 0) {
+				release_outbound_iatu_slot(tt_dev, pinning->outbound_iatu_region);
+				pinning->outbound_iatu_region = -1;
+			}
+		}
+
+		mutex_unlock(&tt_dev->iatu_mutex);
+		mutex_unlock(&priv->mutex);
+	}
+	mutex_unlock(&tt_dev->chardev_mutex);
 }
 
 static void unpin_pinned_page_range(struct chardev_private *priv,

--- a/memory.h
+++ b/memory.h
@@ -58,6 +58,7 @@ long ioctl_export_tlb_dmabuf(struct chardev_private *priv,
 int tenstorrent_mmap(struct chardev_private *priv, struct vm_area_struct *vma);
 void tenstorrent_memory_cleanup(struct chardev_private *priv);
 void tenstorrent_vma_zap(struct tenstorrent_device *tt_dev);
+void tenstorrent_reset_reclaim_iatus(struct tenstorrent_device *tt_dev);
 void tenstorrent_revoke_tlb_dmabufs(struct tenstorrent_device *tt_dev);
 bool tenstorrent_has_tlb_dmabuf_exports(struct tenstorrent_device *tt_dev);
 bool is_iommu_translated(struct device *dev);


### PR DESCRIPTION
Fixes https://github.com/tenstorrent/tt-kmd/issues/261.

A reset invalidates every other open fd but left their chip-backed allocations in place, freeable only by a close() that a wedged process never makes. On CI this exhausts TLB windows: tt-smi -r "succeeds", the next job fails ALLOCATE_TLB with -ENOMEM, and the machine stays red until reaped or rebooted.

The reset_gen-bumping reset flavors now reclaim stale fds' TLB windows and outbound iATU slots. Bookkeeping only; the chip is about to be reset and the reset clears this state anyway. Clearing the per-fd back-references makes the stale fd's eventual close() a no-op, so it can't cross-free a resource a post-reset fd has since claimed. Resource locks are driver-only arbitration state with no chip correlate and deliberately survive.

Commit 1: reclaim TLB windows
Commit 2: reclaim outbound iATU regions