### PR TITLE
blackhole: forward firmware logs over PCIe to the kernel log

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,9 @@ jobs:
     - uses: actions/checkout@v4
     - run: |
         make -C test -j $(nproc)
+    - name: Run host-only unit tests
+      run: |
+        make -C test check
 
   build-debian:
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 obj-m += tenstorrent.o
-tenstorrent-y := module.o chardev.o enumerate.o interrupt.o wormhole.o blackhole.o msgqueue.o pcie.o sg_helpers.o memory.o tlb.o telemetry.o
+tenstorrent-y := module.o chardev.o enumerate.o interrupt.o wormhole.o blackhole.o fwlog.o fwlog_parser.o msgqueue.o pcie.o sg_helpers.o memory.o tlb.o telemetry.o
 
 # Capture the module directory at the top level before kernel build system changes context
 MODULE_DIR := $(CURDIR)

--- a/blackhole.c
+++ b/blackhole.c
@@ -72,8 +72,13 @@
 #define ARC_MSG_TYPE_TRIGGER_RESET 0x56
 #define ARC_MSG_TYPE_POWER_SETTING 0x21
 #define ARC_MSG_TYPE_TEST 0x90
+#define ARC_MSG_TYPE_FW_LOG 0xC7          // TT_SMC_MSG_TT_PCIE_LOG
 #define ARC_BOOT_STATUS RESET_SCRATCH(2)
 #define ARC_BOOT_STATUS_READY_FOR_MSG 0x1
+
+// Sub-commands carried in byte 1 of the ARC_MSG_TYPE_FW_LOG header.
+#define FW_LOG_SUBCMD_SETUP   0x1
+#define FW_LOG_SUBCMD_RELEASE 0x2
 
 #define IATU_BASE 0x1000	// Relative to the start of BAR2
 #define IATU_OUTBOUND 0
@@ -535,6 +540,36 @@ static bool send_arc_message(struct blackhole_device *bh, struct arc_msg *msg)
 	return msg->header == 0;
 }
 
+// The generic fwlog implementation invokes these shims for its control path.
+// ARC message construction and send_arc_message() are Blackhole-specific;
+// buffer management, parsing, output, and ownership handoff live in fwlog.c.
+bool fw_log_hw_setup(void *hw_ctx, dma_addr_t buffer_dma, u32 buffer_size)
+{
+	struct blackhole_device *bh = hw_ctx;
+	struct arc_msg msg = { 0 };
+
+	msg.header = ARC_MSG_TYPE_FW_LOG | (FW_LOG_SUBCMD_SETUP << 8) |
+		     (FW_LOG_PROTOCOL_VERSION << 16);
+	msg.payload[0] = lower_32_bits(buffer_dma);
+	msg.payload[1] = upper_32_bits(buffer_dma);
+	msg.payload[2] = buffer_size;
+	return send_arc_message(bh, &msg);
+}
+
+bool fw_log_hw_release(void *hw_ctx)
+{
+	struct blackhole_device *bh = hw_ctx;
+	struct arc_msg msg = { 0 };
+
+	msg.header = ARC_MSG_TYPE_FW_LOG | (FW_LOG_SUBCMD_RELEASE << 8);
+	return send_arc_message(bh, &msg);
+}
+
+static void blackhole_interrupt(struct tenstorrent_device *tt_dev)
+{
+	fw_log_interrupt(&tt_dev->fw_log);
+}
+
 static bool blackhole_reset(struct tenstorrent_device *tt_dev, u32 reset_flag)
 {
 	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
@@ -605,6 +640,11 @@ static bool blackhole_init(struct tenstorrent_device *tt_dev)
 	set_bit(KERNEL_TLB_INDEX, tt_dev->tlbs);
 	mutex_init(&bh->kernel_tlb_mutex);
 
+	// Initialize once and reserve the device-lifetime DMA buffer. The MSI
+	// handler may schedule work after the firmware handshake, which happens
+	// later in blackhole_init_hardware().
+	fw_log_init(&tt_dev->fw_log, &tt_dev->pdev->dev, bh);
+
 	tt_dev->hwmon_attributes = bh_hwmon_attrs;
 	tt_dev->hwmon_labels = bh_hwmon_labels;
 	tt_dev->telemetry_sysfs = bh_sysfs_attributes;
@@ -635,6 +675,9 @@ static bool blackhole_init_hardware(struct tenstorrent_device *tt_dev)
 	msg.payload[0] = 1000 * auto_reset_timeout; // Convert seconds to milliseconds
 	if (!send_arc_message(bh, &msg))
 		dev_warn(&tt_dev->pdev->dev, "Failed to set ARC watchdog timeout (this is normal for old FW)\n");
+
+	// Best-effort: start firmware log forwarding. Also re-runs on resume.
+	fw_log_setup(&tt_dev->fw_log);
 
 	return true;
 }
@@ -700,6 +743,17 @@ static void blackhole_cleanup_hardware(struct tenstorrent_device *tt_dev)
 	if (tt_dev->detached)
 		return;
 
+	// Suspend retains the DMA allocation and reuses it at resume. IRQs were
+	// disabled by the common suspend path, so drain any batch that was queued
+	// before firmware is told to stop; otherwise it could run concurrently
+	// with fw_log_setup() clearing and reinitializing the shared buffer.
+	fw_log_quiesce(&tt_dev->fw_log);
+
+	// Tell firmware to stop writing the shared log buffer while the device
+	// is still reachable. The buffer itself is freed later on the
+	// always-run device cleanup path (blackhole_cleanup -> fw_log_free).
+	fw_log_notify_release(&tt_dev->fw_log);
+
 	msg.header = ARC_MSG_TYPE_ASIC_STATE3;
 	if (!send_arc_message(bh, &msg))
 		dev_err(&tt_dev->pdev->dev, "Failed to send ARC message for A3 state\n");
