### PR TITLE
Treat suspend/resume as a reset

### DIFF
--- a/chardev.c
+++ b/chardev.c
@@ -202,7 +202,7 @@ static void bump_reset_gen(struct chardev_private *priv)
 // process may never reach, leaking windows until the pool is exhausted.
 // Caller holds reset_rwsem exclusive and has already called bump_reset_gen()
 // and tenstorrent_vma_zap().
-static void tenstorrent_reset_reclaim_tlbs(struct tenstorrent_device *tt_dev)
+void tenstorrent_reset_reclaim_tlbs(struct tenstorrent_device *tt_dev)
 {
 	struct chardev_private *priv;
 	long gen = atomic_long_read(&tt_dev->reset_gen);

--- a/chardev.h
+++ b/chardev.h
@@ -14,5 +14,6 @@ int tenstorrent_register_device(struct tenstorrent_device *gs_dev);
 void tenstorrent_unregister_device(struct tenstorrent_device *gs_dev);
 int tenstorrent_set_aggregated_power_state(struct tenstorrent_device *tt_dev);
 void tenstorrent_power_down_work_func(struct work_struct *work);
+void tenstorrent_reset_reclaim_tlbs(struct tenstorrent_device *tt_dev);
 
 #endif

--- a/enumerate.c
+++ b/enumerate.c
@@ -488,11 +488,28 @@ void tenstorrent_device_put(struct tenstorrent_device *tt_dev) {
 	kref_put(&tt_dev->kref, tt_dev_release);
 }
 
-static int tenstorrent_suspend(struct device *dev) {
+static int tenstorrent_suspend(struct device *dev)
+{
 	struct pci_dev *pdev = to_pci_dev(dev);
 	struct tenstorrent_device *tt_dev = pci_get_drvdata(pdev);
 
 	cancel_delayed_work_sync(&tt_dev->power_down_work);
+
+	// Suspend loses hardware state (TLB routing, iATU programming, etc.), so
+	// suspend behaves like a reset: bump reset_gen to invalidate every open fd,
+	// zap userspace MMIO mappings, and reclaim chip-backed allocations.
+	down_write(&tt_dev->reset_rwsem);
+	atomic_long_inc(&tt_dev->reset_gen);
+	tenstorrent_vma_zap(tt_dev);
+	tenstorrent_reset_reclaim_tlbs(tt_dev);
+	tenstorrent_reset_reclaim_iatus(tt_dev);
+	up_write(&tt_dev->reset_rwsem);
+
+	// Wake blocked LOCK_CTL waiters so they observe the bumped generation and
+	// return -ENODEV instead of parking on a lock no pre-suspend fd can
+	// release via ioctl.
+	wake_up_interruptible(&tt_dev->resource_lock_waitqueue);
+
 	tenstorrent_revoke_tlb_dmabufs(tt_dev);
 
 	tt_dev->dev_class->cleanup_hardware(tt_dev);


### PR DESCRIPTION
Suspend loses hardware state, but the driver did nothing to tell userspace, leaving pre-suspend fds running against a device whose state had silently been wiped on resume.  Until we can save & restore that state, make suspend behave like a reset.

Closes https://github.com/tenstorrent/tt-kmd/issues/253