### PR TITLE
Add tlb_mutex to break mmap_lock deadlock cycle

### DIFF
--- a/chardev.c
+++ b/chardev.c
@@ -214,10 +214,12 @@ static void tenstorrent_reset_reclaim_tlbs(struct tenstorrent_device *tt_dev)
 		if (priv->open_reset_gen == gen)
 			continue;
 
+		mutex_lock(&priv->tlb_mutex);
 		for_each_set_bit(bitpos, priv->tlbs, TENSTORRENT_MAX_INBOUND_TLBS) {
 			tenstorrent_device_free_tlb(tt_dev, bitpos);
 			clear_bit(bitpos, priv->tlbs);
 		}
+		mutex_unlock(&priv->tlb_mutex);
 	}
 	mutex_unlock(&tt_dev->chardev_mutex);
 }
@@ -839,6 +841,7 @@ static int tt_cdev_open(struct inode *inode, struct file *file)
 	INIT_LIST_HEAD(&private_data->peer_mappings);
 	INIT_LIST_HEAD(&private_data->vma_list);
 	mutex_init(&private_data->vma_lock);
+	mutex_init(&private_data->tlb_mutex);
 
 	kref_get(&tt_dev->kref);
 	private_data->device = tt_dev;
@@ -920,8 +923,13 @@ static void tt_cdev_release_resource_locks(struct chardev_private *priv)
 static void tt_cdev_release_tlbs(struct chardev_private *priv)
 {
 	unsigned int bitpos;
-	for_each_set_bit(bitpos, priv->tlbs, TENSTORRENT_MAX_INBOUND_TLBS)
+
+	mutex_lock(&priv->tlb_mutex);
+	for_each_set_bit(bitpos, priv->tlbs, TENSTORRENT_MAX_INBOUND_TLBS) {
 		tenstorrent_device_free_tlb(priv->device, bitpos);
+		clear_bit(bitpos, priv->tlbs);
+	}
+	mutex_unlock(&priv->tlb_mutex);
 }
 
 static void tt_cdev_release_power(struct chardev_private *priv)

--- a/chardev_private.h
+++ b/chardev_private.h
@@ -71,6 +71,13 @@ struct chardev_private {
 
 	DECLARE_BITMAP(tlbs, TENSTORRENT_MAX_INBOUND_TLBS);	// TLBs owned by this fd
 
+	// Protects tlbs and serializes TLB ownership check-then-act sequences
+	// (e.g. mmap of a window vs FREE_TLB). The mmap path takes it with
+	// mmap_lock held, so never access userspace memory or pin user pages
+	// while holding it. Ordering: mmap_lock -> tlb_mutex -> vma_lock;
+	// also chardev_mutex -> tlb_mutex (reset reclaim).
+	struct mutex tlb_mutex;
+
 	struct tenstorrent_set_noc_cleanup noc_cleanup; // NOC write on release action
 	struct tenstorrent_power_state power_state; // Power state for this fd
 

--- a/enumerate.c
+++ b/enumerate.c
@@ -175,8 +175,13 @@ static int mappings_seq_show(struct seq_file *s, void *v)
 		}
 
 		// Allocated TLB windows.
-		for_each_set_bit(tlb_id, priv->tlbs, TENSTORRENT_MAX_INBOUND_TLBS) {
-			seq_printf(s, "%-8d %-16s %-14s ID: %-3u\n", pid, priv->comm, "TLB-alloc", tlb_id);
+		if (!mutex_trylock(&priv->tlb_mutex)) {
+			seq_printf(s, "%-8s %-16s %-14s\n", "", "", "...TLBs busy, skipping...");
+		} else {
+			for_each_set_bit(tlb_id, priv->tlbs, TENSTORRENT_MAX_INBOUND_TLBS) {
+				seq_printf(s, "%-8d %-16s %-14s ID: %-3u\n", pid, priv->comm, "TLB-alloc", tlb_id);
+			}
+			mutex_unlock(&priv->tlb_mutex);
 		}
 
 		// BAR/TLB mappings.

--- a/memory.c
+++ b/memory.c
@@ -988,7 +988,9 @@ long ioctl_allocate_tlb(struct chardev_private *priv,
 		return -EFAULT;
 	}
 
+	mutex_lock(&priv->tlb_mutex);
 	set_bit(id, priv->tlbs);
+	mutex_unlock(&priv->tlb_mutex);
 
 	return 0;
 }
