### PR TITLE
Add NOC read/write ioctls for small reset-safe transfers

### DIFF
--- a/blackhole.c
+++ b/blackhole.c
@@ -9,6 +9,7 @@
 #include <linux/slab.h>
 #include <linux/jiffies.h>
 #include <linux/delay.h>
+#include <linux/io-64-nonatomic-lo-hi.h>
 
 #include "blackhole.h"
 #include "pcie.h"
@@ -249,17 +250,58 @@ static u8 __iomem *bh_configure_kernel_tlb(struct blackhole_device *bh, u32 x, u
 	return bh->kernel_tlb + offset;
 }
 
-static u32 noc_read32(struct blackhole_device *bh, u32 x, u32 y, u64 addr, int noc)
+static int blackhole_noc_read(struct tenstorrent_device *tt_dev, u32 x, u32 y, u64 addr, void *value, u32 width, int noc)
 {
-	u32 val;
+	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
 	u8 __iomem *tlb_window;
+	int ret = 0;
 
 	mutex_lock(&bh->kernel_tlb_mutex);
 
 	tlb_window = bh_configure_kernel_tlb(bh, x, y, addr, noc);
-	val = ioread32(tlb_window);
+
+	switch (width) {
+	case 1: *(u8  *)value = ioread8(tlb_window);  break;
+	case 2: *(u16 *)value = ioread16(tlb_window); break;
+	case 4: *(u32 *)value = ioread32(tlb_window); break;
+	case 8: *(u64 *)value = ioread64(tlb_window); break;
+	default: ret = -EINVAL; break;
+	}
 
 	mutex_unlock(&bh->kernel_tlb_mutex);
+
+	return ret;
+}
+
+static int blackhole_noc_write(struct tenstorrent_device *tt_dev, u32 x, u32 y, u64 addr, const void *value, u32 width,
+			       int noc)
+{
+	struct blackhole_device *bh = tt_dev_to_bh_dev(tt_dev);
+	u8 __iomem *tlb_window;
+	int ret = 0;
+
+	mutex_lock(&bh->kernel_tlb_mutex);
+
+	tlb_window = bh_configure_kernel_tlb(bh, x, y, addr, noc);
+
+	switch (width) {
+	case 1: iowrite8(*(const u8  *)value, tlb_window);  break;
+	case 2: iowrite16(*(const u16 *)value, tlb_window); break;
+	case 4: iowrite32(*(const u32 *)value, tlb_window); break;
+	case 8: iowrite64(*(const u64 *)value, tlb_window); break;
+	default: ret = -EINVAL; break;
+	}
+
+	mutex_unlock(&bh->kernel_tlb_mutex);
+
+	return ret;
+}
+
+static u32 noc_read32(struct blackhole_device *bh, u32 x, u32 y, u64 addr, int noc)
+{
+	u32 val = 0;
+
+	blackhole_noc_read(&bh->tt, x, y, addr, &val, sizeof(val), noc);
 
 	return val;
 }
@@ -280,14 +322,7 @@ static void blackhole_report_cable_fault(struct blackhole_device *bh)
 
 static void noc_write32(struct blackhole_device *bh, u32 x, u32 y, u64 addr, u32 data, int noc)
 {
-	u8 __iomem *tlb_window;
-
-	mutex_lock(&bh->kernel_tlb_mutex);
-
-	tlb_window = bh_configure_kernel_tlb(bh, x, y, addr, noc);
-	iowrite32(data, tlb_window);
-
-	mutex_unlock(&bh->kernel_tlb_mutex);
+	blackhole_noc_write(&bh->tt, x, y, addr, &data, sizeof(data), noc);
 }
 
 static int csm_read32(struct blackhole_device *bh, u64 addr, u32 *value)
