### PR TITLE
Fix chardev lifetime races during PCI removal

### DIFF
--- a/chardev.c
+++ b/chardev.c
@@ -95,12 +95,17 @@ int tenstorrent_register_device(struct tenstorrent_device *tt_dev)
 	init_waitqueue_head(&tt_dev->resource_lock_waitqueue);
 	init_waitqueue_head(&tt_dev->chardev_excl_waitqueue);
 
+	// device_initialize creates the reference that tenstorrent_pci_remove
+	// drops.  dev.release makes the device kobject the owner of tt_dev's
+	// memory: cdev_device_add (below) parents chardev.kobj under dev.kobj,
+	// so the VFS references taken by chrdev_open keep tt_dev alive across
+	// remove until the last fd closes.  See the comment in device.h.
 	device_initialize(&tt_dev->dev);
 	tt_dev->dev.devt = devt;
 	tt_dev->dev.class = tt_dev_class;
 	tt_dev->dev.parent = &tt_dev->pdev->dev;
 	tt_dev->dev.groups = NULL;
-	tt_dev->dev.release = NULL;
+	tt_dev->dev.release = tt_dev_release;
 
 	tt_dev->dev.id = tt_dev->ordinal;
 	dev_set_name(&tt_dev->dev, TENSTORRENT "/%d", tt_dev->ordinal);
@@ -840,7 +845,11 @@ static int tt_cdev_open(struct inode *inode, struct file *file)
 	INIT_LIST_HEAD(&private_data->vma_list);
 	mutex_init(&private_data->vma_lock);
 
-	kref_get(&tt_dev->kref);
+	// Safe even if remove ran to completion while this open was in flight:
+	// the chardev.kobj reference our caller (chrdev_open) holds pins
+	// dev.kobj, which owns tt_dev's memory.  This get is the fd's own
+	// long-lived reference, dropped in tt_cdev_release.
+	get_device(&tt_dev->dev);
 	private_data->device = tt_dev;
 	private_data->open_reset_gen = atomic_long_read(&tt_dev->reset_gen);
 
@@ -859,7 +868,7 @@ static int tt_cdev_open(struct inode *inode, struct file *file)
 	if (ret) {
 		put_pid(private_data->pid);
 		kfree(private_data);
-		tenstorrent_device_put(tt_dev);
+		put_device(&tt_dev->dev);
 		return ret;
 	}
 
@@ -982,7 +991,7 @@ static int tt_cdev_release(struct inode *inode, struct file *file)
 
 	up_read(&tt_dev->reset_rwsem);
 
-	tenstorrent_device_put(tt_dev);
+	put_device(&tt_dev->dev);
 	put_pid(priv->pid);
 	kfree(file->private_data);
 	file->private_data = NULL;

--- a/device.h
+++ b/device.h
@@ -9,7 +9,6 @@
 #include <linux/pci.h>
 #include <linux/cdev.h>
 #include <linux/reboot.h>
-#include <linux/kref.h>
 #include <linux/refcount.h>
 #include <linux/rwsem.h>
 #include <linux/wait.h>
@@ -24,8 +23,14 @@
 struct tenstorrent_device_class;
 
 struct tenstorrent_device {
-	struct kref kref;
-
+	// dev owns the lifetime of this structure: dev.release (tt_dev_release)
+	// frees it when the last reference drops.  Long-lived references (open
+	// fds, TLB dma-buf exports, the probe reference dropped by remove) use
+	// get_device/put_device.  An open racing remove is additionally covered
+	// by the VFS: chrdev_open takes a chardev.kobj reference before calling
+	// tt_cdev_open, and chardev.kobj holds dev.kobj (wired by
+	// cdev_device_add), so this structure cannot be freed while any open is
+	// in flight or any fd remains.
 	struct device dev;
 	struct cdev chardev;
 	struct pci_dev *pdev;
@@ -125,6 +130,6 @@ struct tenstorrent_device_class {
 	bool defer_idle_powerdown;
 };
 
-void tenstorrent_device_put(struct tenstorrent_device *);
+void tt_dev_release(struct device *dev);
 
 #endif

--- a/enumerate.c
+++ b/enumerate.c
@@ -298,9 +298,6 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 		return err;
 	}
 
-	// The refcount created here persists until remove.
-	kref_init(&tt_dev->kref);
-
 	tt_dev->detached = false;
 	tt_dev->needs_hw_init = true;
 	tt_dev->dev_class = device_class;
@@ -404,6 +401,8 @@ fail_init_device:
 	pci_set_drvdata(dev, NULL);
 	pci_dev_put(dev);
 	xa_erase(&tenstorrent_dev_xa, ordinal);
+	// Direct kfree: this path runs before tenstorrent_register_device,
+	// so tt_dev->dev is not yet initialized and cannot be put_device'd.
 	kfree(tt_dev);
 	pci_disable_device(dev);
 	return err;
@@ -479,23 +478,23 @@ static void tenstorrent_pci_remove(struct pci_dev *dev)
 	// If this is postponed, a subsequent probe is forced to use a different ordinal.
 	xa_erase(&tenstorrent_dev_xa, tt_dev->ordinal);
 