@@ -1005,7 +1007,7 @@ long ioctl_free_tlb(struct chardev_private *priv, struct tenstorrent_free_tlb __
 	if (in.id >= TENSTORRENT_MAX_INBOUND_TLBS)
 		return -EINVAL;
 
-	mutex_lock(&priv->mutex);
+	mutex_lock(&priv->tlb_mutex);
 
 	if (!test_bit(in.id, priv->tlbs)) {
 		ret = -EPERM;
@@ -1027,7 +1029,7 @@ long ioctl_free_tlb(struct chardev_private *priv, struct tenstorrent_free_tlb __
 	ret = tenstorrent_device_free_tlb(tt_dev, in.id);
 
 unlock:
-	mutex_unlock(&priv->mutex);
+	mutex_unlock(&priv->tlb_mutex);
 	return ret;
 }
 
@@ -1035,6 +1037,7 @@ long ioctl_configure_tlb(struct chardev_private *priv,
 			 struct tenstorrent_configure_tlb __user *arg) {
 	struct tenstorrent_device *tt_dev = priv->device;
 	struct tenstorrent_configure_tlb_in in = {0};
+	long ret;
 
 	if (copy_from_user(&in, &arg->in, sizeof(in)))
 		return -EFAULT;
@@ -1042,10 +1045,17 @@ long ioctl_configure_tlb(struct chardev_private *priv,
 	if (in.id >= TENSTORRENT_MAX_INBOUND_TLBS)
 		return -EINVAL;
 
-	if (!test_bit(in.id, priv->tlbs))
-		return -EPERM;
+	// Hold tlb_mutex across the check and the configure so the window
+	// cannot be freed (and reallocated to another fd) in between.
+	mutex_lock(&priv->tlb_mutex);
 
-	return tenstorrent_device_configure_tlb(tt_dev, in.id, &in.config);
+	if (test_bit(in.id, priv->tlbs))
+		ret = tenstorrent_device_configure_tlb(tt_dev, in.id, &in.config);
+	else
+		ret = -EPERM;
+
+	mutex_unlock(&priv->tlb_mutex);
+	return ret;
 }
 
 // On kernels older than 5.8.0, EXPORT_TLB_DMABUF is unsupported.
@@ -1227,7 +1237,7 @@ long ioctl_export_tlb_dmabuf(struct chardev_private *priv, struct tenstorrent_ex
 		return -EINVAL;
 
 	// The caller must own the TLB window it wants to export.
-	mutex_lock(&priv->mutex);
+	mutex_lock(&priv->tlb_mutex);
 	if (!test_bit(in.tlb_id, priv->tlbs)) {
 		ret = -EPERM;
 		goto unlock;
@@ -1278,7 +1288,7 @@ long ioctl_export_tlb_dmabuf(struct chardev_private *priv, struct tenstorrent_ex
 	// export survives FREE_TLB and close() of this fd. Both references are
 	// dropped in tt_tlb_dmabuf_release(). Taken before dma_buf_export() so
 	// the release callback -- reachable via dma_buf_put() on the error paths
-	// below -- balances them. The window is still owned here (priv->mutex is
+	// below -- balances them. The window is still owned here (tlb_mutex is
 	// held and ownership was verified above), so its refcount is >= 1.
 	kref_get(&tt_dev->kref);
 	tenstorrent_tlb_export_get(tt_dev, in.tlb_id);
@@ -1303,7 +1313,7 @@ long ioctl_export_tlb_dmabuf(struct chardev_private *priv, struct tenstorrent_ex
 	list_add(&dmabuf_priv->list, &tt_dev->dmabuf_exports);
 	mutex_unlock(&tt_dev->dmabuf_export_lock);
 
-	mutex_unlock(&priv->mutex);
+	mutex_unlock(&priv->tlb_mutex);
 
 	fd = get_unused_fd_flags(O_CLOEXEC);
 	if (fd < 0) {
@@ -1324,7 +1334,7 @@ long ioctl_export_tlb_dmabuf(struct chardev_private *priv, struct tenstorrent_ex
 	return 0;
 
 unlock:
-	mutex_unlock(&priv->mutex);
+	mutex_unlock(&priv->tlb_mutex);
 	return ret;
 }
 
@@ -1586,7 +1596,10 @@ static int map_tlb_window(struct chardev_private *priv, struct vm_area_struct *v
 	if (size > tlb_desc.size)
 		return -EINVAL;
 
-	mutex_lock(&priv->mutex);
+	// tlb_mutex (not priv->mutex) so the mmap path never nests the general
+	// per-fd mutex inside mmap_lock; priv->mutex is held across GUP and
+	// uaccess elsewhere (e.g. PIN_PAGES), which nests it outside mmap_lock.
+	mutex_lock(&priv->tlb_mutex);
 
 	if (!test_bit(id, priv->tlbs)) {
 		ret = -EPERM;
@@ -1628,13 +1641,21 @@ static int map_tlb_window(struct chardev_private *priv, struct vm_area_struct *v
 	mutex_unlock(&priv->vma_lock);
 
 unlock:
-	mutex_unlock(&priv->mutex);
+	mutex_unlock(&priv->tlb_mutex);
 	return ret;
 }
 
 int tenstorrent_mmap(struct chardev_private *priv, struct vm_area_struct *vma)
 {
 	struct pci_dev *pdev = priv->device->pdev;
+
+	// The mmap path must never take priv->mutex: we are called with
+	// mmap_lock held, and priv->mutex is held across GUP and uaccess
+	// elsewhere (e.g. PIN_PAGES), which nests it outside mmap_lock.
+	// Taking it here would complete an ABBA deadlock cycle.
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 13, 0)
+	lockdep_assert_not_held(&priv->mutex);
+#endif
 
 	// We multiplex various mappable entities into a single character
 	// device using the mapping offset to determine which entity you get.


### PR DESCRIPTION
Lockdep reports an ABBA deadlock between mmap_lock and priv->mutex. PIN_PAGES holds priv->mutex while GUP may acquire mmap_lock, while mapping a TLB window acquires priv->mutex with mmap_lock already held.

Add a dedicated per-fd tlb_mutex to protect TLB ownership and serialize allocation, configuration, export, mapping, free, and reset reclaim. This removes priv->mutex from the TLB mmap path and establishes the ordering mmap_lock -> tlb_mutex -> vma_lock.

Also protect the previously unlocked CONFIGURE_TLB ownership check, preventing a window from being freed and reallocated to another fd while it is being configured.

Convert the remaining bitmap accesses as well, even where broader lifecycle locking already provides exclusion, so every priv->tlbs access follows one explicit and locally auditable locking rule.

Fixes: https://github.com/tenstorrent/tt-kmd/issues/271