### PR TITLE
Report fan_rpm as N/A when firmware says fan control is disabled

### DIFF
--- a/telemetry.c
+++ b/telemetry.c
@@ -327,6 +327,8 @@ static int tt_hwmon_read(struct device *dev, enum hwmon_sensor_types type, u32 a
 					raw = (raw >> 16) & 0xFFFF;  // VDD_LIMITS: max in upper 16
 				*val = raw;		// Reported in mV
 			} else if (type == hwmon_fan) {
+				if (raw == 0xFFFFFFFF)
+					return -ENODATA; // Firmware reports fan control disabled
 				*val = raw;		// Reported in RPM
 			}
 			return 0;


### PR DESCRIPTION
On boards where the firmware table disables fan control firmware writes the sentinel 0xFFFFFFFF to the FAN_RPM telemetry tag. The driver passed this through as a literal reading, so `sensors` showed "fan_rpm: 4294967295 RPM".

Return -ENODATA for the sentinel so hwmon reports the reading as N/A.

Prior to tt-system-firmware commit 0444266c059f ("lib: bh_arc: Set fan telemetry to invalid if fan ctrl is disabled", first shipped in bundle v19.10.0), such boards reported 0 RPM for this tag.