@@ -708,6 +762,12 @@ static void blackhole_cleanup_hardware(struct tenstorrent_device *tt_dev)
 static void blackhole_cleanup(struct tenstorrent_device *tt_dev)
 {
 	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
+
+	// Software teardown of firmware logging: disable, drain the workqueue,
+	// and free the shared buffer. Runs unconditionally (no hardware
+	// access) so the buffer is always released even on an unreachable
+	// device. Firmware was asked to stop in blackhole_cleanup_hardware.
+	fw_log_free(&tt_dev->fw_log);
 
 	if (bh->tlb_regs)
 		pci_iounmap(tt_dev->pdev, bh->tlb_regs);
@@ -833,6 +893,7 @@ struct tenstorrent_device_class blackhole_class = {
 	.restore_reset_state = blackhole_restore_reset_state,
 	.configure_outbound_atu = blackhole_configure_outbound_atu,
 	.noc_write32 = blackhole_noc_write32,
+	.interrupt = blackhole_interrupt,
 	.csm_read32 = blackhole_csm_read32,
 	.csm_write32 = blackhole_csm_write32,
 	.set_power_state = blackhole_set_power_state,

--- a/device.h
+++ b/device.h
@@ -108,6 +108,10 @@ struct tenstorrent_device_class {
 	void (*restore_reset_state)(struct tenstorrent_device *ttdev);
 	int (*configure_outbound_atu)(struct tenstorrent_device *ttdev, u32 region, u64 base, u64 limit, u64 target);
 	void (*noc_write32)(struct tenstorrent_device *ttdev, u32 x, u32 y, u64 addr, u32 data, int noc);
+
+	// Optional MSI handler invoked from the driver's IRQ handler. May be NULL for devices
+	// with no interrupt handling.
+	void (*interrupt)(struct tenstorrent_device *ttdev);
 	int (*csm_read32)(struct tenstorrent_device *ttdev, u64 addr, u32 *value);
 	int (*csm_write32)(struct tenstorrent_device *ttdev, u64 addr, u32 value);
 	int (*set_power_state)(struct tenstorrent_device *ttdev, struct tenstorrent_power_state *power_state);

--- a/device.h
+++ b/device.h
@@ -18,6 +18,7 @@
 #include "ioctl.h"
 #include "memory.h"
 #include "telemetry.h"
+#include "fwlog_kmd.h"
 
 #define MAX_TLB_KINDS 4
 
@@ -78,6 +79,9 @@ struct tenstorrent_device {
 	// Populated by telemetry_probe(); looked up via binary search.
 	struct telem_cache_entry *telemetry_cache;
 	u16 telemetry_cache_count;
+
+	// Firmware log forwarding.
+	struct fw_log_state fw_log;
 
 	struct list_head dmabuf_exports;
 	struct mutex dmabuf_export_lock;

--- a/enumerate.c
+++ b/enumerate.c
@@ -431,6 +431,14 @@ static void tenstorrent_pci_remove(struct pci_dev *dev)
 	if (vendor_id != U16_MAX)
 		tt_dev->dev_class->cleanup_hardware(tt_dev);
 
+	// Disable interrupts before cleanup_device(). A device-class interrupt
+	// handler may schedule work and cleanup_device() then cancels that work
+	// and frees the buffer it touches. free_irq() waits for in-flight handlers
+	// but does not flush already-scheduled work, so it must run before the drain
+	// otherwise a late interrupt could re-schedule log_work after
+	// cancel_work_sync().
+	tenstorrent_disable_interrupts(tt_dev);
+
 	// Drain in-flight ioctls before BAR unmap.  detached was already
 	// set under chardev_mutex above.
 	down_write(&tt_dev->reset_rwsem);
@@ -459,7 +467,6 @@ static void tenstorrent_pci_remove(struct pci_dev *dev)
 	}
 
 	tenstorrent_unregister_device(tt_dev);
-	tenstorrent_disable_interrupts(tt_dev);
 
 	pci_disable_pcie_error_reporting(dev);
 	pci_disable_device(dev);
@@ -495,6 +502,10 @@ static int tenstorrent_suspend(struct device *dev) {
 	cancel_delayed_work_sync(&tt_dev->power_down_work);
 	tenstorrent_revoke_tlb_dmabufs(tt_dev);
 
+	// Device-class cleanup may need to drain work scheduled by its IRQ
+	// handler before firmware is suspended. free_irq() prevents a late MSI
+	// from queuing more work after that drain.
+	tenstorrent_disable_interrupts(tt_dev);
 	tt_dev->dev_class->cleanup_hardware(tt_dev);
 
 	return 0;
@@ -503,8 +514,14 @@ static int tenstorrent_suspend(struct device *dev) {
 static int tenstorrent_resume(struct device *dev) {
 	struct pci_dev *pdev = to_pci_dev(dev);
 	struct tenstorrent_device *tt_dev = pci_get_drvdata(pdev);
+	bool ok;
 
-	bool ok = tt_dev->dev_class->init_hardware(tt_dev);
+	// Re-establish the handler before init_hardware() re-enables firmware
+	// features that signal completion through MSI (such as FW log batches).
+	if (!tenstorrent_enable_interrupts(tt_dev))
+		dev_warn(dev, "Unable to re-enable interrupts after resume\n");
+
+	ok = tt_dev->dev_class->init_hardware(tt_dev);
 
 	// Suspend invalidates the saved state.
 	if (ok)

--- a/fwlog.c
+++ b/fwlog.c
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <linux/compiler.h>
+#include <linux/dma-mapping.h>
+#include <linux/kernel.h>
+#include <linux/string.h>
+
+#include "fwlog_kmd.h"
+#include "ioctl.h"
+#include "memory.h"
+#include "module.h"
+
+// Wire contract with the firmware backend.
+static_assert(sizeof(struct fw_log_buffer_header) == 16, "fw_log_buffer_header size mismatch");
+static_assert(sizeof(struct fw_log_entry_header) == 12, "fw_log_entry_header size mismatch");
+
+// Emit one decoded record to the kernel log. Invoked by fw_log_parse().
+static void fw_log_emit_to_kernel(void *ctx, const struct fw_log_record *rec)
+{
+	struct device *dev = ctx;
+	const char *source_str = fw_log_source_str(rec->source);
+
+	if (rec->seq_gap)
+		dev_warn(dev, "FW log: sequence gap (expected %u, got %u)\n",
+			 rec->expected_seq, rec->sequence);
+
+	if (!fw_log_prepare_emit(rec, fw_log_level))
+		return;
+
+	switch (rec->log_level) {
+	case FW_LOG_LEVEL_ERROR:
+		dev_err(dev, "%s: %s", source_str, rec->text);
+		break;
+	case FW_LOG_LEVEL_WARN:
+		dev_warn(dev, "%s: %s", source_str, rec->text);
+		break;
+	case FW_LOG_LEVEL_INFO:
+		dev_info(dev, "%s: %s", source_str, rec->text);
+		break;
+	case FW_LOG_LEVEL_DEBUG:
+	default:
+		dev_dbg(dev, "%s: %s", source_str, rec->text);
+		break;
+	}
+}
+
+// Drain the framed logs firmware has published into the shared buffer.
+static void fw_log_work_handler(struct work_struct *work)
+{
+	struct fw_log_state *log = container_of(work, struct fw_log_state, work);
+	struct fw_log_buffer_header *buf_header;
+	struct fw_log_parse_result result;
+
+	if (!READ_ONCE(log->enabled) || !log->buffer_virt)
+		return;
+
+	buf_header = log->buffer_virt;
+
+	// Gate on the firmware's ownership handoff before touching anything else
+	// in the buffer.
+	if (READ_ONCE(buf_header->owner) != FW_LOG_BUFFER_OWNER_HOST)
+		return;
+
+	// The ownership read above must be observed before metadata and payload
+	// reads below.
+	dma_rmb();
+
+	if (buf_header->magic != FW_LOG_BUFFER_MAGIC) {
+		// Disable rather than return because other interrupt sources
+		// keep waking this handler, and without disabling we would log
+		// this on every one of them. A device reset re-runs fw_log_setup
+		// and re-enables.
+		dev_err(log->dev, "FW log buffer corrupted (magic=0x%08x); disabling until reset\n",
+			buf_header->magic);
+		WRITE_ONCE(log->enabled, false);
+		return;
+	}
+
+	result = fw_log_parse(log->buffer_virt, FW_LOG_BUFFER_SIZE, buf_header->write_offset,
+			      &log->seq, fw_log_emit_to_kernel, log->dev);
+
+	if (result.framing_error)
+		dev_warn(log->dev, "FW log: bad record at offset %u (size %u)\n",
+			 result.error_offset, result.error_msg_size);
+
+	// Every payload read above must complete before the store below becomes
+	// visible to firmware.
+	mb();
+	WRITE_ONCE(buf_header->owner, FW_LOG_BUFFER_OWNER_FW);
+}
+
+void fw_log_init(struct fw_log_state *log, struct device *dev, void *hw_ctx)
+{
+	log->dev = dev;
+	log->hw_ctx = hw_ctx;
+	INIT_WORK(&log->work, fw_log_work_handler);
+
+	if (!fw_logging)
+		return;
+
+	// Firmware DMAs into this buffer asynchronously and may ignore a release
+	// handshake after a failure. Without an IOMMU a stray write could corrupt
+	// freed memory; IOMMU translation converts it into a fault instead.
+	if (!is_iommu_translated(log->dev)) {
+		dev_info(log->dev, "FW log forwarding disabled: requires IOMMU translation\n");
+		return;
+	}
+
+	if (log->buffer_virt)
+		return;
+
+	log->buffer_virt = dma_alloc_coherent(log->dev, FW_LOG_BUFFER_SIZE,
+					      &log->buffer_dma, GFP_KERNEL);
+	if (!log->buffer_virt)
+		dev_warn(log->dev, "FW log: buffer allocation failed\n");
+}
+
+// FW-interaction phase (analogous to init_hardware): hand the buffer to
+// firmware and start forwarding. Re-runs on resume. On any failure the
+// buffer (already allocated) is left in place, just not enabled.
+void fw_log_setup(struct fw_log_state *log)
+{
+	struct fw_log_buffer_header *buf_header;
+
+	if (!log->buffer_virt)
+		return;
+
+	memset(log->buffer_virt, 0, FW_LOG_BUFFER_SIZE);
+	log->seq = (struct fw_log_seq){ 0 };
+
+	if (!fw_log_hw_setup(log->hw_ctx, log->buffer_dma, FW_LOG_BUFFER_SIZE)) {
+		dev_dbg(log->dev, "FW log: setup message not acknowledged, unsupported FW\n");
+		return;
+	}
+
+	// Firmware initializes the header synchronously before acknowledging
+	// setup, so validate the framing contract before publishing enable.
+	buf_header = log->buffer_virt;
+	dma_rmb();
+	if (buf_header->magic != FW_LOG_BUFFER_MAGIC) {
+		dev_warn(log->dev, "FW log: firmware did not initialize buffer (magic=0x%08x); disabling\n",
+			 buf_header->magic);
+		return;
+	}
+	if (buf_header->version != FW_LOG_PROTOCOL_VERSION) {
+		dev_warn(log->dev, "FW log: protocol version mismatch (fw=%u, kmd=%u); disabling\n",
+			 buf_header->version, FW_LOG_PROTOCOL_VERSION);
+		return;
+	}
+
+	smp_wmb();
+	WRITE_ONCE(log->enabled, true);
+	dev_info(log->dev, "FW log forwarding enabled\n");
+}
+
+void fw_log_notify_release(struct fw_log_state *log)
+{
+	if (!log->buffer_virt)
+		return;
+
+	if (!fw_log_hw_release(log->hw_ctx))
+		dev_dbg(log->dev, "FW log: release message not acknowledged\n");
+}
+
+void fw_log_quiesce(struct fw_log_state *log)
+{
+	WRITE_ONCE(log->enabled, false);
+	cancel_work_sync(&log->work);
+}
+
+// Software teardown (analogous to cleanup_device): quiesce the worker and
+// release the DMA buffer allocated by fw_log_init().
+void fw_log_free(struct fw_log_state *log)
+{
+	if (!log->buffer_virt)
+		return;
+
+	fw_log_quiesce(log);
+	dma_free_coherent(log->dev, FW_LOG_BUFFER_SIZE, log->buffer_virt, log->buffer_dma);
+	log->buffer_virt = NULL;
+}
+
+void fw_log_interrupt(struct fw_log_state *log)
+{
+	if (READ_ONCE(log->enabled))
+		schedule_work(&log->work);
+}

--- a/fwlog.h
+++ b/fwlog.h
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef TTDRIVER_FWLOG_H_INCLUDED
+#define TTDRIVER_FWLOG_H_INCLUDED
+
+// Wire contract for firmware log forwarding ("tt_pcie_log").
+//
+// Firmware writes framed log records into a host DMA buffer and raises a PCIe
+// MSI. The layout and constants below are shared with the firmware backend
+// (tt-zephyr-platforms: lib/tenstorrent/bh_arc/tt_pcie_log.c) and must be kept
+// in sync with it.
+//
+// This header and its implementation, (fwlog_parser.c) is compiled into both
+// the kernel module and the host-side unit test (test/fwlog_test.cpp), so it
+// must stay free of kernel-only dependencies. The host build supplies the
+// kernel integer names via test/fwlog_compat.h.
+#include <linux/types.h>
+
+// Metadata at the start of the shared buffer (16 bytes).
+struct fw_log_buffer_header {
+	u32 write_offset;	// End offset of valid payload bytes
+	u32 buffer_size;	// Total buffer size in bytes
+	u32 magic;		// FW_LOG_BUFFER_MAGIC when initialized by FW
+	u8 owner;		// FW_LOG_BUFFER_OWNER_{FW,HOST}
+	u8 version;		// Protocol version supported by FW
+	u8 reserved[2];
+} __packed;
+
+// Header preceding each framed log record (12 bytes).
+struct fw_log_entry_header {
+	u16 msg_size;		// Total record size (this header + payload)
+	u8 log_level;		// Zephyr log level, see FW_LOG_LEVEL_*
+	u8 source;		// FW_LOG_SOURCE_{SMC,DMC}
+	u32 timestamp;		// FW timestamp
+	u32 sequence;		// Monotonic sequence number
+} __packed;
+
+// Zephyr log levels, as emitted by firmware.
+#define FW_LOG_LEVEL_NONE	0
+#define FW_LOG_LEVEL_ERROR	1
+#define FW_LOG_LEVEL_WARN	2
+#define FW_LOG_LEVEL_INFO	3
+#define FW_LOG_LEVEL_DEBUG	4
+
+#define FW_LOG_SOURCE_SMC	0
+#define FW_LOG_SOURCE_DMC	1
+
+#define FW_LOG_BUFFER_MAGIC		0x544C4F47	// "TLOG"
+#define FW_LOG_BUFFER_OWNER_FW		0x0		// FW may write; Host has consumed
+#define FW_LOG_BUFFER_OWNER_HOST	0x1		// FW has written; Host must consume
+
+// Protocol version this driver implements.  Sent to FW on setup.
+#define FW_LOG_PROTOCOL_VERSION		0
+
+// Size of the host DMA buffer allocated for firmware logs.
+#define FW_LOG_BUFFER_SIZE		4096
+
+// A single decoded log record handed to the emit callback.
+struct fw_log_record {
+	u8 log_level;		// FW_LOG_LEVEL_*
+	u8 source;		// FW_LOG_SOURCE_*
+	u32 sequence;		// Record sequence number
+	u32 timestamp;		// FW timestamp
+	const char *text;	// NULL terminated payload (may be empty)
+	bool seq_gap;		// True if sequence != expected on entry
+	u32 expected_seq;	// Expected sequence when a gap was detected
+};
+
+// Result of walking the framed records in a batch.
+struct fw_log_parse_result {
+	u32 records;		// Number of valid records emitted
+	bool framing_error;	// True if iteration stopped on a bad record
+	u32 error_offset;	// Offset of the bad record (when framing_error)
+	u32 error_msg_size;	// msg_size of the bad record (when framing_error)
+};
+
+// Firmware's sequence counter is free-running and independent of host setup, so
+// after setup KMD will just use firmware's current seq as it's baseline.
+// Once valid, a mismatch against `next` is a genuine dropped-record gap.
+struct fw_log_seq {
+	u32 next;	// Next expected sequence number (meaningful once valid)
+	bool valid;	// false until the first record establishes the baseline
+};
+
+u32 fw_log_sanitize(char *s);
+const char *fw_log_source_str(u8 source);
+bool fw_log_prepare_emit(const struct fw_log_record *rec, u32 log_level);
+
+// Walk the framed log records the firmware published into `buf`.
+//
+// `buffer_size`     total size of the shared buffer.
+// `write_offset`    end offset of valid bytes, as reported by firmware.
+// `seq`             optional in/out sequence state for gap detection; may be
+//                   NULL to skip it.  When seq->valid is 0 the first record
+//                   establishes the baseline (no gap); afterwards a mismatch
+//                   against seq->next is reported as a gap.
+// `emit`            called once per valid record.  `ctx` is passed through.
+//
+// The payload of each record is forced to be NUL-terminated (the last payload
+// byte is overwritten if needed), so this must be given a writable buffer.
+// Iteration is strictly bounded by `write_offset` (itself clamped to
+// `buffer_size`), so a malformed batch can never read past the buffer.
+//
+struct fw_log_parse_result
+fw_log_parse(void *buf, u32 buffer_size, u32 write_offset, struct fw_log_seq *seq,
+	     void (*emit)(void *ctx, const struct fw_log_record *rec), void *ctx);
+
+#endif // TTDRIVER_FWLOG_H_INCLUDED

--- a/fwlog_kmd.h
+++ b/fwlog_kmd.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef TTDRIVER_FWLOG_KMD_H_INCLUDED
+#define TTDRIVER_FWLOG_KMD_H_INCLUDED
+
+#include <linux/device.h>
+#include <linux/dma-mapping.h>
+#include <linux/types.h>
+#include <linux/workqueue.h>
+
+#include "fwlog.h"
+
+// KMD-owned state for a firmware-log DMA buffer. The wire format and parser
+// declarations live in fwlog.h; this header contains kernel-only lifecycle
+// state.
+struct fw_log_state {
+	struct device *dev;
+	void *hw_ctx;
+	void *buffer_virt;
+	dma_addr_t buffer_dma;
+	struct work_struct work;
+	struct fw_log_seq seq;
+	bool enabled;
+};
+
+// Hardware-control shims. fwlog.c owns generic DMA-buffer lifecycle and
+// parsing; the active device implementation supplies these ARC/NOC-specific
+// operations in blackhole.c.
+extern bool fw_log_hw_setup(void *hw_ctx, dma_addr_t buffer_dma, u32 buffer_size);
+extern bool fw_log_hw_release(void *hw_ctx);
+
+// Lifecycle, split into software vs. FW-interaction phases (mirroring the
+// device class's init_device/init_hardware). fw_log_init()/fw_log_free() own
+// the DMA buffer for the device's lifetime; fw_log_setup()/
+// fw_log_notify_release() do the per-hardware-init firmware handshake.
+void fw_log_init(struct fw_log_state *log, struct device *dev, void *hw_ctx);
+void fw_log_setup(struct fw_log_state *log);
+void fw_log_notify_release(struct fw_log_state *log);
+void fw_log_quiesce(struct fw_log_state *log);
+void fw_log_free(struct fw_log_state *log);
+void fw_log_interrupt(struct fw_log_state *log);
+
+#endif // TTDRIVER_FWLOG_KMD_H_INCLUDED

--- a/fwlog_parser.c
+++ b/fwlog_parser.c
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Pure firmware-log framing/parse/sanitize logic. This file is compiled into
+// both the kernel module and the host-side unit test (test/fwlog_test.cpp), so
+// it must stay free of kernel-only dependencies.
+
+#include "fwlog.h"
+
+u32 fw_log_sanitize(char *s)
+{
+	char *dst = s;
+	const char *src = s;
+
+	while (*src) {
+		unsigned char c = (unsigned char)*src;
+
+		if (c == 0x1b) {
+			src++;
+			if (*src == '[') {
+				src++;
+				while (*src && ((unsigned char)*src < 0x40 ||
+						(unsigned char)*src > 0x7e))
+					src++;
+				if (*src)
+					src++;
+			} else if (*src) {
+				src++;
+			}
+			continue;
+		}
+
+		if (c < 0x20 || c == 0x7f) {
+			src++;
+			continue;
+		}
+
+		*dst++ = (char)c;
+		src++;
+	}
+
+	*dst = '\0';
+	return dst - s;
+}
+
+const char *fw_log_source_str(u8 source)
+{
+	return source == FW_LOG_SOURCE_DMC ? "DMC" : "SMC";
+}
+
+bool fw_log_prepare_emit(const struct fw_log_record *rec, u32 log_level)
+{
+	// Skip empty payloads. This also guards fw_log_sanitize() below from
+	// writing to the read-only "" literal that fw_log_parse() assigns when
+	// a record carries no payload bytes.
+	if (rec->text[0] == '\0')
+		return false;
+
+	if (rec->log_level > log_level)
+		return false;
+
+	return fw_log_sanitize((char *)rec->text) != 0;
+}
+
+struct fw_log_parse_result
+fw_log_parse(void *buf, u32 buffer_size, u32 write_offset, struct fw_log_seq *seq,
+	     void (*emit)(void *ctx, const struct fw_log_record *rec), void *ctx)
+{
+	struct fw_log_parse_result result = { 0 };
+	u32 read_offset = sizeof(struct fw_log_buffer_header);
+
+	if (write_offset > buffer_size)
+		write_offset = buffer_size;
+
+	if (write_offset < read_offset)
+		return result;
+
+	while (write_offset - read_offset >= sizeof(struct fw_log_entry_header)) {
+		struct fw_log_entry_header *entry =
+			(struct fw_log_entry_header *)((char *)buf + read_offset);
+		u16 msg_size = entry->msg_size;
+		struct fw_log_record rec = { 0 };
+		char *payload;
+		u32 payload_len;
+
+		// Subtraction is safe because read_offset <= write_offset. Avoid
+		// addition here so even an untrusted size cannot wrap the bound.
+		if (msg_size < sizeof(struct fw_log_entry_header) ||
+		    msg_size > write_offset - read_offset) {
+			result.framing_error = true;
+			result.error_offset = read_offset;
+			result.error_msg_size = msg_size;
+			break;
+		}
+
+		if (seq) {
+			if (!seq->valid) {
+				// Firmware's sequence counter is free-running, so the
+				// first record establishes the host baseline.
+				seq->next = entry->sequence;
+				seq->valid = true;
+			}
+			if (entry->sequence != seq->next) {
+				rec.seq_gap = true;
+				rec.expected_seq = seq->next;
+				seq->next = entry->sequence;
+			}
+			seq->next++;
+		}
+
+		payload = (char *)entry + sizeof(struct fw_log_entry_header);
+		payload_len = msg_size - sizeof(struct fw_log_entry_header);
+		if (payload_len > 0)
+			payload[payload_len - 1] = '\0';
+
+		rec.log_level = entry->log_level;
+		rec.source = entry->source;
+		rec.sequence = entry->sequence;
+		rec.timestamp = entry->timestamp;
+		rec.text = payload_len > 0 ? payload : "";
+
+		if (emit)
+			emit(ctx, &rec);
+		result.records++;
+
+		read_offset += msg_size;
+	}
+
+	return result;
+}

--- a/interrupt.c
+++ b/interrupt.c
@@ -13,7 +13,9 @@
 static irqreturn_t irq_handler(int irq, void *device)
 {
 	struct tenstorrent_device *tt_dev = device;
-	(void)tt_dev;	// to be used later
+
+	if (tt_dev->dev_class->interrupt)
+		tt_dev->dev_class->interrupt(tt_dev);
 
 	return IRQ_HANDLED;
 }

--- a/module.c
+++ b/module.c
@@ -13,6 +13,7 @@
 
 #include "chardev.h"
 #include "enumerate.h"
+#include "fwlog.h"
 
 #include "module.h"
 
@@ -52,6 +53,16 @@ MODULE_PARM_DESC(auto_reset_timeout, "Timeout duration in seconds for M3 auto re
 bool power_policy = true;
 module_param(power_policy, bool, 0444);
 MODULE_PARM_DESC(power_policy, "Enable power policy: low power at probe, re-aggregate on close (default=on).");
+
+bool fw_logging = true;
+module_param(fw_logging, bool, 0444);
+MODULE_PARM_DESC(fw_logging, "Forward Blackhole firmware log messages to the kernel log (default=on).");
+
+uint fw_log_level = FW_LOG_LEVEL_WARN;
+module_param(fw_log_level, uint, 0644);
+MODULE_PARM_DESC(fw_log_level,
+		 "Maximum firmware log level forwarded to the kernel log: "
+		 "1=error, 2=warning, 3=info, 4=debug (default=2).");
 
 uint idle_power_down_grace_ms = 5000;
 module_param(idle_power_down_grace_ms, uint, 0644);

--- a/module.h
+++ b/module.h
@@ -27,6 +27,8 @@ extern uint reset_limit;
 extern unsigned char auto_reset_timeout;
 extern bool power_policy;
 extern uint idle_power_down_grace_ms;
+extern bool fw_logging;
+extern uint fw_log_level;
 
 extern struct tenstorrent_device_class wormhole_class;
 extern struct tenstorrent_device_class blackhole_class;

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,2 +1,3 @@
 /build
 /ttkmd_test
+/fwlog_test

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,6 +5,9 @@ all::
 
 PROG := ttkmd_test
 
+# Host-only unit test binary (no hardware/kernel module required).
+UNIT_PROG := fwlog_test
+
 TEST_SOURCES := get_driver_info.cpp get_device_info.cpp query_mappings.cpp \
 	dma_buf.cpp pin_pages.cpp config_space.cpp lock.cpp hwmon.cpp map_peer_bar.cpp \
 	ioctl_overrun.cpp ioctl_zeroing.cpp tlbs.cpp dmabuf_export.cpp release.cpp \
@@ -15,23 +18,41 @@ SOURCES := $(CORE_SOURCES) $(TEST_SOURCES)
 
 BUILDDIR := build
 OBJS := $(patsubst %.cpp,$(BUILDDIR)/%.o,$(SOURCES))
+UNIT_OBJS := $(BUILDDIR)/fwlog_test.o $(BUILDDIR)/fwlog_parser.o
 
 OPT_FLAGS := -O2
 CXXFLAGS := -std=c++17 -Wall -Wno-narrowing $(OPT_FLAGS)
 
+# fwlog_test.cpp includes the driver's fwlog.h directly from the parent directory.
+$(BUILDDIR)/fwlog_test.o: CXXFLAGS += -I..
+$(BUILDDIR)/fwlog_test.o: fwlog_compat.h ../fwlog.h
+
+# Compile the same parser implementation linked into the kernel module.  The
+# compatibility header supplies kernel-style integer names to the host compiler.
+$(BUILDDIR)/fwlog_parser.o: ../fwlog_parser.c fwlog_compat.h ../fwlog.h | $(BUILDDIR)
+	$(CXX) $(CXXFLAGS) -I.. -include fwlog_compat.h -x c++ -c $< -o $@
+
 .PHONY: all
-all:: $(PROG)
+all:: $(PROG) $(UNIT_PROG)
 
 $(PROG): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(LIBS) $^ -o $@
 
-$(OBJS): $(BUILDDIR)/%.o: %.cpp | $(BUILDDIR)
-	$(CXX) $(CXXFLAGS) -c $^ -o $@
+$(UNIT_PROG): $(UNIT_OBJS)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $^ -o $@
+
+$(BUILDDIR)/%.o: %.cpp | $(BUILDDIR)
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(BUILDDIR):
 	mkdir $(BUILDDIR)
 
+# Build and run the host-only unit tests.
+.PHONY: check
+check: $(UNIT_PROG)
+	./$(UNIT_PROG)
+
 .PHONY: clean
 clean::
 	-rm -rf $(BUILDDIR)
-	-rm -f $(PROG)
+	-rm -f $(PROG) $(UNIT_PROG)

--- a/test/fwlog_compat.h
+++ b/test/fwlog_compat.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef TTDRIVER_TEST_FWLOG_COMPAT_H_INCLUDED
+#define TTDRIVER_TEST_FWLOG_COMPAT_H_INCLUDED
+
+#include <linux/types.h>
+
+typedef __u8 u8;
+typedef __u16 u16;
+typedef __u32 u32;
+
+// The kernel build gets __packed from <linux/compiler_attributes.h>; the host
+// build needs its own definition.
+#ifndef __packed
+#define __packed __attribute__((packed))
+#endif
+
+#endif // TTDRIVER_TEST_FWLOG_COMPAT_H_INCLUDED

--- a/test/fwlog_test.cpp
+++ b/test/fwlog_test.cpp
@@ -1,0 +1,568 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+//
+// Host-side unit test for the firmware-log framing/parser (fwlog.h).
+//
+// This exercises the exact fw_log_parse() the driver uses, feeding it batches
+// laid out the way firmware produces them, and checking the decoded records
+// and framing-error handling.  It needs no hardware or kernel module, so it
+// runs in the plain build-tests CI job.
+//
+// Build & run:  make -C test fwlog_test && ./test/fwlog_test
+
+#include <cstdint>
+#include <cstddef>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "fwlog_compat.h"
+#include "fwlog.h"
+
+// ---- tiny non-aborting check framework (so every case runs) ----
+static int g_checks = 0;
+static int g_failures = 0;
+
+#define CHECK(cond)                                                             \
+	do {                                                                    \
+		++g_checks;                                                     \
+		if (!(cond)) {                                                  \
+			++g_failures;                                           \
+			std::cerr << "FAIL " << __func__ << ":" << __LINE__     \
+				  << ": " #cond "\n";                           \
+		}                                                               \
+	} while (0)
+
+// ---- capture emitted records ----
+struct Captured {
+	uint8_t level;
+	uint8_t source;
+	uint32_t sequence;
+	uint32_t timestamp;
+	std::string text;
+	bool seq_gap;
+	uint32_t expected_seq;
+};
+
+static void collect(void *ctx, const struct fw_log_record *r)
+{
+	auto *out = static_cast<std::vector<Captured> *>(ctx);
+	out->push_back({ r->log_level, r->source, r->sequence, r->timestamp,
+			 std::string(r->text), r->seq_gap, r->expected_seq });
+}
+
+// ---- helper that lays out a batch the way firmware does ----
+struct Batch {
+	std::vector<uint8_t> buf;
+
+	explicit Batch(uint32_t buffer_size = FW_LOG_BUFFER_SIZE)
+	{
+		buf.assign(buffer_size, 0);
+		hdr()->write_offset = sizeof(struct fw_log_buffer_header);
+		hdr()->buffer_size = buffer_size;
+		hdr()->magic = FW_LOG_BUFFER_MAGIC;
+		hdr()->owner = FW_LOG_BUFFER_OWNER_HOST;
+		hdr()->version = FW_LOG_PROTOCOL_VERSION;
+	}
+
+	struct fw_log_buffer_header *hdr()
+	{
+		return reinterpret_cast<struct fw_log_buffer_header *>(buf.data());
+	}
+
+	// Append a record with a NUL-terminated payload (firmware's normal case).
+	void add(uint8_t level, uint8_t source, uint32_t seq, const std::string &text)
+	{
+		uint32_t payload = static_cast<uint32_t>(text.size()) + 1; // include NUL
+		uint32_t off = write_entry(level, source, seq, payload);
+		std::memcpy(buf.data() + off, text.c_str(), payload);
+	}
+
+	// Append a record whose payload is NOT NUL-terminated (malformed FW).
+	void add_unterminated(uint8_t level, uint8_t source, uint32_t seq, uint32_t payload)
+	{
+		uint32_t off = write_entry(level, source, seq, payload);
+		std::memset(buf.data() + off, 'A', payload); // no NUL anywhere
+	}
+
+	// Append an entry header with an explicit (possibly bogus) msg_size and
+	// no payload bytes reserved beyond it.  Used to craft framing errors.
+	void add_raw_header(uint16_t msg_size, uint32_t seq)
+	{
+		uint32_t off = hdr()->write_offset;
+		auto *e = reinterpret_cast<struct fw_log_entry_header *>(buf.data() + off);
+		e->msg_size = msg_size;
+		e->sequence = seq;
+		hdr()->write_offset = off + sizeof(struct fw_log_entry_header);
+	}
+
+	void set_write_offset(uint32_t v) { hdr()->write_offset = v; }
+
+    private:
+	uint32_t write_entry(uint8_t level, uint8_t source, uint32_t seq, uint32_t payload)
+	{
+		uint32_t off = hdr()->write_offset;
+		auto *e = reinterpret_cast<struct fw_log_entry_header *>(buf.data() + off);
+		e->msg_size = static_cast<uint16_t>(sizeof(struct fw_log_entry_header) + payload);
+		e->log_level = level;
+		e->source = source;
+		e->timestamp = 1000 + seq;
+		e->sequence = seq;
+		hdr()->write_offset = off + e->msg_size;
+		return off + sizeof(struct fw_log_entry_header);
+	}
+};
+
+// Compatibility runner for the mid-session tests: the baseline is treated as
+// already established at *expected (seq.valid = 1), so gap detection is active
+// from the first record.  Writes the running counter back to *expected.
+static struct fw_log_parse_result run(Batch &b, uint32_t *expected, std::vector<Captured> &out)
+{
+	struct fw_log_seq seq = { *expected, true };
+	auto r = fw_log_parse(b.buf.data(), b.hdr()->buffer_size, b.hdr()->write_offset,
+			      &seq, collect, &out);
+	*expected = seq.next;
+	return r;
+}
+
+// --------------------------- test cases ---------------------------
+
+static void test_layout_contract()
+{
+	// Sizes must match the firmware's packed headers.
+	static_assert(sizeof(struct fw_log_buffer_header) == 16, "buffer header size");
+	static_assert(sizeof(struct fw_log_entry_header) == 12, "entry header size");
+
+	CHECK(offsetof(struct fw_log_buffer_header, write_offset) == 0);
+	CHECK(offsetof(struct fw_log_buffer_header, buffer_size) == 4);
+	CHECK(offsetof(struct fw_log_buffer_header, magic) == 8);
+	CHECK(offsetof(struct fw_log_buffer_header, owner) == 12);
+	CHECK(offsetof(struct fw_log_buffer_header, version) == 13);
+
+	CHECK(offsetof(struct fw_log_entry_header, msg_size) == 0);
+	CHECK(offsetof(struct fw_log_entry_header, log_level) == 2);
+	CHECK(offsetof(struct fw_log_entry_header, source) == 3);
+	CHECK(offsetof(struct fw_log_entry_header, timestamp) == 4);
+	CHECK(offsetof(struct fw_log_entry_header, sequence) == 8);
+
+	CHECK(FW_LOG_BUFFER_MAGIC == 0x544C4F47);
+	CHECK(FW_LOG_BUFFER_OWNER_FW == 0);
+	CHECK(FW_LOG_BUFFER_OWNER_HOST == 1);
+	CHECK(FW_LOG_LEVEL_ERROR == 1 && FW_LOG_LEVEL_WARN == 2 &&
+	      FW_LOG_LEVEL_INFO == 3 && FW_LOG_LEVEL_DEBUG == 4);
+	CHECK(FW_LOG_SOURCE_SMC == 0 && FW_LOG_SOURCE_DMC == 1);
+}
+
+static void test_single_record()
+{
+	Batch b;
+	b.add(FW_LOG_LEVEL_INFO, FW_LOG_SOURCE_SMC, 0, "boot complete");
+
+	uint32_t expected = 0;
+	std::vector<Captured> out;
+	auto r = run(b, &expected, out);
+
+	CHECK(!r.framing_error);
+	CHECK(r.records == 1);
+	CHECK(out.size() == 1);
+	CHECK(out[0].level == FW_LOG_LEVEL_INFO);
+	CHECK(out[0].source == FW_LOG_SOURCE_SMC);
+	CHECK(out[0].sequence == 0);
+	CHECK(out[0].text == "boot complete");
+	CHECK(!out[0].seq_gap);
+	CHECK(expected == 1);
+}
+
+static void test_multiple_records()
+{
+	Batch b;
+	b.add(FW_LOG_LEVEL_INFO, FW_LOG_SOURCE_SMC, 0, "one");
+	b.add(FW_LOG_LEVEL_WARN, FW_LOG_SOURCE_SMC, 1, "two");
+	b.add(FW_LOG_LEVEL_ERROR, FW_LOG_SOURCE_DMC, 2, "three");
+
+	uint32_t expected = 0;
+	std::vector<Captured> out;
+	auto r = run(b, &expected, out);
+
+	CHECK(!r.framing_error);
+	CHECK(r.records == 3 && out.size() == 3);
+	CHECK(out[0].text == "one" && out[1].text == "two" && out[2].text == "three");
+	CHECK(out[2].source == FW_LOG_SOURCE_DMC);
+	CHECK(!out[0].seq_gap && !out[1].seq_gap && !out[2].seq_gap);
+	CHECK(expected == 3);
+}
+
+static void test_empty_batch()
+{
+	Batch b; // write_offset left at header size -> no records
+	uint32_t expected = 0;
+	std::vector<Captured> out;
+	auto r = run(b, &expected, out);
+
+	CHECK(!r.framing_error);
+	CHECK(r.records == 0 && out.empty());
+	CHECK(expected == 0);
+}
+
+static void test_empty_payload()
+{
+	Batch b;
+	b.add(FW_LOG_LEVEL_INFO, FW_LOG_SOURCE_SMC, 0, ""); // payload = just the NUL
+
+	uint32_t expected = 0;
+	std::vector<Captured> out;
+	auto r = run(b, &expected, out);
+
+	CHECK(!r.framing_error && r.records == 1);
+	CHECK(out[0].text.empty());
+}
+
+static void test_sequence_gap()
+{
+	Batch b;
+	b.add(FW_LOG_LEVEL_INFO, FW_LOG_SOURCE_SMC, 5, "late"); // expected 0, got 5
+	b.add(FW_LOG_LEVEL_INFO, FW_LOG_SOURCE_SMC, 6, "next");
+
+	uint32_t expected = 0;
+	std::vector<Captured> out;
+	auto r = run(b, &expected, out);
+
+	CHECK(r.records == 2);
+	CHECK(out[0].seq_gap);
+	CHECK(out[0].expected_seq == 0);
+	CHECK(!out[1].seq_gap); // resynced
+	CHECK(expected == 7);
+}
+
+// Option B: after a (re)attach the host has no baseline (seq.valid is false), so
+// the first record firmware sends is adopted as the baseline instead of
+// producing a spurious gap against the host's fresh counter.
+static void test_seq_baseline_on_attach()
+{
+	Batch b;
+	b.add(FW_LOG_LEVEL_INFO, FW_LOG_SOURCE_SMC, 34, "first after reattach");
+	b.add(FW_LOG_LEVEL_INFO, FW_LOG_SOURCE_SMC, 35, "next");
+
+	struct fw_log_seq seq = { 0, false }; // baseline not yet established
+	std::vector<Captured> out;
+	auto r = fw_log_parse(b.buf.data(), b.hdr()->buffer_size, b.hdr()->write_offset,
+			      &seq, collect, &out);
+
+	CHECK(r.records == 2);
+	CHECK(!out[0].seq_gap); // adopted 34, no spurious warning
+	CHECK(!out[1].seq_gap);
+	CHECK(seq.valid);
+	CHECK(seq.next == 36);
+}
+
+// A genuine drop is still detected once the baseline has been adopted.
+static void test_seq_gap_after_baseline()
+{
+	Batch b;
+	b.add(FW_LOG_LEVEL_INFO, FW_LOG_SOURCE_SMC, 34, "baseline");
+	b.add(FW_LOG_LEVEL_INFO, FW_LOG_SOURCE_SMC, 40, "after drop"); // lost 35-39
+
+	struct fw_log_seq seq = { 0, false };
+	std::vector<Captured> out;
+	auto r = fw_log_parse(b.buf.data(), b.hdr()->buffer_size, b.hdr()->write_offset,
+			      &seq, collect, &out);
+
+	CHECK(r.records == 2);
+	CHECK(!out[0].seq_gap);              // baseline adopted
+	CHECK(out[1].seq_gap);               // real gap reported
+	CHECK(out[1].expected_seq == 35);
+	CHECK(seq.next == 41);               // resynced past the gap
+}
+
+// The baseline persists across batches: a first batch establishes it, and a
+// contiguous second batch (parsed with the same seq state) shows no gap.
+static void test_seq_baseline_persists_across_batches()
+{
+	struct fw_log_seq seq = { 0, false };
+
+	Batch b1;
+	b1.add(FW_LOG_LEVEL_INFO, FW_LOG_SOURCE_SMC, 100, "b1");
+	std::vector<Captured> out1;
+	fw_log_parse(b1.buf.data(), b1.hdr()->buffer_size, b1.hdr()->write_offset,
+		     &seq, collect, &out1);
+	CHECK(!out1[0].seq_gap);
+	CHECK(seq.next == 101);
+
+	Batch b2;
+	b2.add(FW_LOG_LEVEL_INFO, FW_LOG_SOURCE_SMC, 101, "b2");
+	std::vector<Captured> out2;
+	fw_log_parse(b2.buf.data(), b2.hdr()->buffer_size, b2.hdr()->write_offset,
+		     &seq, collect, &out2);
+	CHECK(!out2[0].seq_gap); // contiguous, no spurious gap
+	CHECK(seq.next == 102);
+}
+
+static void test_zero_msg_size()
+{
+	Batch b;
+	b.add(FW_LOG_LEVEL_INFO, FW_LOG_SOURCE_SMC, 0, "ok");
+	uint32_t bad_off = b.hdr()->write_offset;
+	b.add_raw_header(0, 1); // msg_size 0 -> framing error
+
+	uint32_t expected = 0;
+	std::vector<Captured> out;
+	auto r = run(b, &expected, out);
+
+	CHECK(r.records == 1 && out.size() == 1); // the good one before the bad one
+	CHECK(r.framing_error);
+	CHECK(r.error_offset == bad_off);
+	CHECK(r.error_msg_size == 0);
+}
+
+static void test_msg_size_too_small()
+{
+	Batch b;
+	uint32_t bad_off = b.hdr()->write_offset;
+	b.add_raw_header(5, 0); // < sizeof(entry header)
+
+	uint32_t expected = 0;
+	std::vector<Captured> out;
+	auto r = run(b, &expected, out);
+
+	CHECK(r.records == 0);
+	CHECK(r.framing_error && r.error_offset == bad_off && r.error_msg_size == 5);
+}
+
+static void test_msg_size_overruns()
+{
+	Batch b;
+	b.add(FW_LOG_LEVEL_INFO, FW_LOG_SOURCE_SMC, 0, "good");
+	// Craft the largest possible wire size with no corresponding payload.
+	uint32_t bad_off = b.hdr()->write_offset;
+	b.add_raw_header(0xffff, 1);
+	// write_offset only advanced by the header, so msg_size overruns it.
+
+	uint32_t expected = 0;
+	std::vector<Captured> out;
+	auto r = run(b, &expected, out);
+
+	CHECK(r.records == 1);            // the valid record was emitted
+	CHECK(r.framing_error && r.error_offset == bad_off);
+	CHECK(r.error_msg_size == 0xffff);
+}
+
+static void test_truncated_trailing_header()
+{
+	Batch b;
+	b.add(FW_LOG_LEVEL_INFO, FW_LOG_SOURCE_SMC, 0, "only");
+	// Pretend firmware left a few dangling bytes (< entry header) at the end.
+	b.set_write_offset(b.hdr()->write_offset + 4);
+
+	uint32_t expected = 0;
+	std::vector<Captured> out;
+	auto r = run(b, &expected, out);
+
+	// Loop condition stops before reading a partial header -> no error, no crash.
+	CHECK(r.records == 1);
+	CHECK(!r.framing_error);
+}
+
+static void test_forces_nul_termination()
+{
+	Batch b;
+	b.add_unterminated(FW_LOG_LEVEL_INFO, FW_LOG_SOURCE_SMC, 0, 8); // 8 'A's, no NUL
+
+	uint32_t expected = 0;
+	std::vector<Captured> out;
+	auto r = run(b, &expected, out);
+
+	CHECK(r.records == 1);
+	CHECK(out[0].text.size() == 7);      // last byte forced to NUL
+	CHECK(out[0].text == "AAAAAAA");
+}
+
+static void test_write_offset_clamped()
+{
+	Batch b;
+	b.add(FW_LOG_LEVEL_INFO, FW_LOG_SOURCE_SMC, 0, "hi");
+	// Firmware reports a wildly-too-large write_offset; parser must clamp to
+	// buffer_size and never read past the allocation (ASAN would catch it).
+	b.set_write_offset(0xFFFFFFF0u);
+
+	uint32_t expected = 0;
+	std::vector<Captured> out;
+	run(b, &expected, out);
+
+	// It should stop cleanly at the first malformed/zeroed record within the
+	// buffer rather than running off the end.
+	CHECK(out.size() >= 1);
+	CHECK(out[0].text == "hi");
+}
+
+// --------------------- sanitizer unit tests ----------------------
+
+static std::string sanitized(const std::string &in)
+{
+	std::vector<char> buf(in.begin(), in.end());
+	buf.push_back('\0');
+	uint32_t len = fw_log_sanitize(buf.data());
+	std::string out(buf.data());
+	CHECK(out.size() == len); // returned length matches resulting C-string
+	return out;
+}
+
+static void test_sanitize_plain_text_unchanged()
+{
+	CHECK(sanitized("boot complete") == "boot complete");
+	CHECK(sanitized("") == "");
+	CHECK(sanitized("with spaces and 123!") == "with spaces and 123!");
+}
+
+static void test_sanitize_strips_ansi()
+{
+	CHECK(sanitized("\x1b[0m<inf> hello\x1b[0m") == "<inf> hello"); // colour wrap
+	CHECK(sanitized("\x1b[1;31mred\x1b[0m") == "red");              // multi-param SGR
+	CHECK(sanitized("\x1b[0m") == "");                             // bare reset -> empty
+}
+
+static void test_sanitize_strips_control_chars()
+{
+	CHECK(sanitized("line one\nline two") == "line oneline two"); // embedded LF
+	CHECK(sanitized("a\r\nb") == "ab");                            // CRLF
+	CHECK(sanitized("tab\there") == "tabhere");                    // TAB
+	CHECK(sanitized("del\x7f end") == "del end");                  // DEL
+}
+
+static void test_sanitize_two_char_escape()
+{
+	CHECK(sanitized("a\x1b" "cb") == "ab"); // ESC + one char dropped
+	CHECK(sanitized("done\x1b") == "done"); // trailing lone ESC, no overread
+}
+
+static void test_sanitize_truncated_ansi()
+{
+	CHECK(sanitized("keep\x1b[0") == "keep"); // CSI with no final byte
+}
+
+// ------------- full-pipeline (parse + policy) tests --------------
+//
+// These exercise the exact path the driver uses end to end: fw_log_parse()
+// framing -> fw_log_prepare_emit() verbosity gate + sanitize -> the rendered
+// "SOURCE: text" line the driver hands to printk. This is the closest thing
+// to an integration test that runs without hardware.
+
+struct Rendered {
+	std::string line; // "SMC: text", as printk would receive it
+	uint8_t level;    // severity it would be printed at
+};
+
+struct PipelineCtx {
+	uint32_t max_level;
+	std::vector<Rendered> *out;
+};
+
+static void pipeline_emit(void *ctx, const struct fw_log_record *r)
+{
+	auto *pc = static_cast<PipelineCtx *>(ctx);
+	if (!fw_log_prepare_emit(r, pc->max_level))
+		return;
+	pc->out->push_back({ std::string(fw_log_source_str(r->source)) + ": " + r->text,
+			     r->log_level });
+}
+
+static std::vector<Rendered> run_pipeline(Batch &b, uint32_t max_level)
+{
+	std::vector<Rendered> out;
+	PipelineCtx pc{ max_level, &out };
+	struct fw_log_seq seq = { 0, false };
+	fw_log_parse(b.buf.data(), b.hdr()->buffer_size, b.hdr()->write_offset,
+		     &seq, pipeline_emit, &pc);
+	return out;
+}
+
+// A realistic mixed batch: ANSI colours, CRLF, embedded newlines, a record
+// that sanitizes to nothing, and mixed levels/sources.
+static void fill_golden(Batch &b)
+{
+	b.add(FW_LOG_LEVEL_ERROR, FW_LOG_SOURCE_SMC, 0, "\x1b[0m<err> boot fail\x1b[0m");
+	b.add(FW_LOG_LEVEL_WARN,  FW_LOG_SOURCE_DMC, 1, "temp high\r\n");
+	b.add(FW_LOG_LEVEL_INFO,  FW_LOG_SOURCE_SMC, 2, "\x1b[32minfo line\x1b[0m");
+	b.add(FW_LOG_LEVEL_DEBUG, FW_LOG_SOURCE_SMC, 3, "verbose");
+	b.add(FW_LOG_LEVEL_INFO,  FW_LOG_SOURCE_SMC, 4, "\x1b[0m"); // -> empty, dropped
+	b.add(FW_LOG_LEVEL_ERROR, FW_LOG_SOURCE_SMC, 5, "multi\nline\nmsg");
+}
+
+static void test_pipeline_default_warn()
+{
+	Batch b;
+	fill_golden(b);
+	auto out = run_pipeline(b, FW_LOG_LEVEL_WARN);
+
+	CHECK(out.size() == 3); // err + warn + err; info/debug/empty dropped
+	CHECK(out[0].line == "SMC: <err> boot fail" && out[0].level == FW_LOG_LEVEL_ERROR);
+	CHECK(out[1].line == "DMC: temp high"       && out[1].level == FW_LOG_LEVEL_WARN);
+	CHECK(out[2].line == "SMC: multilinemsg"    && out[2].level == FW_LOG_LEVEL_ERROR);
+}
+
+static void test_pipeline_info_level()
+{
+	Batch b;
+	fill_golden(b);
+	auto out = run_pipeline(b, FW_LOG_LEVEL_INFO);
+
+	CHECK(out.size() == 4); // err, warn, info, err; debug + empty dropped
+	CHECK(out[0].line == "SMC: <err> boot fail");
+	CHECK(out[1].line == "DMC: temp high");
+	CHECK(out[2].line == "SMC: info line" && out[2].level == FW_LOG_LEVEL_INFO);
+	CHECK(out[3].line == "SMC: multilinemsg");
+}
+
+static void test_pipeline_debug_level()
+{
+	Batch b;
+	fill_golden(b);
+	auto out = run_pipeline(b, FW_LOG_LEVEL_DEBUG);
+
+	CHECK(out.size() == 5); // everything except the sanitized-empty record
+	CHECK(out[3].line == "SMC: verbose" && out[3].level == FW_LOG_LEVEL_DEBUG);
+}
+
+static void test_pipeline_level_none_always_kept()
+{
+	// A record tagged NONE (0) does not fit the severity scale and must be
+	// printed even at the strictest threshold.
+	Batch b;
+	b.add(FW_LOG_LEVEL_NONE, FW_LOG_SOURCE_SMC, 0, "raw printk line");
+	auto out = run_pipeline(b, FW_LOG_LEVEL_ERROR);
+
+	CHECK(out.size() == 1);
+	CHECK(out[0].line == "SMC: raw printk line");
+}
+
+int main()
+{
+	test_layout_contract();
+	test_single_record();
+	test_multiple_records();
+	test_empty_batch();
+	test_empty_payload();
+	test_sequence_gap();
+	test_seq_baseline_on_attach();
+	test_seq_gap_after_baseline();
+	test_seq_baseline_persists_across_batches();
+	test_zero_msg_size();
+	test_msg_size_too_small();
+	test_msg_size_overruns();
+	test_truncated_trailing_header();
+	test_forces_nul_termination();
+	test_write_offset_clamped();
+	test_sanitize_plain_text_unchanged();
+	test_sanitize_strips_ansi();
+	test_sanitize_strips_control_chars();
+	test_sanitize_two_char_escape();
+	test_sanitize_truncated_ansi();
+	test_pipeline_default_warn();
+	test_pipeline_info_level();
+	test_pipeline_debug_level();
+	test_pipeline_level_none_always_kept();
+
+	std::cout << (g_failures ? "FAILED" : "PASSED") << ": " << (g_checks - g_failures)
+		  << "/" << g_checks << " checks passed\n";
+	return g_failures ? 1 : 0;
+}


### PR DESCRIPTION
Blackhole firmware can stream its Zephyr logs to the host through a shared DMA buffer
    - Allocate a DMA buffer and hand its size to firmware via a new ARC message
    - On MSI, drain the buffer from a workqueue, parse framed records, send them to the kernel log with level mapping, and hand the buffer back
    - Gracefully no-op on firmware that doesn't support the feature

Built off [jgrowdenTT/tt-kmd/tree/kmd_log](https://github.com/jgrowdenTT/tt-kmd/tree/kmd_log)

Resolves #257 

---

## TODO:

Still have to write more tests for this

---

**Manual Tests,**

1. Using this KMD feature with older firmware; expect a gracefully exit,
```
[3135809.213991] tenstorrent 0000:01:00.0: FW log: setup message not acknowledged, unsupported FW
```

2. Using this KMD feature with compatible firmware,
```
(.venv) aapostolu@aus-syseng-01:~/tt-kmd$ sudo rmmod tenstorrent
sudo insmod ~/tt-kmd/tenstorrent.ko
sudo dmesg -w | grep -iE 'FW log|SMC:|DMC:'
[3137249.646132] tenstorrent 0000:01:00.0: FW log forwarding enabled
[3137250.646463] tenstorrent 0000:01:00.0: SMC: [00:00:00.001,000] \x1b[0m<inf> bh_fwtable: Applying CCFGOVR bank 'ccfgovra' seq=142 (12 override bytes)\x1b[0m
[3137250.646468] tenstorrent 0000:01:00.0: SMC: [00:00:00.001,000] \x1b[0m<inf> bh_fwtable: CCFGOVR override: chip_limits.kernel_throttler_stop_nops_freq = 800\x1b[0m
[3137250.646469] tenstorrent 0000:01:00.0: SMC: [00:00:00.001,000] \x1b[0m<inf> bh_fwtable: CCFGOVR override: feature_enable.kernel_throttler_at_floor_en = 1\x1b[0m
[3137250.646470] tenstorrent 0000:01:00.0: SMC: [00:00:00.001,000] \x1b[0m<inf> InitHW: Cable Power Limit: 600\x1b[0m
[3137250.646472] tenstorrent 0000:01:00.0: SMC: [00:00:00.003,000] \x1b[0m<inf> bh_arc: BAR0 (512 -> size 512 MiB)\x1b[0m
[3137250.646473] tenstorrent 0000:01:00.0: SMC: [00:00:00.003,000] \x1b[0m<inf> bh_arc: BAR2 (1 -> size 1 MiB)\x1b[0m
[3137250.646474] tenstorrent 0000:01:00.0: SMC: [00:00:00.003,000] \x1b[0m<inf> bh_arc: BAR4 (32768 -> size 32768 MiB)\x1b[0m
[3137250.646475] tenstorrent 0000:01:00.0: SMC: [00:00:00.006,000] \x1b[0m<inf> tensix_init: wipe_dest: found destwipe at 0x22c000, size 808\x1b[0m
[3137250.646476] tenstorrent 0000:01:00.0: SMC: [00:00:00.006,000] \x1b[0m<inf> tensix_init: wipe_dest: firmware loaded\x1b[0m
[3137250.646477] tenstorrent 0000:01:00.0: SMC: [00:00:00.006,000] \x1b[0m<inf> tensix_init: wipe_dest: completed\x1b[0m
[3137250.646478] tenstorrent 0000:01:00.0: SMC: [00:00:00.208,000] \x1b[0m<inf> throttler: Throttler 0 limit set to 150\x1b[0m
[3137250.646479] tenstorrent 0000:01:00.0: SMC: [00:00:00.208,000] \x1b[0m<inf> throttler: Throttler 1 limit set to 220\x1b[0m
[3137250.646480] tenstorrent 0000:01:00.0: SMC: [00:00:00.208,000] \x1b[0m<inf> throttler: Throttler 2 limit set to 200\x1b[0m
[3137250.646481] tenstorrent 0000:01:00.0: SMC: [00:00:00.208,000] \x1b[0m<inf> throttler: Throttler 3 limit set to 90\x1b[0m
[3137250.646482] tenstorrent 0000:01:00.0: SMC: [00:00:00.208,000] \x1b[0m<inf> throttler: Throttler 4 limit set to 150\x1b[0m
[3137250.646483] tenstorrent 0000:01:00.0: SMC: [00:00:00.208,000] \x1b[0m<inf> throttler: Throttler 5 limit set to 89\x1b[0m
[3137250.646484] tenstorrent 0000:01:00.0: SMC: [00:00:00.208,000] \x1b[0m<inf> throttler: Throttler 6 limit set to 150\x1b[0m
[3137250.646485] tenstorrent 0000:01:00.0: SMC: [00:00:00.224,000] \x1b[0m<inf> throttler: Cable Power Limit: 600\x1b[0m
[3137250.646486] tenstorrent 0000:01:00.0: SMC: [00:00:00.224,000] \x1b[0m<inf> throttler: Throttler 4 limit set to 300\x1b[0m
[3137250.646487] tenstorrent 0000:01:00.0: SMC: [00:00:00.224,000] \x1b[0m<inf> throttler: Throttler 6 limit set to 300\x1b[0m
[3137250.646488] tenstorrent 0000:01:00.0: SMC: [00:00:12.736,000] \x1b[0m<inf> asic_state: ASIC entering A0 state (active)\x1b[0m
[3137250.646489] tenstorrent 0000:01:00.0: SMC: [00:00:23.388,000] \x1b[0m<inf> asic_state: ASIC entering A0 state (active)\x1b[0m
[3137250.646490] tenstorrent 0000:01:00.0: SMC: [00:00:23.388,000] \x1b[0m<inf> fw_tt_pcie_log_backend: Host tt_pcie_log enabled: buffer=0x3ffffffff3c0000, size=4096 bytes\x1b[0m

```