### PR TITLE
Make both DMA masks per device class

### DIFF
--- a/blackhole.c
+++ b/blackhole.c
@@ -931,7 +931,12 @@ static int blackhole_set_power_state(struct tenstorrent_device *tt_dev, struct t
 struct tenstorrent_device_class blackhole_class = {
 	.name = "Blackhole",
 	.instance_size = sizeof(struct blackhole_device),
-	.dma_address_bits = 58,
+	// An IOVA can be used directly as a NOC address, and the upper 6 bits of
+	// a 64-bit NOC-outbound address select the PCIe outbound TLB window. An
+	// IOVA wider than 58 bits would select the wrong window and silently
+	// misdirect the DMA. Same limit for both masks.
+	.coherent_dma_bits = 58,
+	.streaming_dma_bits = 58,
 	.noc_dma_limit = (1ULL << 58) - 1,
 	.noc_pcie_offset = (4ULL << 58),
 	.tlb_kinds = 2,

--- a/device.h
+++ b/device.h
@@ -103,7 +103,8 @@ struct tlb_descriptor;
 struct tenstorrent_device_class {
 	const char *name;
 	u32 instance_size;
-	u32 dma_address_bits;
+	u32 coherent_dma_bits;	// mask for dma_alloc_coherent (ALLOCATE_DMA_BUF)
+	u32 streaming_dma_bits;	// mask for dma_map_* (PIN_PAGES); must be >= coherent_dma_bits
 	u64 noc_dma_limit;
 	u64 noc_pcie_offset;
 	u32 tlb_kinds;

--- a/enumerate.c
+++ b/enumerate.c
@@ -323,24 +323,16 @@ static int tenstorrent_pci_probe(struct pci_dev *dev, const struct pci_device_id
 	INIT_LIST_HEAD(&tt_dev->dmabuf_exports);
 	INIT_DELAYED_WORK(&tt_dev->power_down_work, tenstorrent_power_down_work_func);
 
-	// The coherent DMA mask (ALLOCATE_DMA_BUF) comes from the device class.
-	// Wormhole is 32 because legacy software assumes it will get 32-bit
-	// addresses from that API; Blackhole is 58.
-	//
-	// The streaming DMA mask (PIN_PAGES) is capped at 58 bits. On Blackhole
-	// an IOVA can be used directly as a NOC address, and the upper 6 bits of
-	// a 64-bit NOC-outbound address select the PCIe outbound TLB window. An
-	// IOVA wider than 58 bits would select the wrong window and silently
-	// misdirect the DMA. 58 bits is also far more IOVA space than any
-	// Wormhole pinning needs, so one 58-bit cap is correct for both; a
-	// 32-bit streaming mask would be too limiting for user pinnings under
-	// IOMMU. The dma_address_bits module parameter overrides both masks.
+	// Both DMA masks come from the device class; the reasons for each chip's
+	// numbers are next to them in the class definitions. The
+	// dma_address_bits module parameter overrides both.
 	//
 	// linux/dma-mapping.h says the coherent mask may be set the same as or
 	// smaller than the streaming mask, so only dma_set_mask()'s return value
-	// is checked.
-	tt_dev->dma_capable = (dma_set_mask(&dev->dev, DMA_BIT_MASK(dma_address_bits ?: 58)) == 0);
-	dma_set_coherent_mask(&dev->dev, DMA_BIT_MASK(dma_address_bits ?: device_class->dma_address_bits));
+	// is checked. The class table must keep coherent <= streaming.
+	WARN_ON(device_class->coherent_dma_bits > device_class->streaming_dma_bits);
+	tt_dev->dma_capable = (dma_set_mask(&dev->dev, DMA_BIT_MASK(dma_address_bits ?: device_class->streaming_dma_bits)) == 0);
+	dma_set_coherent_mask(&dev->dev, DMA_BIT_MASK(dma_address_bits ?: device_class->coherent_dma_bits));
 
 	// Max these to ensure the IOVA allocator will not split large pinned regions.
 	dma_set_max_seg_size(&dev->dev, UINT_MAX);

--- a/wormhole.c
+++ b/wormhole.c
@@ -1110,7 +1110,13 @@ static int wormhole_set_power_state(struct tenstorrent_device *tt_dev, struct te
 struct tenstorrent_device_class wormhole_class = {
 	.name = "Wormhole",
 	.instance_size = sizeof(struct wormhole_device),
-	.dma_address_bits = 32,
+	// Coherent is 32 because legacy software assumes it will get 32-bit
+	// addresses from ALLOCATE_DMA_BUF. Streaming is 64: pinned pages are
+	// reached through the iATU, which takes a full 64-bit target and is
+	// programmed per pinning, so there is nothing to cap. A 32-bit streaming
+	// mask would be too limiting for user pinnings under IOMMU.
+	.coherent_dma_bits = 32,
+	.streaming_dma_bits = 64,
 	.noc_dma_limit = (0xFFFE0000 - 1),
 	.noc_pcie_offset = 0x800000000ULL,
 	.tlb_kinds = NUM_TLB_KINDS,


### PR DESCRIPTION
Replace dma_address_bits with coherent_dma_bits and streaming_dma_bits in the class, and move each chip's reasoning next to its numbers:
```
  Wormhole   32 / 64   coherent stays 32 for legacy software; pinned
                       pages go through the iATU, which takes a full
                       64-bit target, so streaming has nothing to cap.
  Blackhole  58 / 58   the upper 6 bits of a NOC-outbound address
                       select the PCIe outbound TLB window, as before.
```
enumerate.c now just reads the class and WARNs if coherent > streaming, which dma-mapping.h requires. The dma_address_bits module parameter still overrides both.

No behavior change for Blackhole. Wormhole streaming widens 58 -> 64; the 58 there was Blackhole's number applied to both chips.

Why now: Keraunos needs 48 for both masks, and the hard-coded 58 in enumerate.c would have been wrong for it. Getting the WH/BH restructure onto main first keeps the Keraunos branch to Keraunos changes.