@@ -919,6 +954,8 @@ struct tenstorrent_device_class blackhole_class = {
 	.configure_outbound_atu = blackhole_configure_outbound_atu,
 	.noc_write32 = blackhole_noc_write32,
 	.interrupt = blackhole_interrupt,
+	.noc_read = blackhole_noc_read,
+	.noc_write = blackhole_noc_write,
 	.csm_read32 = blackhole_csm_read32,
 	.csm_write32 = blackhole_csm_write32,
 	.arc_msg_locate_queue = blackhole_arc_msg_locate_queue,

--- a/chardev.c
+++ b/chardev.c
@@ -542,6 +542,87 @@ static long ioctl_set_noc_cleanup(struct chardev_private *priv,
 	return 0;
 }
 
+// Validate the common header of a NOC read/write request. The two request
+// structs share an identical layout, so a single validator covers both.
+static long validate_noc_io(u32 argsz, u32 flags, u16 x, u16 y, const u8 reserved0[2],
+			    u8 noc, u8 width, u64 addr, u32 expected_argsz)
+{
+	if (argsz != expected_argsz)
+		return -EINVAL;
+
+	if (flags != 0 || reserved0[0] != 0 || reserved0[1] != 0)
+		return -EINVAL;
+
+	if (x > 63 || y > 63)
+		return -EINVAL;
+
+	// NOC must be either 0 or 1.
+	if (noc > 1)
+		return -EINVAL;
+
+	// Only 1, 2, 4, and 8 byte transfers are supported.
+	if (width != 1 && width != 2 && width != 4 && width != 8)
+		return -EINVAL;
+
+	// The KMD cannot validate the address itself, but it must be naturally
+	// aligned to the transfer width.
+	if (addr & (width - 1))
+		return -EINVAL;
+
+	return 0;
+}
+
+static long ioctl_noc_read(struct chardev_private *priv, struct tenstorrent_noc_read __user *arg)
+{
+	struct tenstorrent_device *tt_dev = priv->device;
+	struct tenstorrent_noc_read data = {0};
+	u64 value = 0;
+	long ret;
+
+	if (!tt_dev->dev_class->noc_read)
+		return -EOPNOTSUPP;
+
+	if (copy_from_user(&data, arg, sizeof(data)) != 0)
+		return -EFAULT;
+
+	ret = validate_noc_io(data.argsz, data.flags, data.x, data.y, data.reserved0, data.noc,
+			      data.width, data.addr, sizeof(data));
+	if (ret)
+		return ret;
+
+	ret = tt_dev->dev_class->noc_read(tt_dev, data.x, data.y, data.addr, &value, data.width, data.noc);
+	if (ret)
+		return ret;
+
+	data.value = value;
+
+	if (copy_to_user(arg, &data, sizeof(data)) != 0)
+		return -EFAULT;
+
+	return 0;
+}
+
+static long ioctl_noc_write(struct chardev_private *priv, struct tenstorrent_noc_write __user *arg)
+{
+	struct tenstorrent_device *tt_dev = priv->device;
+	struct tenstorrent_noc_write data = {0};
+	long ret;
+
+	if (!tt_dev->dev_class->noc_write)
+		return -EOPNOTSUPP;
+
+	if (copy_from_user(&data, arg, sizeof(data)) != 0)
+		return -EFAULT;
+
+	ret = validate_noc_io(data.argsz, data.flags, data.x, data.y, data.reserved0, data.noc,
+			      data.width, data.addr, sizeof(data));
+	if (ret)
+		return ret;
+
+	// Only the low data.width bytes of data.value are written.
+	return tt_dev->dev_class->noc_write(tt_dev, data.x, data.y, data.addr, &data.value, data.width, data.noc);
+}
+
 static int tenstorrent_set_aggregated_power_state_locked(struct tenstorrent_device *tt_dev)
 {
 	struct tenstorrent_power_state power_state = { 0 };
@@ -848,6 +929,14 @@ static long tt_cdev_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
 
 		case TENSTORRENT_IOCTL_SMC_MSG:
 			ret = ioctl_arc_msg(priv, (struct tenstorrent_smc_msg __user *)arg);
+			break;
+
+		case TENSTORRENT_IOCTL_NOC_READ:
+			ret = ioctl_noc_read(priv, (struct tenstorrent_noc_read __user *)arg);
+			break;
+
+		case TENSTORRENT_IOCTL_NOC_WRITE:
+			ret = ioctl_noc_write(priv, (struct tenstorrent_noc_write __user *)arg);
 			break;
 
 		default:

--- a/device.h
+++ b/device.h
@@ -127,6 +127,10 @@ struct tenstorrent_device_class {
 	// Optional MSI handler invoked from the driver's IRQ handler. May be NULL for devices
 	// with no interrupt handling.
 	void (*interrupt)(struct tenstorrent_device *ttdev);
+	// Reset-safe scalar NOC transfers. width is one of 1, 2, 4, 8.
+	// Return 0 on success or a negative errno.
+	int (*noc_read)(struct tenstorrent_device *ttdev, u32 x, u32 y, u64 addr, void *value, u32 width, int noc);
+	int (*noc_write)(struct tenstorrent_device *ttdev, u32 x, u32 y, u64 addr, const void *value, u32 width, int noc);
 	int (*csm_read32)(struct tenstorrent_device *ttdev, u64 addr, u32 *value);
 	int (*csm_write32)(struct tenstorrent_device *ttdev, u64 addr, u32 value);
 	int (*arc_msg_locate_queue)(struct tenstorrent_device *ttdev, u32 *queue_base, u32 *num_entries);

--- a/ioctl.h
+++ b/ioctl.h
@@ -29,6 +29,8 @@
 #define TENSTORRENT_IOCTL_SET_POWER_STATE		_IO(TENSTORRENT_IOCTL_MAGIC, 15)
 #define TENSTORRENT_IOCTL_EXPORT_TLB_DMABUF		_IO(TENSTORRENT_IOCTL_MAGIC, 16)
 #define TENSTORRENT_IOCTL_SMC_MSG		_IO(TENSTORRENT_IOCTL_MAGIC, 17)
+#define TENSTORRENT_IOCTL_NOC_READ		_IO(TENSTORRENT_IOCTL_MAGIC, 18)
+#define TENSTORRENT_IOCTL_NOC_WRITE		_IO(TENSTORRENT_IOCTL_MAGIC, 19)
 
 // For tenstorrent_mapping.mapping_id. These are not array indices.
 #define TENSTORRENT_MAPPING_UNUSED		0
@@ -503,5 +505,57 @@ struct tenstorrent_smc_msg {
 	__u32 message[8];
 };
 
+/**
+ * TENSTORRENT_IOCTL_NOC_READ - Read a small value from a NOC endpoint
+ * TENSTORRENT_IOCTL_NOC_WRITE - Write a small value to a NOC endpoint
+ *
+ * These perform a single 1, 2, 4, or 8 byte read or write to a NOC address.
+ * The transfer is mediated by the kernel using a reserved address window, so
+ * it remains safe across device reset: a reset invalidates the file
+ * descriptor (subsequent calls return -ENODEV) rather than letting userspace
+ * fault on a zapped MMIO mapping. This trades throughput and latency for
+ * robustness, which suits long-running device management and telemetry tools.
+ *
+ * The target endpoint is identified by NOC coordinates (@x, @y) plus a local
+ * @addr. @flags is reserved for future addressing modes (e.g. hardware without
+ * X/Y coordinates) and must currently be 0.
+ *
+ * The KMD cannot validate that @addr refers to anything meaningful; it only
+ * enforces that @addr is naturally aligned to @width.
+ *
+ * @argsz: Must be sizeof(struct tenstorrent_noc_read/write).
+ * @flags: Reserved for future use, must be 0.
+ * @x: X coordinate of the NOC endpoint; must be in the range 0-63.
+ * @y: Y coordinate of the NOC endpoint; must be in the range 0-63.
+ * @noc: NOC ID to use; must be 0 or 1.
+ * @width: Transfer width in bytes; must be 1, 2, 4, or 8.
+ * @reserved0: Must be 0.
+ * @addr: NOC address; must be aligned to @width.
+ * @value: For NOC_READ, receives the value (zero-extended to 64 bits). For
+ *         NOC_WRITE, the value to write (only the low @width bytes are used).
+ */
+struct tenstorrent_noc_read {
+	__u32 argsz;
+	__u32 flags;
+	__u16 x;
+	__u16 y;
+	__u8 noc;
+	__u8 width;
+	__u8 reserved0[2];
+	__u64 addr;
+	__u64 value;
+};
+
+struct tenstorrent_noc_write {
+	__u32 argsz;
+	__u32 flags;
+	__u16 x;
+	__u16 y;
+	__u8 noc;
+	__u8 width;
+	__u8 reserved0[2];
+	__u64 addr;
+	__u64 value;
+};
 
 #endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,7 +14,7 @@ ARC_MSG_PROG := arc_msg_test
 TEST_SOURCES := get_driver_info.cpp get_device_info.cpp query_mappings.cpp \
 	dma_buf.cpp pin_pages.cpp config_space.cpp lock.cpp hwmon.cpp map_peer_bar.cpp \
 	ioctl_overrun.cpp ioctl_zeroing.cpp tlbs.cpp dmabuf_export.cpp release.cpp \
-	mappings_debugfs.cpp procfs_pids.cpp excl.cpp smc_msg.cpp
+	mappings_debugfs.cpp procfs_pids.cpp excl.cpp smc_msg.cpp noc_io.cpp
 
 CORE_SOURCES := enumeration.cpp util.cpp devfd.cpp main.cpp test_failure.cpp
 SOURCES := $(CORE_SOURCES) $(TEST_SOURCES)

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -27,6 +27,7 @@ void TestMappingsDebugfs(const EnumeratedDevice &dev);
 void TestProcfsPids(const EnumeratedDevice &dev);
 void TestExcl(const EnumeratedDevice &dev);
 void TestSmcMsg(const EnumeratedDevice &dev);
+void TestNocIo(const EnumeratedDevice &dev);
 
 int main(int argc, char *argv[])
 {
@@ -55,6 +56,7 @@ int main(int argc, char *argv[])
         TestIoctlZeroing(d);
         TestTlbs(d);
         TestTlbExport(d);
+        TestNocIo(d);
         TestMappingsDebugfs(d);
         TestProcfsPids(d);
         TestExcl(d);

--- a/test/noc_io.cpp
+++ b/test/noc_io.cpp
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Tests for the small reset-safe NOC transfer ioctls
+// (TENSTORRENT_IOCTL_NOC_READ / TENSTORRENT_IOCTL_NOC_WRITE).
+
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <array>
+#include <cerrno>
+#include <cstdint>
+#include <random>
+
+#include "ioctl.h"
+
+#include "devfd.h"
+#include "enumeration.h"
+#include "test_failure.h"
+#include "tlbs.h"
+
+namespace
+{
+
+static std::mt19937_64 RNG{std::random_device{}()};
+
+uint64_t random_aligned_address(uint64_t maximum, uint64_t alignment)
+{
+    std::uniform_int_distribution<uint64_t> dist(0, maximum / alignment - 1);
+    return dist(RNG) * alignment;
+}
+
+uint64_t noc_read(int fd, uint16_t x, uint16_t y, uint8_t noc, uint8_t width, uint64_t addr)
+{
+    tenstorrent_noc_read r{};
+    r.argsz = sizeof(r);
+    r.x = x;
+    r.y = y;
+    r.noc = noc;
+    r.width = width;
+    r.addr = addr;
+
+    if (ioctl(fd, TENSTORRENT_IOCTL_NOC_READ, &r) != 0)
+        THROW_TEST_FAILURE("NOC_READ ioctl failed");
+
+    return r.value;
+}
+
+void noc_write(int fd, uint16_t x, uint16_t y, uint8_t noc, uint8_t width, uint64_t addr, uint64_t value)
+{
+    tenstorrent_noc_write w{};
+    w.argsz = sizeof(w);
+    w.x = x;
+    w.y = y;
+    w.noc = noc;
+    w.width = width;
+    w.addr = addr;
+    w.value = value;
+
+    if (ioctl(fd, TENSTORRENT_IOCTL_NOC_WRITE, &w) != 0)
+        THROW_TEST_FAILURE("NOC_WRITE ioctl failed");
+}
+
+// A NOC tile's node_id register encodes its own coordinates: x in bits [5:0]
+// and y in bits [11:6]. Reading it back is a self-checking way to verify that
+// the read reached the requested endpoint.
+void VerifyNodeId(int fd, uint16_t x, uint16_t y, uint64_t node_id_addr)
+{
+    uint32_t node_id = static_cast<uint32_t>(noc_read(fd, x, y, 0, 4, node_id_addr));
+    uint32_t read_x = (node_id >> 0) & 0x3f;
+    uint32_t read_y = (node_id >> 6) & 0x3f;
+
+    if (read_x != x || read_y != y)
+        THROW_TEST_FAILURE("NOC_READ node id mismatch");
+}
+
+// Write then read back each transfer width at a DRAM endpoint.
+void VerifyRoundtrip(int fd, uint16_t x, uint16_t y)
+{
+    static constexpr std::array<std::pair<uint8_t, uint64_t>, 4> cases = {{
+        {1, 0xffull},
+        {2, 0xffffull},
+        {4, 0xffffffffull},
+        {8, ~0ull},
+    }};
+
+    // Pick a random 8-byte-aligned base within the first 1 GiB; give each
+    // width its own 8-byte slot so the writes don't overlap.
+    uint64_t base = random_aligned_address(1ULL << 30, 8);
+    uint64_t offset = 0;
+
+    for (const auto &[width, mask] : cases) {
+        uint64_t addr = base + offset;
+        uint64_t value = RNG() & mask;
+
+        noc_write(fd, x, y, 0, width, addr, value);
+        uint64_t got = noc_read(fd, x, y, 0, width, addr) & mask;
+
+        if (got != value)
+            THROW_TEST_FAILURE("NOC roundtrip data mismatch");
+
+        offset += 8;
+    }
+}
+
+void ExpectReadRejected(int fd, const tenstorrent_noc_read &request, const char *what)
+{
+    tenstorrent_noc_read r = request;
+    if (ioctl(fd, TENSTORRENT_IOCTL_NOC_READ, &r) == 0)
+        THROW_TEST_FAILURE(std::string("NOC_READ accepted invalid request: ") + what);
+}
+
+void ExpectWriteRejected(int fd, const tenstorrent_noc_write &request, const char *what)
+{
+    tenstorrent_noc_write w = request;
+    if (ioctl(fd, TENSTORRENT_IOCTL_NOC_WRITE, &w) == 0)
+        THROW_TEST_FAILURE(std::string("NOC_WRITE accepted invalid request: ") + what);
+}
+
+void VerifyValidation(int fd)
+{
+    auto good = [] {
+        tenstorrent_noc_read r{};
+        r.argsz = sizeof(r);
+        r.x = 0;
+        r.y = 0;
+        r.noc = 0;
+        r.width = 4;
+        r.addr = 0;
+        return r;
+    };
+
+    { auto r = good(); r.argsz = sizeof(r) - 1;     ExpectReadRejected(fd, r, "bad argsz"); }
+    { auto r = good(); r.flags = 1;                 ExpectReadRejected(fd, r, "nonzero flags"); }
+    { auto r = good(); r.reserved0[0] = 1;          ExpectReadRejected(fd, r, "nonzero reserved0"); }
+    { auto r = good(); r.x = 64;                    ExpectReadRejected(fd, r, "x > 63"); }
+    { auto r = good(); r.y = 64;                    ExpectReadRejected(fd, r, "y > 63"); }
+    { auto r = good(); r.noc = 2;                   ExpectReadRejected(fd, r, "noc > 1"); }
+    { auto r = good(); r.width = 3;                  ExpectReadRejected(fd, r, "unsupported width"); }
+    { auto r = good(); r.width = 0;                  ExpectReadRejected(fd, r, "zero width"); }
+    { auto r = good(); r.width = 4; r.addr = 2;      ExpectReadRejected(fd, r, "misaligned 4-byte"); }
+    { auto r = good(); r.width = 2; r.addr = 1;      ExpectReadRejected(fd, r, "misaligned 2-byte"); }
+    { auto r = good(); r.width = 8; r.addr = 4;      ExpectReadRejected(fd, r, "misaligned 8-byte"); }
+
+    // The write request shares the same layout and validation.
+    tenstorrent_noc_write w{};
+    w.argsz = sizeof(w) + 1;
+    w.width = 4;
+    ExpectWriteRejected(fd, w, "bad argsz");
+}
+
+void VerifyWormholeAddressValidation(int fd)
+{
+    tenstorrent_noc_read r{};
+    r.argsz = sizeof(r);
+    r.width = 4;
+    r.addr = 1ULL << 36;
+    ExpectReadRejected(fd, r, "address exceeds Wormhole NOC range");
+}
+
+void VerifyWormhole(const EnumeratedDevice &dev)
+{
+    DevFd dev_fd(dev.path);
+    int fd = dev_fd.get();
+
+    VerifyWormholeAddressValidation(fd);
+
+    // ARC at (0,10) and DRAM at (0,11) expose node_id registers at these
+    // addresses (see the TLB tests).
+    VerifyNodeId(fd, 0, 10, 0xFFFB2002CULL);
+    VerifyNodeId(fd, 0, 11, 0x10009002CULL);
+
+    // DRAM at (0,0) is a safe scratch endpoint for the roundtrip.
+    VerifyRoundtrip(fd, 0, 0);
+}
+
+void VerifyBlackhole(const EnumeratedDevice &dev)
+{
+    DevFd dev_fd(dev.path);
+    int fd = dev_fd.get();
+    bool translated = is_blackhole_noc_translation_enabled(dev);
+
+    // ARC is at (8,0) regardless of NOC translation.
+    VerifyNodeId(fd, 8, 0, 0x0000000080050044ULL);
+
+    // Use a valid DRAM core as a scratch endpoint for the roundtrip.
+    uint16_t dram_x = translated ? 17 : 0;
+    uint16_t dram_y = translated ? 12 : 0;
+    VerifyRoundtrip(fd, dram_x, dram_y);
+}
+
+} // namespace
+
+void TestNocIo(const EnumeratedDevice &dev)
+{
+    DevFd dev_fd(dev.path);
+    VerifyValidation(dev_fd.get());
+
+    switch (dev.type)
+    {
+    case Wormhole:
+        VerifyWormhole(dev);
+        break;
+    case Blackhole:
+        VerifyBlackhole(dev);
+        break;
+    default:
+        THROW_TEST_FAILURE("Unknown device type");
+    }
+}

--- a/wormhole.c
+++ b/wormhole.c
@@ -10,6 +10,7 @@
 #include <linux/sysfs.h>
 #include <linux/delay.h>
 #include <linux/pci.h>
+#include <linux/io-64-nonatomic-lo-hi.h>
 
 #include "wormhole.h"
 #include "pcie.h"
@@ -926,9 +927,11 @@ static int wormhole_describe_tlb(struct tenstorrent_device *tt_dev, int tlb,
 	return 0;
 }
 
-static u8 __iomem *wh_configure_kernel_tlb(struct wormhole_device *wh, u32 x, u32 y, u64 addr, int noc) {
+static int wh_configure_kernel_tlb(struct wormhole_device *wh, u32 x, u32 y, u64 addr, int noc, u8 __iomem **tlb_window)
+{
 	struct tenstorrent_noc_tlb_config config = { 0 };
 	u64 offset = addr & TLB_16M_WINDOW_MASK;
+	int ret;
 
 	config.addr = addr & ~TLB_16M_WINDOW_MASK;
 	config.x_end = x;
@@ -936,33 +939,79 @@ static u8 __iomem *wh_configure_kernel_tlb(struct wormhole_device *wh, u32 x, u3
 	config.ordering	= 1; // strict
 	config.noc = noc;
 
-	wh_configure_tlb(wh, KERNEL_TLB_INDEX, &config);
-	return wh->bar4_mapping + KERNEL_TLB_START + offset;
+	ret = wh_configure_tlb(wh, KERNEL_TLB_INDEX, &config);
+	if (ret)
+		return ret;
+
+	*tlb_window = wh->bar4_mapping + KERNEL_TLB_START + offset;
+	return 0;
 }
 
-static u32 noc_read32(struct wormhole_device *wh, u32 x, u32 y, u64 addr, int noc) {
-	u32 val;
+static int wormhole_noc_read(struct tenstorrent_device *tt_dev, u32 x, u32 y, u64 addr, void *value, u32 width, int noc)
+{
+	struct wormhole_device *wh = tt_dev_to_wh_dev(tt_dev);
 	u8 __iomem *tlb_window;
+	int ret = 0;
 
 	mutex_lock(&wh->kernel_tlb_mutex);
 
-	tlb_window = wh_configure_kernel_tlb(wh, x, y, addr, noc);
-	val = ioread32(tlb_window);
+	ret = wh_configure_kernel_tlb(wh, x, y, addr, noc, &tlb_window);
+	if (ret)
+		goto out;
 
+	switch (width) {
+	case 1: *(u8  *)value = ioread8(tlb_window);  break;
+	case 2: *(u16 *)value = ioread16(tlb_window); break;
+	case 4: *(u32 *)value = ioread32(tlb_window); break;
+	case 8: *(u64 *)value = ioread64(tlb_window); break;
+	default: ret = -EINVAL; break;
+	}
+
+out:
 	mutex_unlock(&wh->kernel_tlb_mutex);
+
+	return ret;
+}
+
+static int wormhole_noc_write(struct tenstorrent_device *tt_dev, u32 x, u32 y, u64 addr, const void *value, u32 width,
+			      int noc)
+{
+	struct wormhole_device *wh = tt_dev_to_wh_dev(tt_dev);
+	u8 __iomem *tlb_window;
+	int ret = 0;
+
+	mutex_lock(&wh->kernel_tlb_mutex);
+
+	ret = wh_configure_kernel_tlb(wh, x, y, addr, noc, &tlb_window);
+	if (ret)
+		goto out;
+
+	switch (width) {
+	case 1: iowrite8(*(const u8  *)value, tlb_window);  break;
+	case 2: iowrite16(*(const u16 *)value, tlb_window); break;
+	case 4: iowrite32(*(const u32 *)value, tlb_window); break;
+	case 8: iowrite64(*(const u64 *)value, tlb_window); break;
+	default: ret = -EINVAL; break;
+	}
+
+out:
+	mutex_unlock(&wh->kernel_tlb_mutex);
+
+	return ret;
+}
+
+static u32 noc_read32(struct wormhole_device *wh, u32 x, u32 y, u64 addr, int noc)
+{
+	u32 val = 0;
+
+	wormhole_noc_read(&wh->tt, x, y, addr, &val, sizeof(val), noc);
 
 	return val;
 }
 
-static void noc_write32(struct wormhole_device *wh, u32 x, u32 y, u64 addr, u32 data, int noc) {
-	u8 __iomem *tlb_window;
-
-	mutex_lock(&wh->kernel_tlb_mutex);
-
-	tlb_window = wh_configure_kernel_tlb(wh, x, y, addr, noc);
-	iowrite32(data, tlb_window);
-
-	mutex_unlock(&wh->kernel_tlb_mutex);
+static void noc_write32(struct wormhole_device *wh, u32 x, u32 y, u64 addr, u32 data, int noc)
+{
+	wormhole_noc_write(&wh->tt, x, y, addr, &data, sizeof(data), noc);
 }
 
 // open_dbi disrupts normal NOC DMA because all outbound traffic are routed to DBI
@@ -1084,6 +1133,8 @@ struct tenstorrent_device_class wormhole_class = {
 	.restore_reset_state = wormhole_restore_reset_state,
 	.configure_outbound_atu = wormhole_configure_outbound_atu,
 	.noc_write32 = wormhole_noc_write32,
+	.noc_read = wormhole_noc_read,
+	.noc_write = wormhole_noc_write,
 	.csm_read32 = wormhole_csm_read32,
 	.csm_write32 = wormhole_csm_write32,
 	.arc_msg_locate_queue = wormhole_arc_msg_locate_queue,


### PR DESCRIPTION
This supersedes [#260](https://github.com/tenstorrent/tt-kmd/pull/260) and preserves Alex’s authorship of the original implementation and test commits.

Changes made while rebasing:
- Renumbered the ioctls to avoid numbers allocated since the original work.
- Propagated Wormhole TLB configuration failures instead of accessing a stale mapping.
- Rejected NOC coordinates that cannot be represented by the hardware.
- Clarified the scalar ABI by renaming `size` to `width` and `data` to `value`, leaving room for a distinct future block-transfer API.
- Removed tests that assumed sub-32-bit register accesses work.

Closes https://github.com/tenstorrent/tt-kmd/issues/171