### PR TITLE
Stop packaging a misnamed udev rule

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,12 @@ jobs:
           echo "ERROR: udev rule file not found at /etc/udev/rules.d/50-tenstorrent.rules"
           exit 1
         fi
+        # A misnamed udev-50-* file sorts after administrator rules such
+        # as 60-tenstorrent.rules and would override them.
+        if [ -e /lib/udev/rules.d/udev-50-tenstorrent.rules ]; then
+          echo "ERROR: misnamed udev rule file /lib/udev/rules.d/udev-50-tenstorrent.rules"
+          exit 1
+        fi
         echo "✓ udev rule installed correctly"
         
     - name: Verify package installation

--- a/tools/build_debs.sh
+++ b/tools/build_debs.sh
@@ -70,10 +70,6 @@ Description: Tenstorrent kernel mode driver (DKMS)
  The module will be built automatically by DKMS when installed.
 EOF
 
-# Install udev rules
-mkdir -p "${PACKAGE_DIR}/lib/udev/rules.d"
-cp -v udev-50-tenstorrent.rules "${PACKAGE_DIR}/lib/udev/rules.d/"
-
 # Create postinst script
 cat > "${DEBIAN_DIR}/postinst" << 'EOF'
 #!/bin/sh

--- a/tools/build_rpms.sh
+++ b/tools/build_rpms.sh
@@ -92,10 +92,6 @@ cp -a . %{buildroot}/usr/src/${MODULE_NAME}-${RPM_VERSION}/
 # Make dkms-post-install executable
 chmod 755 %{buildroot}/usr/src/${MODULE_NAME}-${RPM_VERSION}/dkms-post-install
 
-# Install udev rules
-mkdir -p %{buildroot}/lib/udev/rules.d
-cp udev-50-tenstorrent.rules %{buildroot}/lib/udev/rules.d/
-
 %post
 # Add module to DKMS
 dkms add -m ${MODULE_NAME} -v ${RPM_VERSION} || true
@@ -153,7 +149,6 @@ fi
 
 %files
 /usr/src/${MODULE_NAME}-${RPM_VERSION}
-/lib/udev/rules.d/udev-50-tenstorrent.rules
 
 %changelog
 * $(date '+%a %b %d %Y') Tenstorrent <releases@tenstorrent.com> - ${RPM_VERSION}-1


### PR DESCRIPTION
The .deb and .rpm packages installed a copy of the udev rule as /lib/udev/rules.d/udev-50-tenstorrent.rules.  Since "u" sorts after every digit, udev processed it after any NN-*.rules file an administrator might add, so the packaged rule overrode a local rule such as /etc/udev/rules.d/60-tenstorrent.rules rather than the other way around.

The copy was also redundant: the DKMS POST_INSTALL hook already installs the same rule as /etc/udev/rules.d/50-tenstorrent.rules on every dkms install.  Drop the packaged copy and rely on that one.  Package managers remove the misnamed file on upgrade since it is no longer in the package.  Check in CI that it is gone.    

