### PR TITLE
Consolidate NOC ioctl request structs

### DIFF
--- a/chardev.c
+++ b/chardev.c
@@ -572,10 +572,10 @@ static long validate_noc_io(u32 argsz, u32 flags, u16 x, u16 y, const u8 reserve
 	return 0;
 }
 
-static long ioctl_noc_read(struct chardev_private *priv, struct tenstorrent_noc_read __user *arg)
+static long ioctl_noc_read(struct chardev_private *priv, struct tenstorrent_noc_io __user *arg)
 {
 	struct tenstorrent_device *tt_dev = priv->device;
-	struct tenstorrent_noc_read data = {0};
+	struct tenstorrent_noc_io data = {0};
 	u64 value = 0;
 	long ret;
 
@@ -602,10 +602,10 @@ static long ioctl_noc_read(struct chardev_private *priv, struct tenstorrent_noc_
 	return 0;
 }
 
-static long ioctl_noc_write(struct chardev_private *priv, struct tenstorrent_noc_write __user *arg)
+static long ioctl_noc_write(struct chardev_private *priv, struct tenstorrent_noc_io __user *arg)
 {
 	struct tenstorrent_device *tt_dev = priv->device;
-	struct tenstorrent_noc_write data = {0};
+	struct tenstorrent_noc_io data = {0};
 	long ret;
 
 	if (!tt_dev->dev_class->noc_write)
@@ -932,11 +932,11 @@ static long tt_cdev_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
 			break;
 
 		case TENSTORRENT_IOCTL_NOC_READ:
-			ret = ioctl_noc_read(priv, (struct tenstorrent_noc_read __user *)arg);
+			ret = ioctl_noc_read(priv, (struct tenstorrent_noc_io __user *)arg);
 			break;
 
 		case TENSTORRENT_IOCTL_NOC_WRITE:
-			ret = ioctl_noc_write(priv, (struct tenstorrent_noc_write __user *)arg);
+			ret = ioctl_noc_write(priv, (struct tenstorrent_noc_io __user *)arg);
 			break;
 
 		default:

--- a/ioctl.h
+++ b/ioctl.h
@@ -523,7 +523,7 @@ struct tenstorrent_smc_msg {
  * The KMD cannot validate that @addr refers to anything meaningful; it only
  * enforces that @addr is naturally aligned to @width.
  *
- * @argsz: Must be sizeof(struct tenstorrent_noc_read/write).
+ * @argsz: Must be sizeof(struct tenstorrent_noc_io).
  * @flags: Reserved for future use, must be 0.
  * @x: X coordinate of the NOC endpoint; must be in the range 0-63.
  * @y: Y coordinate of the NOC endpoint; must be in the range 0-63.
@@ -534,19 +534,7 @@ struct tenstorrent_smc_msg {
  * @value: For NOC_READ, receives the value (zero-extended to 64 bits). For
  *         NOC_WRITE, the value to write (only the low @width bytes are used).
  */
-struct tenstorrent_noc_read {
-	__u32 argsz;
-	__u32 flags;
-	__u16 x;
-	__u16 y;
-	__u8 noc;
-	__u8 width;
-	__u8 reserved0[2];
-	__u64 addr;
-	__u64 value;
-};
-
-struct tenstorrent_noc_write {
+struct tenstorrent_noc_io {
 	__u32 argsz;
 	__u32 flags;
 	__u16 x;

--- a/test/noc_io.cpp
+++ b/test/noc_io.cpp
@@ -32,7 +32,7 @@ uint64_t random_aligned_address(uint64_t maximum, uint64_t alignment)
 
 uint64_t noc_read(int fd, uint16_t x, uint16_t y, uint8_t noc, uint8_t width, uint64_t addr)
 {
-    tenstorrent_noc_read r{};
+    tenstorrent_noc_io r{};
     r.argsz = sizeof(r);
     r.x = x;
     r.y = y;
@@ -48,7 +48,7 @@ uint64_t noc_read(int fd, uint16_t x, uint16_t y, uint8_t noc, uint8_t width, ui
 
 void noc_write(int fd, uint16_t x, uint16_t y, uint8_t noc, uint8_t width, uint64_t addr, uint64_t value)
 {
-    tenstorrent_noc_write w{};
+    tenstorrent_noc_io w{};
     w.argsz = sizeof(w);
     w.x = x;
     w.y = y;
@@ -103,16 +103,16 @@ void VerifyRoundtrip(int fd, uint16_t x, uint16_t y)
     }
 }
 
-void ExpectReadRejected(int fd, const tenstorrent_noc_read &request, const char *what)
+void ExpectReadRejected(int fd, const tenstorrent_noc_io &request, const char *what)
 {
-    tenstorrent_noc_read r = request;
+    tenstorrent_noc_io r = request;
     if (ioctl(fd, TENSTORRENT_IOCTL_NOC_READ, &r) == 0)
         THROW_TEST_FAILURE(std::string("NOC_READ accepted invalid request: ") + what);
 }
 
-void ExpectWriteRejected(int fd, const tenstorrent_noc_write &request, const char *what)
+void ExpectWriteRejected(int fd, const tenstorrent_noc_io &request, const char *what)
 {
-    tenstorrent_noc_write w = request;
+    tenstorrent_noc_io w = request;
     if (ioctl(fd, TENSTORRENT_IOCTL_NOC_WRITE, &w) == 0)
         THROW_TEST_FAILURE(std::string("NOC_WRITE accepted invalid request: ") + what);
 }
@@ -120,7 +120,7 @@ void ExpectWriteRejected(int fd, const tenstorrent_noc_write &request, const cha
 void VerifyValidation(int fd)
 {
     auto good = [] {
-        tenstorrent_noc_read r{};
+        tenstorrent_noc_io r{};
         r.argsz = sizeof(r);
         r.x = 0;
         r.y = 0;
@@ -143,7 +143,7 @@ void VerifyValidation(int fd)
     { auto r = good(); r.width = 8; r.addr = 4;      ExpectReadRejected(fd, r, "misaligned 8-byte"); }
 
     // The write request shares the same layout and validation.
-    tenstorrent_noc_write w{};
+    tenstorrent_noc_io w{};
     w.argsz = sizeof(w) + 1;
     w.width = 4;
     ExpectWriteRejected(fd, w, "bad argsz");
@@ -151,7 +151,7 @@ void VerifyValidation(int fd)
 
 void VerifyWormholeAddressValidation(int fd)
 {
-    tenstorrent_noc_read r{};
+    tenstorrent_noc_io r{};
     r.argsz = sizeof(r);
     r.width = 4;
     r.addr = 1ULL << 36;


### PR DESCRIPTION
Read and write requests have the same layout, so use one common type and avoid duplicating the UAPI definition.

Technically this is is a breaking UAPI change, but we have not made a release that includes the NOC_READ and NOC_WRITE ioctls yet.