### PR TITLE
Document the security model

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,24 @@ make dkms-remove
 ```
 make akms-remove
 ```
+
+## Security Model
+
+A Tenstorrent device is a fully programmable, DMA-capable PCIe accelerator. Opening `/dev/tenstorrent/N` grants complete control, including programming the NOC from the host or device cores. Device-node permissions control access; the driver cannot mediate subsequent device activity.
+
+**Device and host.** Without a translating IOMMU, any device user can read or overwrite arbitrary host memory. With translation, DMA is limited to memory mapped into the device's IOMMU domain. Keep the IOMMU enabled and translating to protect host memory. Disabling it (for example, with `intel_iommu=off`) or enabling passthrough (`iommu=pt`) leaves host memory unprotected from device users. The driver supports these configurations, but all device users must then be trusted with unrestricted host-memory access.
+
+**Users of one device.** All users share the device's cores, memory, and IOMMU domain. Any user can read or overwrite another's device memory and mapped host buffers, including those of privileged processes. Any user can also hang or reset the device. Mutually untrusting users must never use the same device concurrently.
+
+**Assigning devices.** Assign each device to one user or mutually trusting group at a time. Handoff between mutually untrusting users is an orchestration responsibility: revoke the previous user's access and perform a full reset (`tt-smi -r`), which stops device execution and scrubs device memory. Separate-device tenant isolation depends on the platform, not just the driver.
+
+The shipped udev rule uses mode `0666` for trusted development and single-user hosts. Otherwise, restrict access—for example, to a `tenstorrent` group using a later-sorting rule:
+
+```
+# /etc/udev/rules.d/60-tenstorrent.rules
+SUBSYSTEM=="tenstorrent", MODE="0660", GROUP="tenstorrent"
+```
+
+### Reporting security bugs
+
+Access permitted by this model, including unrestricted DMA without a translating IOMMU, is not itself a driver vulnerability. Driver flaws that compromise the host kernel beyond that access, or allow DMA outside the device's translating IOMMU domain, are security bugs. Report suspected security bugs through [GitHub's private vulnerability reporting](https://github.com/tenstorrent/tt-kmd/security/advisories/new).


### PR DESCRIPTION
Explain that device access grants full control of a programmable, DMA-capable accelerator. Describe translating-IOMMU protection and the trust required when translation is disabled or bypassed, both of which remain supported configurations.

Require exclusive assignment between mutually untrusting users and describe the access revocation, execution and DMA shutdown, reset, and sanitization needed before reassignment. Clarify that separate-device tenant isolation also depends on the platform.

Explain the 0666 default, show a restrictive udev rule, and distinguish the documented access model from reportable driver security flaws.