-	tenstorrent_device_put(tt_dev);
+	// Drop the reference from device_initialize (tenstorrent_register_device).
+	// tt_dev is freed here unless open fds or dma-buf exports still hold it.
+	put_device(&tt_dev->dev);
 }
 
-static void tt_dev_release(struct kref *tt_dev_kref) {
-	struct tenstorrent_device *tt_dev = container_of(tt_dev_kref, struct tenstorrent_device, kref);
+// dev.release callback: runs when the last reference on tt_dev->dev drops.
+// Set by tenstorrent_register_device.
+void tt_dev_release(struct device *dev)
+{
+	struct tenstorrent_device *tt_dev = container_of(dev, struct tenstorrent_device, dev);
 	struct pci_dev *pdev = tt_dev->pdev;
 
 	if (tt_dev->dev_class->reboot)
 		unregister_reboot_notifier(&tt_dev->reboot_notifier);
 
-
 	pci_dev_put(pdev);
 	kfree(tt_dev);
-}
-
-void tenstorrent_device_put(struct tenstorrent_device *tt_dev) {
-	kref_put(&tt_dev->kref, tt_dev_release);
 }
 
 static int tenstorrent_suspend(struct device *dev) {

--- a/enumerate.c
+++ b/enumerate.c
@@ -412,7 +412,7 @@ fail_init_device:
 static void tenstorrent_pci_remove(struct pci_dev *dev)
 {
 	struct tenstorrent_device *tt_dev = pci_get_drvdata(dev);
-	struct chardev_private *priv, *tmp;
+	struct chardev_private *priv;
 	u16 vendor_id;
 
 	// Tear down telemetry first.
@@ -462,9 +462,11 @@ static void tenstorrent_pci_remove(struct pci_dev *dev)
 	// they observe detached and return -ENODEV instead of waiting forever.
 	wake_up_interruptible(&tt_dev->resource_lock_waitqueue);
 
-	list_for_each_entry_safe(priv, tmp, &tt_dev->open_fds_list, open_fd) {
+	mutex_lock(&tt_dev->chardev_mutex);
+	list_for_each_entry(priv, &tt_dev->open_fds_list, open_fd) {
 		tenstorrent_memory_cleanup(priv);
 	}
+	mutex_unlock(&tt_dev->chardev_mutex);
 
 	tenstorrent_unregister_device(tt_dev);
 	tenstorrent_disable_interrupts(tt_dev);

--- a/memory.c
+++ b/memory.c
@@ -1179,7 +1179,7 @@ static void tt_tlb_dmabuf_release(struct dma_buf *dmabuf)
 	// device reference taken at export time is what makes touching tt_dev
 	// safe here even if the device was removed while the dma-buf was open.
 	tenstorrent_tlb_export_put(priv->tt_dev, priv->tlb_id);
-	tenstorrent_device_put(priv->tt_dev);
+	put_device(&priv->tt_dev->dev);
 
 	kfree(priv);
 }
@@ -1280,7 +1280,7 @@ long ioctl_export_tlb_dmabuf(struct chardev_private *priv, struct tenstorrent_ex
 	// the release callback -- reachable via dma_buf_put() on the error paths
 	// below -- balances them. The window is still owned here (priv->mutex is
 	// held and ownership was verified above), so its refcount is >= 1.
-	kref_get(&tt_dev->kref);
+	get_device(&tt_dev->dev);
 	tenstorrent_tlb_export_get(tt_dev, in.tlb_id);
 
 	exp_info.ops = &tt_tlb_dmabuf_ops;
@@ -1291,7 +1291,7 @@ long ioctl_export_tlb_dmabuf(struct chardev_private *priv, struct tenstorrent_ex
 	dmabuf = dma_buf_export(&exp_info);
 	if (IS_ERR(dmabuf)) {
 		tenstorrent_tlb_export_put(tt_dev, in.tlb_id);
-		tenstorrent_device_put(tt_dev);
+		put_device(&tt_dev->dev);
 		kfree(dmabuf_priv);
 		ret = PTR_ERR(dmabuf);
 		goto unlock;


### PR DESCRIPTION
Serialize remove-time fd cleanup against concurrent open and close, and use device-model references so an in-flight open cannot access a freed embedded cdev.

Fixes: https://github.com/tenstorrent/tt-kmd/issues/256

Remaining gaps:

* cleanup_hardware() is not ordered against in-flight ioctls. Remove calls it before the reset_rwsem write-side drain, so an ioctl that passed its detached check could race hardware teardown. Latent today: both callbacks return early once detached is set, which also means orderly unbind never actually shuts down present hardware. Fix: separate physical presence from logical detachment and run cleanup_hardware() after the drain.

* Opens are not rejected during removal. admit_chardev_open() never checks detached, so a racing open can succeed against a dying device and produce a zombie fd, or block forever on chardev_excl_waitqueue (no detached term in the wake condition, and remove never wakes it). Fix: check detached under chardev_mutex including after each wait, and wake the queue during removal.